### PR TITLE
Fix GCS folders being uploaded as files when they only contain the schema.cql file

### DIFF
--- a/medusa/backup.py
+++ b/medusa/backup.py
@@ -35,7 +35,7 @@ from medusa.storage import Storage, format_bytes_str, ManifestObject
 
 
 class NodeBackupCache(object):
-    NEVER_BACKED_UP = ['manifest.json']
+    NEVER_BACKED_UP = ['manifest.json', 'schema.cql']
 
     def __init__(self, *, node_backup, differential_mode, storage_driver, storage_provider, storage_config):
         if node_backup:

--- a/medusa/storage/google_cloud_storage/gsutil.py
+++ b/medusa/storage/google_cloud_storage/gsutil.py
@@ -96,6 +96,7 @@ class GSUtil(object):
                                                stderr=subprocess.STDOUT,
                                                universal_newlines=True)
                 for src in srcs:
+                    logging.debug("Uploading {}".format(str(src)))
                     process.stdin.write(str(src) + '\n')
                 process.stdin.close()
                 if process.wait() == 0:


### PR DESCRIPTION
Empty tables get uploaded to GCS in a weird way as they appear as a file instead of a directory, whose content is the content of the schema.cql file 🙄 

It seems like in some edge cases, this breaks the verification of backups which breaks them.
This PR skips the schema.cql (the one generated by Cassandra during a snapshot) which then allows to skip empty tables altogether.