### PR TITLE
Disable checksum comparisons for the local storage provider.

### DIFF
--- a/medusa/verify.py
+++ b/medusa/verify.py
@@ -17,6 +17,7 @@ import base64
 import json
 import logging
 
+from libcloud.storage.providers import Provider
 from medusa.storage import Storage
 
 
@@ -89,6 +90,9 @@ def validate_manifest(storage, node_backup):
             yield("  - [{}] Doesn't exists".format(object_in_manifest['path']))
             continue
 
+        if storage.storage_provider == Provider.LOCAL:
+            # the local provider doesn't provide reliable hashes.
+            continue
         if "-" in object_in_manifest['MD5']:
             # multi part S3 uploads
             if object_in_manifest['MD5'] != str(blob.hash):

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -266,7 +266,8 @@ Feature: Integration tests
         Then I can see the backup named "first_backup" when I list the backups
         Then I can see the backup named "second_backup" when I list the backups
         Then I can see the backup named "third_backup" when I list the backups
-        Then verify fails on the backup named "third_backup"
+        # The following is disabled as we don't compare hashes with local storage
+        # Then verify fails on the backup named "third_backup"
         When I delete the backup named "first_backup"
         Then I cannot see the backup named "first_backup" when I list the backups
         Then I can see the backup named "second_backup" when I list the backups


### PR DESCRIPTION
The libcloud local storage provider uses the file modification time instead of the content to compute hashes. This can make comparisons fail if the transfer to the backup folder changes that modification time, although the files have the same contents.
We need to disable the check while we look for an alternate way of computing hashes with local storage.