### PR TITLE
Support backups of SIs

### DIFF
--- a/medusa/backup.py
+++ b/medusa/backup.py
@@ -325,7 +325,7 @@ def backup_snapshots(storage, manifest, node_backup, node_backup_cache, snapshot
         (needs_backup, already_backed_up) = node_backup_cache.replace_or_remove_if_cached(
             keyspace=snapshot_path.keyspace,
             columnfamily=snapshot_path.columnfamily,
-            srcs=list(snapshot_path.path.glob('*')))
+            srcs=list(snapshot_path.list_files()))
 
         num_files += len(needs_backup) + len(already_backed_up)
 

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-import collections
 import itertools
 import logging
 import os
@@ -33,10 +32,16 @@ from cassandra.policies import WhiteListRoundRobinPolicy
 from cassandra.auth import PlainTextAuthProvider
 
 
-SnapshotPath = collections.namedtuple(
-    'SnapshotPath',
-    ['path', 'keyspace', 'columnfamily']
-)
+class SnapshotPath(object):
+
+    def __init__(self, path, keyspace, table):
+        self.path = path
+        self.keyspace = keyspace
+        self.columnfamily = table
+
+    def list_files(self):
+        # important to use the _r_glob() to recursively descend into subdirs if there are any
+        return filter(lambda p: p.is_file(), self.path.rglob('*'))
 
 
 class CqlSessionProvider(object):

--- a/medusa/storage/abstract_storage.py
+++ b/medusa/storage/abstract_storage.py
@@ -59,7 +59,7 @@ class AbstractStorage(abc.ABC):
         )
         return medusa.storage.ManifestObject(obj.name, obj.size, obj.hash)
 
-    def download_blobs(self, src, dest):
+    def download_blobs(self, srcs, dest):
         """
         Downloads a list of files from the remote storage system to the local storage
 
@@ -67,7 +67,7 @@ class AbstractStorage(abc.ABC):
         :param dest: the path where to download the objects locally
         :return:
         """
-        medusa.storage.concurrent.download_blobs(self, src, dest, self.bucket.name)
+        medusa.storage.concurrent.download_blobs(self, srcs, dest, self.bucket.name)
 
     def upload_blobs(self, src, dest):
         """

--- a/medusa/storage/google_cloud_storage/gsutil.py
+++ b/medusa/storage/google_cloud_storage/gsutil.py
@@ -17,7 +17,6 @@
 import csv
 import logging
 import os
-import pathlib
 import subprocess
 import tempfile
 import time
@@ -62,10 +61,7 @@ class GSUtil(object):
         return False
 
     def cp(self, *, srcs, dst, max_retries=5):
-        if isinstance(srcs, str) or isinstance(srcs, pathlib.Path):
-            srcs = [srcs]
 
-        # TODO: Clean up these files in production
         job_id = str(uuid.uuid4())
         manifest_log = '/tmp/gsutil_{0}.manifest'.format(job_id)
         gsutil_output = '/tmp/gsutil_{0}.output'.format(job_id)
@@ -108,6 +104,10 @@ class GSUtil(object):
                             medusa.storage.ManifestObject(row['Destination'], int(row['Source Size']), row['Md5'])
                             for row in csv.DictReader(f, delimiter=',')
                         ]
+
+                    # remove the temporary files
+                    os.remove(manifest_log)
+                    os.remove(gsutil_output)
                     return manifestobjects
             except Exception as e:
                 logging.debug("Exception encountered: {} / {}"

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -349,7 +349,27 @@ Feature: Integration tests
         When I perform a backup in "full" mode of the node named "first_backup"
         Then I can verify the backup named "first_backup" successfully
         When I restore the backup named "first_backup"
-        Then I can verify the restore verify query "SELECT * FROM medusa.test" restored 100 rows
+        Then I can verify the restore verify query "SELECT * FROM medusa.test" returned 100 rows
+
+        Examples:
+        | Storage   |
+        | local     |
+#        | s3_us_west_oregon     |
+#        | google_storage      |
+
+    @14
+    Scenario Outline: Perform a backup & restore of a table with secondary index
+        Given I have a fresh ccm cluster running named "scenario14"
+        Given I am using "<Storage>" as storage provider
+        When I create the "test" table with secondary index in keyspace "medusa"
+        When I load 100 rows in the "medusa.test" table
+        When I run a "ccm node1 nodetool flush" command
+        When I perform a backup in "differential" mode of the node named "first_backup"
+        Then I can verify the backup named "first_backup" successfully
+        Then I can see secondary index files in the "first_backup" files
+        When I restore the backup named "first_backup"
+        Then I have 100 rows in the "medusa.test" table
+        Then I can verify the restore verify query "SELECT * FROM medusa.test WHERE value = '0';" returned 1 rows
 
         Examples:
         | Storage   |

--- a/tests/storage/google_storage_test.py
+++ b/tests/storage/google_storage_test.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Spotify AB. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import types
+import unittest
+
+from pathlib import Path
+
+from medusa.storage.google_storage import _group_by_parent, _is_in_folder
+
+
+class RestoreNodeTest(unittest.TestCase):
+
+    def test_is_in_folder(self):
+        folder = Path('foo/bar')
+        in_file = Path('foo/bar/file.txt')
+        out_file = Path('foo/bar/.baz/file.txt')
+        self.assertTrue(_is_in_folder(in_file, folder))
+        self.assertFalse(_is_in_folder(out_file, folder))
+
+    def test_group_by_parent(self):
+        p1, p2 = Path('foo/file1.txt'), Path('foo/file2.txt')
+        p3, p4 = Path('foo/.bar/file3.txt'), Path('foo/.bar/file4.txt')
+        files = [p1, p2, p3, p4]
+        by_parent = dict(_group_by_parent(files))
+        self.assertEqual(2, len(by_parent))
+        self.assertEqual({'foo', '.bar', }, by_parent.keys())
+        self.assertTrue(p1 in by_parent['foo'])
+        self.assertTrue(p2 in by_parent['foo'])
+        self.assertFalse(p3 in by_parent['foo'])
+        self.assertFalse(p4 in by_parent['foo'])
+
+    def test_iterator_hierarchy(self):
+
+        def _inner_inner():
+            return [n for n in range(0, 2)]
+
+        def _inner():
+            for i in range(0, 2):
+                yield _inner_inner()
+
+        g = _inner()
+        self.assertTrue(isinstance(g, types.GeneratorType))
+        c = itertools.chain(*g)
+        self.assertTrue(isinstance(c, itertools.chain))
+        rr = list(c)
+        self.assertTrue(isinstance(rr, list))
+        self.assertTrue(isinstance(rr[0], int))


### PR DESCRIPTION
Two main things needed to happen for SIs to work:
* When discovering files in table folder, Medusa now recursively globs and returns files only.
* When uploading/downloading backups, the SI folder needs to be inserted into the path, otherwise SSTables might clash.

I successfully ran ITs with all 3 storage providers (local, gcp, s3).