### PR TITLE
Remove --storage-port arg if default port is 7000

### DIFF
--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -168,14 +168,17 @@ def invoke_sstableloader(config, download_dir, keep_auth, fqtns_to_restore, stor
                     logging.debug('Restoring table {} with sstableloader...'.format(table))
                     cql_username = 'foo' if config.cassandra.cql_username is None else config.cassandra.cql_username
                     cql_password = 'foo' if config.cassandra.cql_password is None else config.cassandra.cql_password
-                    output = subprocess.check_output([config.cassandra.sstableloader_bin,
-                                                      '-d', socket.getfqdn() if cassandra_is_ccm == 0
-                                                      else '127.0.0.1',
-                                                      '--storage-port', storage_port,
-                                                      '-u', cql_username,
-                                                      '--password', cql_password,
-                                                      '--no-progress',
-                                                      os.path.join(ks_path, table)])
+                    sstableloader_args = [config.cassandra.sstableloader_bin,
+                                          '-d', socket.getfqdn() if cassandra_is_ccm == 0
+                                          else '127.0.0.1',
+                                          '--username', cql_username,
+                                          '--password', cql_password,
+                                          '--no-progress',
+                                          os.path.join(ks_path, table)]
+                    if storage_port != "7000":
+                        sstableloader_args.append("--storage-port")
+                        sstableloader_args.append(storage_port)
+                    output = subprocess.check_output(sstableloader_args)
                     for line in output.decode('utf-8').split('\n'):
                         logging.debug(line)
     clean_path(download_dir)


### PR DESCRIPTION
I don't know what happened but I had some difficulties to squash the commits (i think that github was with some problems). I'm sorry for the duplicated PR: https://github.com/thelastpickle/cassandra-medusa/pull/82

In ScyllaDB the sstableloader binary doesn't have the ```storage-port``` flag therefore the restore-cluster or restore-node commands fail:
```
[2020-02-18 16:05:52,497] DEBUG: Restoring table view_virtual_columns-08843b6345dc3be29798a0418295cfaa with sstableloader...
Unrecognized option: --storage-port
Traceback (most recent call last):
  File "/usr/local/bin/medusa", line 11, in <module>
    load_entry_point('cassandra-medusa==0.6.0.dev0', 'console_scripts', 'medusa')()
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/medusa/medusacli.py", line 212, in restore_node
    verify, set(keyspaces), set(tables), use_sstableloader)
  File "/usr/local/lib/python3.5/dist-packages/medusa/restore_node.py", line 51, in restore_node
    keyspaces, tables)
  File "/usr/local/lib/python3.5/dist-packages/medusa/restore_node.py", line 152, in restore_node_sstableloader
    invoke_sstableloader(config, download_dir, keep_auth, fqtns_to_restore, cassandra.storage_port)
  File "/usr/local/lib/python3.5/dist-packages/medusa/restore_node.py", line 176, in invoke_sstableloader
    os.path.join(ks_path, table)])
  File "/usr/local/lib/python3.5/dist-packages/gevent/subprocess.py", line 348, in check_output
    raise CalledProcessError(retcode, process.args, output=output)
subprocess.CalledProcessError: Command '['sstableloader', '-d', 'scylladb-test-4a53de998b', '--storage-port', '7000', '--username', 'xxx', '--password', 'xxx', '--no-progress', '/tmp/medusa-restore-55d11fa6-7324-499f-b2d3-24faedefa942/system_schema/view_virtual_columns-08843b6345dc3be29798a0418295cfaa']' returned non-zero exit status 1
```

The ```--storage-port``` is the inter-node communication port used on a Cassandra/ScyllaDB Cluster and the default is TCP 7000: https://docs.datastax.com/en/archived/cassandra/3.0/cassandra/tools/toolsBulkloader.html. 
So, to maintain the compatibility with ScyllaDB/Cassandra, the idea is if the ```--storage-port``` is the default (7000), ```--storage-port``` flag is removed in the sstableloader call.

Integration tests done:
```
1 feature passed, 0 failed, 0 skipped
14 scenarios passed, 0 failed, 20 skipped
251 steps passed, 0 failed, 360 skipped, 0 undefined
Took 7m49.947s
```

Any questions or improvement please feel free to ping me.