### PR TITLE
[WIP] Refactor checksum comparisons

### DIFF
--- a/medusa/backup.py
+++ b/medusa/backup.py
@@ -136,11 +136,7 @@ class NodeBackupCache(object):
                 if self._storage_provider == Provider.GOOGLE_STORAGE or self._differential_mode is True:
                     cached_item = self._cached_objects.get(fqtn, {}).get(src.name)
 
-                if cached_item is None \
-                    or files_are_different(src,
-                                           cached_item,
-                                           self._storage_config.multi_part_upload_threshold,
-                                           self._storage_provider):
+                if cached_item is None or self._storage_driver.files_are_different(cached_item, src):
                     # We have no matching object in the cache matching the file
                     retained.append(src)
                 else:
@@ -266,7 +262,7 @@ def main(config, backup_name_arg, stagger_time, mode):
                     time.sleep(60)
                 else:
                     raise IOError('Backups on previous nodes did not complete'
-                                  ' within our stagger time.'.format(backup_name))
+                                  ' within our stagger time.')
 
         actual_start = datetime.datetime.now()
 

--- a/medusa/storage/abstract_storage.py
+++ b/medusa/storage/abstract_storage.py
@@ -142,3 +142,18 @@ class AbstractStorage(abc.ABC):
         Each child class should implement this function if it relies on an optional dependency.
         """
         pass
+
+    @abc.abstractmethod
+    def checksums_match(self, blob, src):
+        pass
+
+    def files_are_different(self, blob, src):
+        """
+        Compares a local file and a blob from remote storage using their sizes and checksums. Note that checksums vary
+        by storage provider. See implementations of checksums_match for more details.
+
+        :param blob: An object that represents a file in remote storage
+        :param src: A pathlib.Path object
+        :return: True if the files do not match.
+        """
+        return src.stat().st_size != blob['size'] or not self.checksums_match(blob, src)

--- a/medusa/storage/google_storage.py
+++ b/medusa/storage/google_storage.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import base64
 import io
 import itertools
 import json
@@ -27,6 +27,7 @@ from pathlib import Path
 
 from medusa.storage.abstract_storage import AbstractStorage
 from medusa.storage.google_cloud_storage.gsutil import GSUtil
+from medusa import backup
 
 
 class GoogleStorage(AbstractStorage):
@@ -115,6 +116,12 @@ class GoogleStorage(AbstractStorage):
     def get_cache_path(self, path):
         # Full path for files that will be taken from previous backups
         return self.get_download_path(path)
+
+    def checksums_match(self, blob, src):
+        md5_hash = backup.generate_md5_hash(src)
+        b64_encoded_hash = base64.b64decode(md5_hash).hex()
+
+        return b64_encoded_hash == blob['MD5']
 
 
 def _is_in_folder(file_path, folder_path):

--- a/medusa/storage/local_storage.py
+++ b/medusa/storage/local_storage.py
@@ -49,3 +49,14 @@ class LocalStorage(AbstractStorage):
     def get_cache_path(self, path):
         # Full path for files that will be taken from previous backups
         return "{}/{}/{}".format(self.config.base_path, self.config.bucket_name, path)
+
+    def checksums_match(self, blob, src):
+        """
+        This is basically a no-op. It always returns True because the local provider checksum implementation is
+        unreliable.
+
+        :param blob: An object that represents a file in remote storage
+        :param src: A pathlib.Path object
+        :return: True
+        """
+        return True


### PR DESCRIPTION
Fixes #124

There is still a lot of work to do but I wanted to open the PR and get some feedback. I have added a method named `files_are_different` in `abstract_storage.py`. It is intended to replace the `files_are_different` function in `backup.py`.  

I still need to update unit tests in `RestoreNodeTest` and remove unused code in `backup.py`. 

You will also see that the implementations of the `checksums_match` function currently call the helper functions in `backup.py`. If they are not used anywhere else, then it probably makes sense to move those functions closer to where they are used which will be in the storage providers.

I also need to refactor the `validate_manifest` method in `verify.py`. I have not started on it yet. It is a different use case that the `files_are_different` method and will most likely require another method in the storage drivers.