### PR TITLE
Add wait for node shutdown. Fix healtcheck config. Fixes #72

### DIFF
--- a/medusa/config.py
+++ b/medusa/config.py
@@ -56,7 +56,7 @@ MonitoringConfig = collections.namedtuple(
 
 MedusaConfig = collections.namedtuple(
     'MedusaConfig',
-    ['storage', 'cassandra', 'ssh', 'restore', 'monitoring', 'logging']
+    ['storage', 'cassandra', 'ssh', 'checks', 'monitoring', 'logging']
 )
 
 LoggingConfig = collections.namedtuple(

--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -24,7 +24,7 @@ import sys
 import time
 import uuid
 
-from medusa.cassandra_utils import Cassandra, is_node_up
+from medusa.cassandra_utils import Cassandra, is_node_up, wait_for_node_to_go_down
 from medusa.download import download_data
 from medusa.storage import Storage
 from medusa.verify_restore import verify_restore
@@ -82,6 +82,7 @@ def restore_node_locally(config, temp_dir, backup_name, in_place, keep_auth, see
 
     logging.info('Stopping Cassandra')
     cassandra.shutdown()
+    wait_for_node_to_go_down(config, cassandra.hostname)
 
     # Clean the commitlogs, the saved cache to prevent any kind of conflict
     # especially around system tables.

--- a/medusa/verify_restore.py
+++ b/medusa/verify_restore.py
@@ -35,7 +35,7 @@ def verify_restore(hosts, config):
     for host in hosts:
         wait_for_node_to_come_up(config, host)
 
-    restore_verify_query = config.restore.query
+    restore_verify_query = config.checks.query
 
     if len(restore_verify_query) > 0:
         logging.info('Executing restore verify query: {}'.format(restore_verify_query))
@@ -47,9 +47,9 @@ def verify_restore(hosts, config):
             logging.info('Restore verify query completed successfully')
 
             # if config tells us to check for expected row count, we check that
-            expected_row_count = int(config.restore.expected_rows)
+            expected_row_count = int(config.checks.expected_rows)
             if expected_row_count:
-                if actual_row_count == int(config.restore.expected_rows):
+                if actual_row_count == int(config.checks.expected_rows):
                     logging.info('Restore verify query returned expected number of rows {}'.format(expected_row_count))
                 else:
                     logging.error('Restore verify query returned unexpected number of rows')
@@ -57,9 +57,9 @@ def verify_restore(hosts, config):
                     sys.exit(1)
 
             # if the config tells us to check for actual results, we check that too
-            if config.restore.expected_result:
+            if config.checks.expected_result:
                 # expected result allows just one row
-                expected_result = config.restore.expected_result
+                expected_result = config.checks.expected_result
                 actual_result = ','.join(rows[0] if len(rows) >= 1 else [])
                 if actual_result == expected_result:
                     logging.info('Restore verify query returned expected result {}'.format(expected_result))

--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -42,7 +42,7 @@ class CassandraUtilsTest(unittest.TestCase):
             monitoring={},
             cassandra=None,
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
 
@@ -134,7 +134,7 @@ class CassandraUtilsTest(unittest.TestCase):
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
         n = Nodetool(medusa_config.cassandra).nodetool
@@ -155,7 +155,7 @@ class CassandraUtilsTest(unittest.TestCase):
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
         n = Nodetool(medusa_config.cassandra).nodetool
@@ -178,7 +178,7 @@ class CassandraUtilsTest(unittest.TestCase):
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
         n = Nodetool(medusa_config.cassandra).nodetool
@@ -203,7 +203,7 @@ class CassandraUtilsTest(unittest.TestCase):
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
 
@@ -234,7 +234,7 @@ class CassandraUtilsTest(unittest.TestCase):
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
 
@@ -266,7 +266,7 @@ class CassandraUtilsTest(unittest.TestCase):
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
 
@@ -297,7 +297,7 @@ class CassandraUtilsTest(unittest.TestCase):
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
 

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -227,12 +227,16 @@ def i_am_using_storage_provider(context, storage_provider, client_encryption):
 
     config["monitoring"] = {"monitoring_provider": "local"}
 
+    config["checks"] = {
+        "health_check": "cql"
+    }
+
     context.medusa_config = MedusaConfig(
         storage=_namedtuple_from_dict(StorageConfig, config["storage"]),
         cassandra=_namedtuple_from_dict(CassandraConfig, config["cassandra"]),
         monitoring=_namedtuple_from_dict(MonitoringConfig, config["monitoring"]),
         ssh=None,
-        restore=None,
+        checks=_namedtuple_from_dict(ChecksConfig, config["checks"]),
         logging=None
     )
     cleanup_storage(context, storage_provider)
@@ -736,7 +740,7 @@ def _i_can_verify_the_restore_verify_query_returned_rows(context, query, expecte
         storage=context.medusa_config.storage,
         cassandra=context.medusa_config.cassandra,
         monitoring=context.medusa_config.monitoring,
-        restore=_namedtuple_from_dict(ChecksConfig, restore_config),
+        checks=_namedtuple_from_dict(ChecksConfig, restore_config),
         ssh=None,
         logging=None
     )

--- a/tests/purge_test.py
+++ b/tests/purge_test.py
@@ -44,7 +44,7 @@ class PurgeTest(unittest.TestCase):
             monitoring={},
             cassandra=None,
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None,
         )
         self.storage = Storage(config=self.config.storage)

--- a/tests/restore_cluster_test.py
+++ b/tests/restore_cluster_test.py
@@ -48,7 +48,7 @@ class RestoreClusterTest(unittest.TestCase):
             monitoring={},
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
 

--- a/tests/restore_node_test.py
+++ b/tests/restore_node_test.py
@@ -36,7 +36,7 @@ class RestoreNodeTest(unittest.TestCase):
             monitoring={},
             cassandra=None,
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
 

--- a/tests/storage_test.py
+++ b/tests/storage_test.py
@@ -63,7 +63,7 @@ class RestoreNodeTest(unittest.TestCase):
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             monitoring={},
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
 

--- a/tests/storage_test_with_prefix.py
+++ b/tests/storage_test_with_prefix.py
@@ -64,7 +64,7 @@ class RestoreNodeTest(unittest.TestCase):
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             monitoring={},
             ssh=None,
-            restore=None,
+            checks=None,
             logging=None
         )
 


### PR DESCRIPTION
This ended up being bigger than I intended because it turned out the we were still accessing health checks via old `config.restore` sections. We renamed that to `config.checks` some time ago.

As for #72, we've seen plenty of C* processes not going away even after drain and service stop. In these cases we need to do a `kill`. I did not do that in this PR, but if you think we should, I can easily add it.