### PR TITLE
Add ini option to enable --ssl parameter for nodetool

### DIFF
--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -31,6 +31,9 @@
 ;sstableloader_ks = <Client SSL: full path to keystore>
 ;sstableloader_kspw = <Client SSL: password of the keystore>
 
+; Enable this to add the '--ssl' parameter to nodetool. The nodetool-ssl.properties is expected to be in the normal location
+;nodetool_ssl = true
+
 ; Command ran to verify if Cassandra is running on a node. Defaults to "nodetool version"
 ;check_running = nodetool version
 

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -107,6 +107,8 @@ class Nodetool(object):
 
     def __init__(self, cassandra_config):
         self._nodetool = ['nodetool']
+        if cassandra_config.nodetool_ssl == "true":
+            self._nodetool += ['--ssl']
         if cassandra_config.nodetool_username is not None:
             self._nodetool += ['-u', cassandra_config.nodetool_username]
         if cassandra_config.nodetool_password is not None:

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -36,7 +36,7 @@ CassandraConfig = collections.namedtuple(
     ['start_cmd', 'stop_cmd', 'config_file', 'cql_username', 'cql_password', 'check_running', 'is_ccm',
      'sstableloader_bin', 'nodetool_username', 'nodetool_password', 'nodetool_password_file_path', 'nodetool_host',
      'nodetool_port', 'certfile', 'usercert', 'userkey', 'sstableloader_ts', 'sstableloader_tspw',
-     'sstableloader_ks', 'sstableloader_kspw']
+     'sstableloader_ks', 'sstableloader_kspw', 'nodetool_ssl']
 )
 
 SSHConfig = collections.namedtuple(

--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -140,6 +140,30 @@ class CassandraUtilsTest(unittest.TestCase):
     def test_nodetool_command_with_parameters(self):
         config = configparser.ConfigParser(interpolation=None)
         config['cassandra'] = {
+            'nodetool_ssl': 'true',
+            'nodetool_username': 'cassandra',
+            'nodetool_password': 'password',
+            'nodetool_password_file_path': '/etc/cassandra/jmx.password',
+            'nodetool_host': '127.0.0.1',
+            'nodetool_port': '7199'
+        }
+        medusa_config = MedusaConfig(
+            storage=None,
+            monitoring=None,
+            cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
+            ssh=None,
+            restore=None,
+            logging=None
+        )
+        n = Nodetool(medusa_config.cassandra).nodetool
+        expected = ['nodetool', '--ssl', '-u', 'cassandra', '-pw', 'password', '-pwf', '/etc/cassandra/jmx.password',
+                    '-h', '127.0.0.1', '-p', '7199']
+        self.assertEqual(n, expected)
+
+    def test_nodetool_command_with_ssl_false(self):
+        config = configparser.ConfigParser(interpolation=None)
+        config['cassandra'] = {
+            'nodetool_ssl': 'false',
             'nodetool_username': 'cassandra',
             'nodetool_password': 'password',
             'nodetool_password_file_path': '/etc/cassandra/jmx.password',


### PR DESCRIPTION
This adds an ini parameter "nodetool_ssl" that can be set to true to pass the "--ssl" parameter to nodetool. This is required for SSL JMX connections (https://docs.datastax.com/en/security/5.1/security/secureNodetoolSSL.html)

Related to #99 but I think it's a different issue (cqlsh vs. nodetool)