### PR TITLE
Restrict allowed gevent versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ parallel-ssh==1.9.1
 # ssh2-python==0.20.0 is broken, 0.22.0+ should work.
 ssh2-python==0.19.0
 requests==2.22.0
+gevent>=1.1,<=1.4.0

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setuptools.setup(
         'retrying>=1.3.3',
         'parallel-ssh==1.9.1',
         'ssh2-python==0.19.0',  # <-- ssh2-python==0.20.0 is broken, 0.22.0+ should work.
-        'requests==2.22.0'
+        'requests==2.22.0',
+        'gevent>=1.1,<=1.4.0'
     ],
     extras_require={
         'S3': ["awscli>=1.16.291"],


### PR DESCRIPTION
The gevent dependency above 1.4.0 seems to break builds in some environments.
Let's limit the allowed versions to prevent that kind of breakages.