### PR TITLE
Remove ListBucketByTags from S3 policy

### DIFF
--- a/docs/aws_s3_setup.md
+++ b/docs/aws_s3_setup.md
@@ -17,7 +17,6 @@ Create an IAM Policy called `MedusaStorageStrategy`, with the following definiti
             "Sid": "VisualEditor0",
             "Effect": "Allow",
             "Action": [
-                "s3:ListBucketByTags",
                 "s3:GetLifecycleConfiguration",
                 "s3:GetBucketTagging",
                 "s3:GetInventoryConfiguration",


### PR DESCRIPTION
ListBucketByTags not available anymore under s3 policy.

<img width="275" alt="Screen Shot 2020-06-10 at 13 50 31" src="https://user-images.githubusercontent.com/4068390/84264583-bbb9ae00-ab21-11ea-990d-8048325a0306.png">
