### PR TITLE
(#201) Ubuntu 16.04 & 18.04 debian packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+debian/cassandra-medusa/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,35 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
+    - name: Build and publish Debian
+      env:
+        BINTRAY_USERNAME: ${{ secrets.BINTRAY_USERNAME }}
+        BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
+        SUITES: "bionic xenial buster stretch"
+      run: |
+        cd packaging/docker-build
+        $all_suites=($SUITES) # dash supports arrays expansion
+        for suite in $all_suites
+        do
+          docker-compose build "cassandra-medusa-builder-${suite} \
+            && docker-compose run "cassandra-medusa-builder-${suite}"
+        done
+        cd ../..
+        version=$(cat VERSION)
+        for suite in $all_suites
+        do
+          if [ -f "packages/cassandra-medusa_${version}-0~${suite}0_amd64.deb" ]; then
+            echo "uploading packages/cassandra-medusa_${version}-0~${suite}0_amd64.deb from ${suite} to Bintray"
+            curl -T "packages/cassandra-medusa_${version}-0~${suite}0_amd64.deb" \
+              -u${BINTRAY_USERNAME}:${BINTRAY_KEY} \
+              -H X-Bintray-Debian-Distribution:${suite} -H X-Bintray-Debian-Component:main -H X-Bintray-Debian-Architecture:amd64 -H X-Bintray-Version:${version} \
+              https://api.bintray.com/content/thelastpickle/medusa-deb/cassandra-medusa/${version}/cassandra-medusa_${version}-0~${suite}0_amd64.deb
+          else
+            echo "Error: no packages found for ${suite}"
+          fi
+        done
+        echo "Publishing release in Bintray"
+        curl -X POST -u${BINTRAY_USERNAME}:${BINTRAY_KEY} https://api.bintray.com/content/thelastpickle/medusa-deb/cassandra-medusa/${version}/publish
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
@@ -161,20 +190,3 @@ jobs:
         pip install setuptools wheel twine
         python setup.py sdist bdist_wheel
         twine upload dist/*
-    - name: Build and publish Debian
-      env:
-        BINTRAY_USERNAME: ${{ secrets.BINTRAY_USERNAME }}
-        BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
-      run: |
-        cd packaging/docker-build
-        docker-compose build cassandra-medusa-builder && docker-compose run cassandra-medusa-builder
-        cd ../..
-        debPackage=$(ls packages/*.deb)
-        version=$(cat VERSION)
-        echo "uploading ${debPackage} to Bintray"
-        curl -T packages/cassandra-medusa_${version}_amd64.deb \
-          -u${BINTRAY_USERNAME}:${BINTRAY_KEY} \
-          -H X-Bintray-Debian-Distribution:wheezy,bionic,jessie,xenial -H X-Bintray-Debian-Component:main -H X-Bintray-Debian-Architecture:amd64 -H X-Bintray-Version:${version} \
-          https://api.bintray.com/content/thelastpickle/medusa-deb/cassandra-medusa/${version}/cassandra-medusa_${version}_amd64.deb
-        echo "Publishing release in Bintray"
-        curl -X POST -u${BINTRAY_USERNAME}:${BINTRAY_KEY} https://api.bintray.com/content/thelastpickle/medusa-deb/cassandra-medusa/${version}/publish

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ debhelper-build-stamp
 files
 installed-by-dh_installdocs
 debian/.debhelper
+debian/cassandra-medusa/

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: python
 Priority: extra
 Maintainer: The Last Pickle <oss@thelastpickle.com>
 Build-Depends:
-  debhelper (>= 11),
+  debhelper (>= 9),
   dh-python,
   python3-all,
   python3-all-dev,
@@ -14,6 +14,7 @@ Standards-Version: 3.9.5
 
 Package: cassandra-medusa
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Pre-Depends: dpkg (>= 1.16.1), python3, python3-venv, ${misc:Pre-Depends}
+Depends: ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
 Description: Backup tool for Cassandra databases
  Make immutable backups for Cassandra databases and extract them to an external storage.

--- a/debian/rules
+++ b/debian/rules
@@ -15,16 +15,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+VERSION = $(shell dpkg-parsechangelog --show-field Version)
+DISTRIBUTION = $(shell sed -n "s/^VERSION_CODENAME=//p" /etc/os-release)
+PACKAGEVERSION = $(VERSION)-0~$(DISTRIBUTION)0
+
 export DH_ALWAYS_EXCLUDE = .git
 export DH_VIRTUALENV_INSTALL_ROOT = /usr/share
 %:
 	dh $@ --with python-virtualenv
 
 override_dh_virtualenv:
-	dh_virtualenv --python /usr/bin/python3 --preinstall=setuptools==40.3.0 --builtin-venv
+	dh_virtualenv --python /usr/bin/python3 --preinstall=setuptools==40.3.0 --preinstall=pip==20.2.3 --preinstall=wheel --builtin-venv
 
 override_dh_strip:
 	dh_strip --no-automatic-dbgsym --exclude libssh2
 
 override_dh_shlibdeps:
-	dh_shlibdeps -l$(CURDIR)/debian/cassandra-medusa/usr/share/cassandra-medusa/lib/python3.6/site-packages/ssh2/.libs/
+	dh_shlibdeps -l$(CURDIR)/$(SSH2_LIBS_SUFFIX)
+
+override_dh_gencontrol:
+	dh_gencontrol -- -v$(PACKAGEVERSION)

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -1,7 +1,24 @@
 #!/usr/bin/env bash
 
-set -xe
+set -e
+
+case $1 in
+  ""|bionic|xenial|buster|stretch)
+    suites=("${1:-bionic}")
+    ;;
+  all)
+    suites=(bionic xenial buster stretch)
+    ;;
+  *)
+    echo "Unknown distribution suite - allowed values: 'all', 'bionic', 'xenial', 'buster', 'stretch'"
+    exit 1
+    ;;
+esac
 
 cd docker-build
-docker-compose build
-docker-compose run cassandra-medusa-builder
+
+for suite in "${suites[@]}"
+do
+  docker-compose build "cassandra-medusa-builder-${suite}"
+  docker-compose run "cassandra-medusa-builder-${suite}"
+done

--- a/packaging/docker-build/Dockerfile
+++ b/packaging/docker-build/Dockerfile
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-FROM ubuntu:18.04
+ARG BUILD_IMAGE=ubuntu:18.04
+FROM ${BUILD_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Paris
@@ -24,10 +24,12 @@ WORKDIR ${WORKDIR}
 ENV PIP_DEFAULT_TIMEOUT 100
 RUN echo "Acquire::http::Pipeline-Depth 0;" >> /etc/apt/apt.conf
 
-# add a repo that contains a backport of dh-virtualenv 1.1 for Bionic
+# add a repo that contains a backport of dh-virtualenv 1.1 for Bionic & xenial
 RUN apt-get update && \
-    apt-get install -y software-properties-common
-RUN add-apt-repository ppa:kalon33/gamesgiroll -y
+    apt-get install -y software-properties-common && \
+    case $BUILD_IMAGE in ubuntu*) \
+        add-apt-repository ppa:kalon33/gamesgiroll -y ;; \
+    esac
 
 # install dependencies
 RUN apt-get update \
@@ -42,7 +44,9 @@ RUN apt-get update \
         python3-pip \
         python3-setuptools \
         python3-venv \
+        python3-wheel \
         build-essential \
+        cmake \
         devscripts \
         dh-virtualenv \
         equivs \

--- a/packaging/docker-build/docker-compose.yml
+++ b/packaging/docker-build/docker-compose.yml
@@ -15,14 +15,54 @@
 version: '2.1'
 
 services:
-  cassandra-medusa-builder:
+  cassandra-medusa-builder-bionic:
     build:
       context: ../..
       dockerfile: packaging/docker-build/Dockerfile
+      args:
+        - BUILD_IMAGE=ubuntu:18.04
+    environment:
+      - SSH2_LIBS_SUFFIX=debian/cassandra-medusa/usr/share/cassandra-medusa/lib/python3.6/site-packages/ssh2_python.libs/
     volumes:
       - ../..:/usr/src/app/cassandra-medusa
       - ../../packages:/usr/src/app/packages
       - ./scripts:/usr/src/app/scripts
+  cassandra-medusa-builder-xenial:
+    build:
+      context: ../..
+      dockerfile: packaging/docker-build/Dockerfile
+      args:
+        - BUILD_IMAGE=ubuntu:16.04
+    volumes:
+      - ../..:/usr/src/app/cassandra-medusa
+      - ../../packages:/usr/src/app/packages
+      - ./scripts:/usr/src/app/scripts
+    environment:
+      - SSH2_LIBS_SUFFIX=debian/cassandra-medusa/usr/share/cassandra-medusa/lib/python3.5/site-packages/ssh2_python.libs/
+  cassandra-medusa-builder-stretch:
+    build:
+      context: ../..
+      dockerfile: packaging/docker-build/Dockerfile
+      args:
+        - BUILD_IMAGE=debian:stretch
+    volumes:
+      - ../..:/usr/src/app/cassandra-medusa
+      - ../../packages:/usr/src/app/packages
+      - ./scripts:/usr/src/app/scripts
+    environment:
+      - SSH2_LIBS_SUFFIX=debian/cassandra-medusa/usr/share/cassandra-medusa/lib/python3.5/site-packages/ssh2_python.libs/
+  cassandra-medusa-builder-buster:
+    build:
+      context: ../..
+      dockerfile: packaging/docker-build/Dockerfile
+      args:
+        - BUILD_IMAGE=debian:buster
+    volumes:
+      - ../..:/usr/src/app/cassandra-medusa
+      - ../../packages:/usr/src/app/packages
+      - ./scripts:/usr/src/app/scripts
+    environment:
+      - SSH2_LIBS_SUFFIX=debian/cassandra-medusa/usr/share/cassandra-medusa/lib/python3.7/site-packages/ssh2_python.libs/
   release:
     build:
       context: ../..

--- a/packaging/docker-build/docker-entrypoint.sh
+++ b/packaging/docker-build/docker-entrypoint.sh
@@ -15,6 +15,8 @@
 
 set -ex
 
+export SSH2_LIBS_SUFFIX
+
 # build Debian
 # copy built packages into a mounted volume
 


### PR DESCRIPTION
The current debian package generated was not working properly on ubuntu xenial (see #201). This change allows to fix this by extending the way how the debian package is built.
`build-deb.sh` will now build a package for ubuntu 16.04 (xenial) and 18.04 (bionic) 
Both packages version reflect the distribution codename they've been built for, so they can be deployed to the same debian repository.
It would be relatively easy to extend the package build to other ubuntu or debian releases (provided they run a relatively recent python3 and have `dh_virtualenv >= 1.0`).
