### PR TITLE
Avoid double purge (through count + age) of the same backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.7.2 (TBD)
 - Fixed flakey tests (@adejanovski / @arodrime)
+- Avoid double purge (through count + age) of the same backup (@arodrime)
 
 ### 0.7.1 (2020/07/30 11:12 +00:00)
 - Add a timeout for nc checks - node_up? (@arodrime)

--- a/medusa/purge.py
+++ b/medusa/purge.py
@@ -27,7 +27,7 @@ from medusa.storage import Storage, format_bytes_str
 
 
 def main(config, max_backup_age=0, max_backup_count=0):
-    backups_to_purge = list()
+    backups_to_purge = set()
     monitoring = Monitoring(config=config.monitoring)
 
     try:
@@ -38,9 +38,9 @@ def main(config, max_backup_age=0, max_backup_count=0):
         backup_index = storage.list_backup_index_blobs()
         backups = list(storage.list_node_backups(fqdn=config.storage.fqdn, backup_index_blobs=backup_index))
         # list all backups to purge based on date conditions
-        backups_to_purge += backups_to_purge_by_age(backups, max_backup_age)
+        backups_to_purge |= set(backups_to_purge_by_age(backups, max_backup_age))
         # list all backups to purge based on count conditions
-        backups_to_purge += backups_to_purge_by_count(backups, max_backup_count)
+        backups_to_purge |= set(backups_to_purge_by_count(backups, max_backup_count))
         # purge all candidate backups
         purge_backups(storage, backups_to_purge)
 
@@ -84,7 +84,7 @@ def backups_to_purge_by_count(backups, max_backup_count):
 
 def purge_backups(storage, backups):
     """
-    Core function to purge a list of node_backups
+    Core function to purge a set of node_backups
     Used for node purge and backup delete (using a specific backup_name)
     """
     logging.info("{} backups are candidate to be purged".format(len(backups)))


### PR DESCRIPTION
Fixes #194 (or part of it - to be determined there)

set() instead of list() with the hope that when a backup is to be deleted because of both age and count, we still only reference the backup one time and delete it once.