### PR TITLE
Add a setting to cleanup fqdn from their domain names and have a consistent view of the hosts

### DIFF
--- a/medusa/network/__init__.py
+++ b/medusa/network/__init__.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Datastax, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/medusa/network/hostname_resolver.py
+++ b/medusa/network/hostname_resolver.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import socket
+import logging
+
+
+class HostnameResolver():
+    def __init__(self, resolve_addresses=True):
+        self.resolve_addresses = resolve_addresses
+        logging.debug
+
+    def resolve_fqdn(self, ip_address=''):
+        if str(self.resolve_addresses) == "False":
+            logging.debug("Not resolving {} as requested".format(ip_address))
+            return ip_address
+
+        fqdn = socket.getfqdn(ip_address)
+        logging.debug("Resolved {} to {}".format(ip_address, fqdn))
+        return fqdn

--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -37,10 +37,13 @@ class CassandraUtilsTest(unittest.TestCase):
         config['storage'] = {
             'host_file_separator': ','
         }
+        config['cassandra'] = {
+            'resolve_ip_addresses': False
+        }
         self.config = MedusaConfig(
             storage=_namedtuple_from_dict(StorageConfig, config['storage']),
             monitoring={},
-            cassandra=None,
+            cassandra=_namedtuple_from_dict(StorageConfig, config['cassandra']),
             ssh=None,
             checks=None,
             logging=None
@@ -56,10 +59,10 @@ class CassandraUtilsTest(unittest.TestCase):
         session.cluster.metadata.token_map.token_to_host_owner = {
             Murmur3Token(-9): host
         }
-        s = CqlSession(session)
+        s = CqlSession(session, resolve_ip_addresses=False)
         token_map = s.tokenmap()
         self.assertEqual(
-            {'localhost': {'is_up': True, 'tokens': [-9]}},
+            {'127.0.0.1': {'is_up': True, 'tokens': [-9]}},
             token_map
         )
 
@@ -75,10 +78,10 @@ class CassandraUtilsTest(unittest.TestCase):
             Murmur3Token(-6): host,
             Murmur3Token(0): host
         }
-        s = CqlSession(session)
+        s = CqlSession(session, resolve_ip_addresses=False)
         token_map = s.tokenmap()
-        self.assertEqual(True, token_map["localhost"]["is_up"])
-        self.assertEqual([-9, -6, 0], sorted(token_map["localhost"]["tokens"]))
+        self.assertEqual(True, token_map["127.0.0.1"]["is_up"])
+        self.assertEqual([-9, -6, 0], sorted(token_map["127.0.0.1"]["tokens"]))
 
     def test_tokenmap_two_dc(self):
         hostA = Mock()
@@ -98,10 +101,10 @@ class CassandraUtilsTest(unittest.TestCase):
             Murmur3Token(-6): hostA,
             Murmur3Token(6): hostB
         }
-        s = CqlSession(session)
+        s = CqlSession(session, resolve_ip_addresses=False)
         token_map = s.tokenmap()
         self.assertEqual(
-            {'localhost': {'is_up': True, 'tokens': [-6]}},
+            {'127.0.0.1': {'is_up': True, 'tokens': [-6]}},
             token_map
         )
 

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -210,6 +210,7 @@ def i_am_using_storage_provider(context, storage_provider, client_encryption):
                 "sstableloader",
             )
         ),
+        "resolve_ip_addresses": True
     }
 
     if client_encryption == 'with_client_encryption':

--- a/tests/network/hostname_resolver_test.py
+++ b/tests/network/hostname_resolver_test.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from medusa.network.hostname_resolver import HostnameResolver
+
+
+class HostnameResolverTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def test_no_address_resolving(self):
+        hostname_resolver = HostnameResolver(resolve_addresses=False)
+        self.assertEqual("127.0.0.1", hostname_resolver.resolve_fqdn("127.0.0.1"))
+
+    def test_address_resolving(self):
+        hostname_resolver = HostnameResolver(resolve_addresses=True)
+        self.assertNotEqual("127.0.0.1", hostname_resolver.resolve_fqdn("127.0.0.1"))

--- a/tests/restore_cluster_test.py
+++ b/tests/restore_cluster_test.py
@@ -41,7 +41,8 @@ class RestoreClusterTest(unittest.TestCase):
                                         'resources/yaml/work/cassandra_with_tokens_and_autobootstrap.yaml'),
             'start_cmd': '/etc/init.d/cassandra start',
             'stop_cmd': '/etc/init.d/cassandra stop',
-            'is_ccm': '1'
+            'is_ccm': '1',
+            'resolve_ip_addresses': 'False'
         }
         self.config = MedusaConfig(
             storage=_namedtuple_from_dict(StorageConfig, config['storage']),


### PR DESCRIPTION
Fixes #162 
Also fix config parsing that failed due to "restore" not being changed to "checks" in a previous PR.

I still need to add automatic detection of domain mismatches to either switch automatically to cleaning up the domain or stop and issue an error message asking ops to do it.