### PR TITLE
Fixes restore infinite loop and fqdn resolving in host mapping files

### DIFF
--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -22,6 +22,7 @@ import uuid
 import datetime
 import traceback
 import paramiko
+import socket
 
 from medusa.monitoring import Monitoring
 from medusa.cassandra_utils import CqlSessionProvider
@@ -279,7 +280,7 @@ class RestoreJob(object):
             for line in f.readlines():
                 seed, target, source = line.replace('\n', '').split(self.config.storage.host_file_separator)
                 # in python, bool('False') evaluates to True. Need to test the membership as below
-                self.host_map[target.strip()] = {'source': [source.strip()], 'seed': seed in ['True']}
+                self.host_map[socket.getfqdn(target.strip())] = {'source': [socket.getfqdn(source.strip())], 'seed': seed in ['True']}
 
     def _restore_data(self):
         # create workdir on each target host

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -280,7 +280,8 @@ class RestoreJob(object):
             for line in f.readlines():
                 seed, target, source = line.replace('\n', '').split(self.config.storage.host_file_separator)
                 # in python, bool('False') evaluates to True. Need to test the membership as below
-                self.host_map[socket.getfqdn(target.strip())] = {'source': [socket.getfqdn(source.strip())], 'seed': seed in ['True']}
+                self.host_map[socket.getfqdn(target.strip())] = {'source': [socket.getfqdn(source.strip())],
+                                                                 'seed': seed in ['True']}
 
     def _restore_data(self):
         # create workdir on each target host


### PR DESCRIPTION
fixes #126 and #132 

Both remote nodetool and ssh wouldn't allow to check if seed nodes are up in most restore scenarios.
I switched to using `nc` to check if the native and/or rpc port are accessible, using the ports from the `cassandra.yaml` file.