### PR TITLE
* Fixed inconsistent resolve_ip_addresses usage in CqlSession

### DIFF
--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -34,7 +34,6 @@ from cassandra.cluster import Cluster, ExecutionProfile
 from cassandra.policies import WhiteListRoundRobinPolicy
 from cassandra.auth import PlainTextAuthProvider
 from ssl import SSLContext, PROTOCOL_TLSv1, CERT_REQUIRED
-from medusa.config import evaluate_boolean
 from medusa.network.hostname_resolver import HostnameResolver
 
 
@@ -136,7 +135,7 @@ class CqlSession(object):
 
     def __init__(self, session, resolve_ip_addresses=True):
         self._session = session
-        self.hostname_resolver = HostnameResolver(evaluate_boolean(resolve_ip_addresses))
+        self.hostname_resolver = HostnameResolver(resolve_ip_addresses)
 
     def __enter__(self):
         return self

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -34,6 +34,7 @@ from cassandra.cluster import Cluster, ExecutionProfile
 from cassandra.policies import WhiteListRoundRobinPolicy
 from cassandra.auth import PlainTextAuthProvider
 from ssl import SSLContext, PROTOCOL_TLSv1, CERT_REQUIRED
+from medusa.config import evaluate_boolean
 from medusa.network.hostname_resolver import HostnameResolver
 
 
@@ -135,7 +136,7 @@ class CqlSession(object):
 
     def __init__(self, session, resolve_ip_addresses=True):
         self._session = session
-        self.hostname_resolver = HostnameResolver(resolve_ip_addresses)
+        self.hostname_resolver = HostnameResolver(evaluate_boolean(resolve_ip_addresses))
 
     def __enter__(self):
         return self

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -164,8 +164,8 @@ def load_config(args, config_file):
         if value is not None
     }})
 
-    if config['storage']['fqdn'] == socket.getfqdn() \
-            and not evaluate_boolean(config['cassandra']['resolve_ip_addresses']):
+    config['cassandra']['resolve_ip_addresses'] = evaluate_boolean(config['cassandra']['resolve_ip_addresses'])
+    if config['storage']['fqdn'] == socket.getfqdn() and not config['cassandra']['resolve_ip_addresses']:
         # Use the ip address instead of the fqdn when DNS resolving is turned off
         config['storage']['fqdn'] = socket.gethostbyname(socket.getfqdn())
 

--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -38,7 +38,7 @@ class CassandraUtilsTest(unittest.TestCase):
             'host_file_separator': ','
         }
         config['cassandra'] = {
-            'resolve_ip_addresses': '0'
+            'resolve_ip_addresses': False
         }
         self.config = MedusaConfig(
             storage=_namedtuple_from_dict(StorageConfig, config['storage']),

--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -38,12 +38,12 @@ class CassandraUtilsTest(unittest.TestCase):
             'host_file_separator': ','
         }
         config['cassandra'] = {
-            'resolve_ip_addresses': False
+            'resolve_ip_addresses': '0'
         }
         self.config = MedusaConfig(
             storage=_namedtuple_from_dict(StorageConfig, config['storage']),
             monitoring={},
-            cassandra=_namedtuple_from_dict(StorageConfig, config['cassandra']),
+            cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             ssh=None,
             checks=None,
             logging=None
@@ -59,7 +59,7 @@ class CassandraUtilsTest(unittest.TestCase):
         session.cluster.metadata.token_map.token_to_host_owner = {
             Murmur3Token(-9): host
         }
-        s = CqlSession(session, resolve_ip_addresses=False)
+        s = CqlSession(session, resolve_ip_addresses=self.config.cassandra.resolve_ip_addresses)
         token_map = s.tokenmap()
         self.assertEqual(
             {'127.0.0.1': {'is_up': True, 'tokens': [-9]}},


### PR DESCRIPTION
Configuration parameter cassandra.resolve_ip_addresses is used differently in medusa/config.py
```python
if config['storage']['fqdn'] == socket.getfqdn() \
    and not evaluate_boolean(config['cassandra']['resolve_ip_addresses']):
    # Use the ip address instead of the fqdn when DNS resolving is turned off
    config['storage']['fqdn'] = socket.gethostbyname(socket.getfqdn())
```
and in medusa/cassandra_utils.py where CqlSession constructor is just passing resolve_ip_addresses without validation.

It makes Cassandra medusa create Incomplete backups as tokenmap contains hostname instead of ip address for the first node in case 
```
[cassandra]
resolve_ip_addresses=0
```
Incomplete backup looks like
```
20200830 [Incomplete!]
- Started: 2020-08-30 05:17:09, Finished: never
- 6 nodes completed, 0 nodes incomplete, 1 nodes missing
- Missing nodes:
    XXXX.internal
```
Missing nodes is always the first one making backup.