### PR TITLE
Normalized resolve_ip_addresses value

### DIFF
--- a/medusa/config.py
+++ b/medusa/config.py
@@ -164,8 +164,9 @@ def load_config(args, config_file):
         if value is not None
     }})
 
-    if config['storage']['fqdn'] == socket.getfqdn() \
-            and not evaluate_boolean(config['cassandra']['resolve_ip_addresses']):
+    resolve_ip_addresses = evaluate_boolean(config['cassandra']['resolve_ip_addresses'])
+    config.set('cassandra', 'resolve_ip_addresses', 'True' if resolve_ip_addresses else 'False')
+    if config['storage']['fqdn'] == socket.getfqdn() and not resolve_ip_addresses:
         # Use the ip address instead of the fqdn when DNS resolving is turned off
         config['storage']['fqdn'] = socket.gethostbyname(socket.getfqdn())
 

--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -43,7 +43,7 @@ class CassandraUtilsTest(unittest.TestCase):
         self.config = MedusaConfig(
             storage=_namedtuple_from_dict(StorageConfig, config['storage']),
             monitoring={},
-            cassandra=_namedtuple_from_dict(StorageConfig, config['cassandra']),
+            cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             ssh=None,
             checks=None,
             logging=None
@@ -59,7 +59,7 @@ class CassandraUtilsTest(unittest.TestCase):
         session.cluster.metadata.token_map.token_to_host_owner = {
             Murmur3Token(-9): host
         }
-        s = CqlSession(session, resolve_ip_addresses=False)
+        s = CqlSession(session, resolve_ip_addresses=self.config.cassandra.resolve_ip_addresses)
         token_map = s.tokenmap()
         self.assertEqual(
             {'127.0.0.1': {'is_up': True, 'tokens': [-9]}},


### PR DESCRIPTION
Configuration parameter **cassandra.resolve_ip_addresses** is used differently in **medusa/config.py**
```python
if config['storage']['fqdn'] == socket.getfqdn() \
    and not evaluate_boolean(config['cassandra']['resolve_ip_addresses']):
    # Use the ip address instead of the fqdn when DNS resolving is turned off
    config['storage']['fqdn'] = socket.gethostbyname(socket.getfqdn())
```
and in **medusa/cassandra_utils.py** where **CqlSession** constructor is just passing string value of **resolve_ip_addresses** to **HostnameResolver**.

if **medusa.ini** contains **cassandra.resolve_ip_addresses=0** logic **str(self.resolve_addresses) == "False"** in **HostnameResolver** works not as expected and it tries to resolve ip addresses anyway.

Incomplete backup for cluster containing 6 nodes looks like
```
20200830 [Incomplete!]
- Started: 2020-08-30 05:17:09, Finished: never
- 6 nodes completed, 0 nodes incomplete, 1 nodes missing
- Missing nodes:
    XXXX.internal
```
Missing nodes is always the first one making backup.