### PR TITLE
Restore node should be done in place by default

### DIFF
--- a/medusa/config.py
+++ b/medusa/config.py
@@ -97,7 +97,7 @@ def load_config(args, config_file):
 
     config['cassandra'] = {
         'config_file': medusa.cassandra_utils.CassandraConfigReader.DEFAULT_CASSANDRA_CONFIG,
-        'start_cmd': 'sudo /etc/init.d/cassandra start',
+        'start_cmd': 'sudo service cassandra start',
         'stop_cmd': 'sudo service cassandra stop',
         'check_running': 'nodetool version',
         'is_ccm': 0,

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -191,8 +191,8 @@ def restore_cluster(medusaconfig, backup_name, seed_target, temp_dir, host_list,
 @cli.command(name='restore-node')
 @click.option('--temp-dir', help='Directory for temporary storage', default="/tmp")
 @click.option('--backup-name', help='Backup name', required=True)
-@click.option('--in-place', help='Indicates if the restore happens on the node the backup was done on.',
-              default=False, is_flag=True)
+@click.option('--in-place/--remote', help='Indicates if the restore happens on the node the backup was done on.',
+              default=True, is_flag=True)
 @click.option('--keep-auth', help='Keep system_auth keyspace as found on the node',
               default=False, is_flag=True)
 @click.option('--seeds', help='Nodes to wait for after downloading backup but before starting C*',

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -391,7 +391,7 @@ class RestoreJob(object):
             verify_restore(target_hosts, self.config)
 
     def _build_restore_cmd(self, target, source, seeds):
-        in_place_option = '--in-place' if self.in_place else ''
+        in_place_option = '--in-place' if self.in_place else '--remote'
         keep_auth_option = '--keep-auth' if self.keep_auth else ''
         keyspace_options = expand_repeatable_option('keyspace', self.keyspaces)
         table_options = expand_repeatable_option('table', self.tables)


### PR DESCRIPTION
Also, the new token enforcement method now allows us to start Cassandra using  `sudo service cassandra start` by default.