### PR TITLE
Pin ssh2-python version to 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Avoid double purge (through count + age) of the same backup (@arodrime)
 - Remove nc (netcat) dependency, use python socket instead (@arodrime)
 - Add multi-cassandra version integration tests (@adejanovski)
+- Pin ssh2 version to 0.19.0 to avoid broken dependency (@arodrime)
 
 ### 0.7.1 (2020/07/30 11:12 +00:00)
 - Add a timeout for nc checks - node_up? (@arodrime)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,6 @@ lockfile>=0.12.2
 pycrypto>=2.6.1
 retrying>=1.3.3
 parallel-ssh==1.9.1
+# ssh2-python==0.20.0 is broken, 0.22.0+ should work.
+ssh2-python==0.19.0
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setuptools.setup(
         'pycrypto>=2.6.1',
         'retrying>=1.3.3',
         'parallel-ssh==1.9.1',
+        'ssh2-python==0.19.0',  # <-- ssh2-python==0.20.0 is broken, 0.22.0+ should work.
         'requests==2.22.0'
     ],
     extras_require={


### PR DESCRIPTION
Fixes #208 #201 

Adding dependency to avoid weirdnesses of ssh2-python==0.20.0 that produces bugs at setup & runtime