### PR TITLE
Relative installation path to config example

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,5 +64,5 @@ setuptools.setup(
             'medusa=medusa.medusacli:cli',
         ]},
     scripts=['bin/medusa-wrapper'],
-    data_files=[('/etc/medusa', ['medusa-example.ini'])]
+    data_files=[('etc', ['medusa-example.ini'])]
 )


### PR DESCRIPTION
Absolute path makes it impossible to install into virtual environment without sudo.