### PR TITLE
Add s3 canned ACL support

### DIFF
--- a/docs/aws_s3_setup.md
+++ b/docs/aws_s3_setup.md
@@ -51,6 +51,7 @@ Create an IAM Policy called `MedusaStorageStrategy`, with the following definiti
                 "s3:GetReplicationConfiguration",
                 "s3:ListMultipartUploadParts",
                 "s3:PutObject",
+                "s3:PutObjectAcl",
                 "s3:GetObject",
                 "s3:GetObjectTorrent",
                 "s3:PutObjectRetention",

--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -71,6 +71,9 @@ concurrent_transfers = 1
 ; Size over which S3 uploads will be using the awscli with multi part uploads. Defaults to 100MB.
 multi_part_upload_threshold = 104857600
 
+; Canned ACL for uploaded objects on S3. Defaults to private
+canned_acl = private
+
 [monitoring]
 ;monitoring_provider = <Provider used for sending metrics. Currently either of "ffwd" or "local">
 

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -29,7 +29,8 @@ StorageConfig = collections.namedtuple(
     'StorageConfig',
     ['bucket_name', 'key_file', 'prefix', 'fqdn', 'host_file_separator', 'storage_provider',
      'base_path', 'max_backup_age', 'max_backup_count', 'api_profile', 'transfer_max_bandwidth',
-     'concurrent_transfers', 'multi_part_upload_threshold', 'host', 'region', 'port', 'secure', 'aws_cli_path']
+     'concurrent_transfers', 'multi_part_upload_threshold', 'canned_acl', 'host',
+     'region', 'port', 'secure', 'aws_cli_path']
 )
 
 CassandraConfig = collections.namedtuple(
@@ -95,6 +96,7 @@ def load_config(args, config_file):
         'aws_cli_path': 'aws',
         'fqdn': socket.getfqdn(),
         'region': 'default',
+        'canned_acl': 'private',
     }
 
     config['logging'] = {

--- a/medusa/storage/aws_s3_storage/awscli.py
+++ b/medusa/storage/aws_s3_storage/awscli.py
@@ -27,6 +27,7 @@ class AwsCli(object):
     def __init__(self, storage):
         self._config = storage.config
         self.storage = storage
+        self.canned_acl = storage.config.canned_acl
 
     @property
     def bucket_name(self):
@@ -73,7 +74,8 @@ class AwsCli(object):
         awscli_output = "/tmp/awscli_{0}.output".format(job_id)
         objects = []
         for src in srcs:
-            cmd = [self._aws_cli_path, "s3", "cp", str(src), "s3://{}/{}".format(bucket_name, dest)]
+            cmd = [self._aws_cli_path, "s3", "cp", "--acl", self.canned_acl,
+                   str(src), "s3://{}/{}".format(bucket_name, dest)]
             objects.append(self.upload_file(cmd, dest, awscli_output))
 
         return objects

--- a/medusa/storage/s3_storage.py
+++ b/medusa/storage/s3_storage.py
@@ -157,6 +157,7 @@ class S3Storage(AbstractStorage):
             srcs,
             dest,
             self.bucket,
+            canned_acl=self.config.canned_acl,
             max_workers=self.config.concurrent_transfers,
             multi_part_upload_threshold=int(self.config.multi_part_upload_threshold),
         )

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -426,7 +426,8 @@ def i_am_using_storage_provider_with_grpc_server(context, storage_provider, clie
             "multi_part_upload_threshold": 1 * 1024,
             "concurrent_transfers": 4,
             "prefix": storage_prefix,
-            "aws_cli_path": "aws"
+            "aws_cli_path": "aws",
+            "canned_acl": "private"
         }
 
     config["cassandra"] = {


### PR DESCRIPTION
Changing default canned ACL[1] would be useful for situations where the S3 bucket is located in a different account. For S3, by default the object owner is the source AWS account where the object comes from [2]. This is a big limitation for a disaster recovery scenario where the restore could be done in a different account and requires to previously change the permissions to all objects in the bucket.

The default ACL value will remain as private.

[1] https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
[2] https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-owner-access/



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1406) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1406
┆priority: Medium
