### PR TITLE
Tolerate custom seed providers in C* yaml

### DIFF
--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -229,7 +229,8 @@ class CassandraConfigReader(object):
         config_file = pathlib.Path(cassandra_config or self.DEFAULT_CASSANDRA_CONFIG)
         if not config_file.is_file():
             raise RuntimeError('{} is not a file'.format(config_file))
-        self._config = yaml.load(config_file.open(), Loader=yaml.BaseLoader)
+        with open(config_file, 'r') as f:
+            self._config = yaml.load(f, Loader=yaml.BaseLoader)
 
     @property
     def root(self):
@@ -288,7 +289,8 @@ class CassandraConfigReader(object):
         seeds = list()
         if 'seed_provider' in self._config:
             if self._config['seed_provider']:
-                return self._config.get('seed_provider')[0]['parameters'][0]['seeds'].replace(' ', '').split(',')
+                if self._config['seed_provider'][0]['class_name'].endswith('SimpleSeedProvider'):
+                    return self._config.get('seed_provider')[0]['parameters'][0]['seeds'].replace(' ', '').split(',')
         return seeds
 
 

--- a/tests/resources/yaml/work/cassandra_with_custom_seedprovider.yaml
+++ b/tests/resources/yaml/work/cassandra_with_custom_seedprovider.yaml
@@ -1,0 +1,124 @@
+authenticator: AllowAllAuthenticator
+authorizer: AllowAllAuthorizer
+auto_snapshot: true
+back_pressure_enabled: false
+back_pressure_strategy:
+- class_name: org.apache.cassandra.net.RateBasedBackPressure
+  parameters:
+  - factor: 5
+    flow: FAST
+    high_ratio: 0.9
+batch_size_fail_threshold_in_kb: 50
+batch_size_warn_threshold_in_kb: 5
+batchlog_replay_throttle_in_kb: 1024
+cas_contention_timeout_in_ms: 1000
+cdc_enabled: false
+client_encryption_options:
+  enabled: false
+  keystore: conf/.keystore
+  keystore_password: cassandra
+  optional: false
+cluster_name: Test Cluster
+column_index_cache_size_in_kb: 2
+column_index_size_in_kb: 64
+commit_failure_policy: stop
+commitlog_directory: /var/lib/cassandra/commitlog
+commitlog_segment_size_in_mb: 32
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+compaction_large_partition_warning_threshold_mb: 100
+compaction_throughput_mb_per_sec: 16
+concurrent_counter_writes: 32
+concurrent_materialized_view_writes: 32
+concurrent_reads: 32
+concurrent_writes: 32
+counter_cache_save_period: 7200
+counter_cache_size_in_mb: null
+counter_write_request_timeout_in_ms: 5000
+credentials_validity_in_ms: 2000
+cross_node_timeout: false
+data_file_directories:
+- /var/lib/cassandra/data
+disk_failure_policy: stop
+dynamic_snitch_badness_threshold: 0.1
+dynamic_snitch_reset_interval_in_ms: 600000
+dynamic_snitch_update_interval_in_ms: 100
+enable_materialized_views: true
+enable_sasi_indexes: true
+enable_scripted_user_defined_functions: false
+enable_user_defined_functions: false
+endpoint_snitch: SimpleSnitch
+gc_warn_threshold_in_ms: 1000
+hinted_handoff_enabled: true
+hinted_handoff_throttle_in_kb: 1024
+hints_flush_period_in_ms: 10000
+incremental_backups: false
+index_summary_capacity_in_mb: null
+index_summary_resize_interval_in_minutes: 60
+initial_token: -10
+inter_dc_tcp_nodelay: false
+internode_compression: dc
+key_cache_save_period: 14400
+key_cache_size_in_mb: null
+listen_address: localhost
+max_hint_window_in_ms: 10800000
+max_hints_delivery_threads: 2
+max_hints_file_size_in_mb: 128
+memtable_allocation_type: heap_buffers
+native_transport_port: 9042
+num_tokens: 1
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+permissions_validity_in_ms: 2000
+prepared_statements_cache_size_mb: null
+range_request_timeout_in_ms: 10000
+read_request_timeout_in_ms: 5000
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+request_timeout_in_ms: 10000
+role_manager: CassandraRoleManager
+roles_validity_in_ms: 2000
+row_cache_save_period: 0
+row_cache_size_in_mb: 0
+rpc_address: localhost
+rpc_keepalive: true
+rpc_port: 9160
+rpc_server_type: sync
+saved_caches_directory: /var/lib/cassandra/saved_caches
+seed_provider:
+- class_name: org.foo.bar.CustomSeedProvider
+server_encryption_options:
+  internode_encryption: none
+  keystore: conf/.keystore
+  keystore_password: cassandra
+  truststore: conf/.truststore
+  truststore_password: cassandra
+slow_query_log_timeout_in_ms: 500
+snapshot_before_compaction: false
+ssl_storage_port: 7001
+sstable_preemptive_open_interval_in_mb: 50
+start_native_transport: true
+start_rpc: false
+storage_port: 7000
+thrift_framed_transport_size_in_mb: 15
+thrift_prepared_statements_cache_size_mb: null
+tombstone_failure_threshold: 100000
+tombstone_warn_threshold: 1000
+tracetype_query_ttl: 86400
+tracetype_repair_ttl: 604800
+transparent_data_encryption_options:
+  chunk_length_kb: 64
+  cipher: AES/CBC/PKCS5Padding
+  enabled: false
+  key_alias: testing:1
+  key_provider:
+  - class_name: org.apache.cassandra.security.JKSKeyProvider
+    parameters:
+    - key_password: cassandra
+      keystore: conf/.keystore
+      keystore_password: cassandra
+      store_type: JCEKS
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+truncate_request_timeout_in_ms: 60000
+unlogged_batch_across_partitions_warn_threshold: 10
+windows_timer_interval: 1
+write_request_timeout_in_ms: 2000


### PR DESCRIPTION
It turned out Medusa was crashing when doing a backup if custom (non SimpleSeedProvider) was in place.
```
[2020-10-20 13:27:18,837] ERROR: This error happened during the backup: 'seeds'
Traceback (most recent call last):
  File "/usr/share/medusa/lib/python3.6/site-packages/medusa/backup.py", line 163, in main
    cassandra = Cassandra(config.cassandra)
  File "/usr/share/medusa/lib/python3.6/site-packages/medusa/cassandra_utils.py", line 320, in __init__
    self.seeds = config_reader.seeds
  File "/usr/share/medusa/lib/python3.6/site-packages/medusa/cassandra_utils.py", line 291, in seeds
    return self._config.get('seed_provider')[0]['parameters'][0]['seeds'].replace(' ', '').split(',')
KeyError: 'seeds'
```

The seed parsing was introduced in https://github.com/thelastpickle/cassandra-medusa/commit/e021bbd9fc51f305c58a919fb4ce0e4c2d091c1e and is meant to allow a specific restore scenario to work. 

@adejanovski said it's OK to just return an empty list in cases of non-default seed provider, because that restore scenario will not work with it anyway :D 