### PR TITLE
Allow to download only a set of keyspaces/tables

### DIFF
--- a/medusa/filtering.py
+++ b/medusa/filtering.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+# Copyright 2019 Spotify AB. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+
+def filter_fqtns(keep_keyspaces, keep_tables, manifest, ignore_system_keyspaces=False):
+    retained = set()
+    ignored = set()
+    manifest = json.loads(manifest)
+
+    for section in manifest:
+        ks = section['keyspace']
+        # in manifest, the table names have cfids, but from CLI we get it without
+        # we need to take care and use both
+        t = section['columnfamily'].split('-')[0]
+
+        fqtn = '{}.{}'.format(ks, t)
+        fqtn_with_id = '{}.{}'.format(section['keyspace'], section['columnfamily'])
+
+        # if not keyspaces / tables were specified, we keep everything
+        if len(keep_keyspaces) == 0 and len(keep_tables) == 0:
+            retained.add(fqtn_with_id)
+            continue
+
+        # if the whole keyspace is a keep, or a system keyspace (C* internal)
+        if keep_or_system_namespace(ks, keep_keyspaces, ignore_system_keyspaces):
+            retained.add(fqtn_with_id)
+            continue
+
+        # if just the table is a keep
+        if fqtn in keep_tables:
+            retained.add(fqtn_with_id)
+            continue
+
+        ignored.add('{}.{}'.format(ks, t))
+
+    return retained, ignored
+
+
+def keep_or_system_namespace(ks, keep_keyspaces, ignore_system_keyspaces):
+    SYSTEM_KEYSPACES = ['system', 'system_schema', 'system_auth', 'system_distributed']
+
+    return ks in keep_keyspaces or (not ignore_system_keyspaces and (ks in SYSTEM_KEYSPACES))

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -143,12 +143,19 @@ def list_backups(medusaconfig, show_all):
 @cli.command(name='download')
 @click.option('--backup-name', help='Custom name for the backup', required=True)
 @click.option('--download-destination', help='Download destination', required=True)
+@click.option('--keyspace', 'keyspaces', help="Restore tables from this keyspace, use --keyspace ks1 [--keyspace ks2]",
+              multiple=True, default={})
+@click.option('--table', 'tables', help="Restore only this table, use --table ks.t1 [--table ks.t2]",
+              multiple=True, default={})
+@click.option('--ignore-system-keyspaces', help='Do not download cassandra system keyspaces', required=True,
+              is_flag=True, default=False)
 @pass_MedusaConfig
-def download(medusaconfig, backup_name, download_destination):
+def download(medusaconfig, backup_name, download_destination, keyspaces, tables, ignore_system_keyspaces):
     """
     Download backup
     """
-    medusa.download.download_cmd(medusaconfig, backup_name, Path(download_destination))
+    medusa.download.download_cmd(medusaconfig, backup_name, Path(download_destination), keyspaces, tables,
+                                 ignore_system_keyspaces)
 
 
 @cli.command(name='restore-cluster')

--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -292,6 +292,10 @@ def maybe_restore_section(section, download_dir, cassandra_data_dir, in_place, k
         logging.debug("Skipping the actual restore of {}".format(section['columnfamily']))
         return
 
+    if not section['objects']:
+        logging.debug("Skipping the actual restore of {} - table empty".format(section['columnfamily']))
+        return
+
     # restore the table
     logging.debug('Restoring {} -> {}'.format(src, dst))
     subprocess.check_output(['sudo', 'mv', str(src), str(dst)])

--- a/tests/filtering_test.py
+++ b/tests/filtering_test.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Spotify AB. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import configparser
+import json
+import unittest
+
+from medusa.config import MedusaConfig, StorageConfig, _namedtuple_from_dict
+from medusa import filtering
+
+
+class FilteringTest(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def setUp(self):
+        config = configparser.ConfigParser(interpolation=None)
+        config['storage'] = {
+            'host_file_separator': ','
+        }
+        self.config = MedusaConfig(
+            storage=_namedtuple_from_dict(StorageConfig, config['storage']),
+            monitoring={},
+            cassandra=None,
+            ssh=None,
+            checks=None,
+            logging=None
+        )
+
+    def test_get_sections_to_restore(self):
+
+        # nothing skipped, both tables make it to restore
+        keep_keyspaces = {}
+        keep_tables = {}
+        manifest = [
+            {'keyspace': 'k1', 'columnfamily': 't1', 'objects': []},
+            {'keyspace': 'k2', 'columnfamily': 't2', 'objects': []}
+        ]
+
+        to_restore, ignored = filtering.filter_fqtns(keep_keyspaces, keep_tables, json.dumps(manifest))
+        self.assertEqual({'k1.t1', 'k2.t2'}, to_restore)
+        self.assertEqual(set(), ignored)
+
+        # skipping one table (must be specified as a fqtn)
+        keep_keyspaces = {}
+        keep_tables = {'k2.t2'}
+        manifest = [
+            {'keyspace': 'k1', 'columnfamily': 't1', 'objects': []},
+            {'keyspace': 'k2', 'columnfamily': 't2', 'objects': []}
+        ]
+        to_restore, ignored = filtering.filter_fqtns(keep_keyspaces, keep_tables, json.dumps(manifest))
+        self.assertEqual({'k2.t2'}, to_restore)
+        self.assertEqual({'k1.t1'}, ignored)
+
+        # saying only table name doesn't cause a keep
+        keep_keyspaces = {}
+        keep_tables = {'t2'}
+        manifest = [
+            {'keyspace': 'k1', 'columnfamily': 't1', 'objects': []},
+            {'keyspace': 'k2', 'columnfamily': 't2', 'objects': []}
+        ]
+        to_restore, ignored = filtering.filter_fqtns(keep_keyspaces, keep_tables, json.dumps(manifest))
+        self.assertEqual(set(), to_restore)
+        self.assertEqual({'k1.t1', 'k2.t2'}, ignored)
+
+        # keeping the whole keyspace
+        keep_keyspaces = {'k2'}
+        keep_tables = {}
+        manifest = [
+            {'keyspace': 'k1', 'columnfamily': 't1', 'objects': []},
+            {'keyspace': 'k2', 'columnfamily': 't2', 'objects': []},
+            {'keyspace': 'k2', 'columnfamily': 't3', 'objects': []}
+        ]
+        to_restore, ignored = filtering.filter_fqtns(keep_keyspaces, keep_tables, json.dumps(manifest))
+        self.assertEqual({'k2.t2', 'k2.t3'}, to_restore)
+        self.assertEqual({'k1.t1'}, ignored)
+
+    def test_get_sections_to_restore_with_cfids(self):
+
+        # kept tables must work also if the manifest has cfids
+        keep_keyspaces = {}
+        keep_tables = {'k2.t2'}
+        manifest = [
+            {'keyspace': 'k1', 'columnfamily': 't1-bigBadCfId', 'objects': []},
+            {'keyspace': 'k2', 'columnfamily': 't2-81ffe430e50c11e99f91a15641db358f', 'objects': []},
+        ]
+        to_restore, ignored = filtering.filter_fqtns(keep_keyspaces, keep_tables, json.dumps(manifest))
+        self.assertEqual({'k2.t2-81ffe430e50c11e99f91a15641db358f'}, to_restore)
+        self.assertEqual({'k1.t1'}, ignored)
+
+    def test_filter_out_system_keyspaces_if_requested(self):
+
+        # system tables should be kept by default
+        keep_keyspaces = {}
+        keep_tables = {'k2.t2'}
+        manifest = [
+            {'keyspace': 'system', 'columnfamily': 'hints-2666e20573ef38b390fefecf96e8f0c7', 'objects': []},
+            {'keyspace': 'system_distributed', 'columnfamily': 'repair_history', 'objects': []},
+            {'keyspace': 'k2', 'columnfamily': 't2', 'objects': []},
+        ]
+        to_restore, ignored = filtering.filter_fqtns(keep_keyspaces, keep_tables, json.dumps(manifest))
+        self.assertEqual({'system.hints-2666e20573ef38b390fefecf96e8f0c7', 'system_distributed.repair_history',
+                          'k2.t2'}, to_restore)
+        self.assertEqual(set(), ignored)
+
+        # system tables should not be kept if requested
+        keep_keyspaces = {}
+        keep_tables = {'k2.t2'}
+        manifest = [
+            {'keyspace': 'system', 'columnfamily': 'hints-2666e20573ef38b390fefecf96e8f0c7', 'objects': []},
+            {'keyspace': 'system_distributed', 'columnfamily': 'repair_history', 'objects': []},
+            {'keyspace': 'k2', 'columnfamily': 't2', 'objects': []},
+        ]
+        to_restore, ignored = filtering.filter_fqtns(keep_keyspaces, keep_tables, json.dumps(manifest), True)
+        self.assertEqual({'k2.t2'}, to_restore)
+        self.assertEqual({'system.hints', 'system_distributed.repair_history'}, ignored)

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -405,9 +405,12 @@ def _i_can_download_the_backup_all_tables_successfully(context, backup_name):
     )
     fqtn = set({})
     medusa.download.download_data(context.medusa_config.storage, backup, fqtn, Path(download_path))
+    # check all manifest objects that have been backed up have been downloaded
+    keyspaces = {section['keyspace'] for section in json.loads(backup.manifest) if section['objects']}
+    for ks in keyspaces:
+        ks_path = os.path.join(download_path, ks)
+        assert os.path.isdir(ks_path)
 
-    sys_dist = os.path.join(download_path, 'system_distributed')
-    assert os.path.isdir(sys_dist)
     cleanup(download_path)
 
 
@@ -427,10 +430,18 @@ def _i_can_download_the_backup_single_table_successfully(context, backup_name, f
         fqdn=config.storage.fqdn,
         name=backup_name,
     )
-    medusa.download.download_data(context.medusa_config.storage, backup, fqtn, Path(download_path))
 
-    sys_dist = os.path.join(download_path, 'system_distributed')
-    assert os.path.isdir(sys_dist)
+    # download_data requires fqtn with table id
+    fqtns_to_download, _ = medusa.filtering.filter_fqtns([], [fqtn], backup.manifest, True)
+    medusa.download.download_data(context.medusa_config.storage, backup, fqtns_to_download, Path(download_path))
+
+    # check the keyspace directory has been created
+    ks, table = fqtn.split('.')
+    ks_path = os.path.join(download_path, ks)
+    assert os.path.isdir(ks_path)
+
+    # check tables have been downloaded
+    assert list(Path(ks_path).glob('{}-*/*.db'.format(table)))
     cleanup(download_path)
 
 

--- a/tests/restore_node_test.py
+++ b/tests/restore_node_test.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import configparser
-import json
 import unittest
 
 from medusa.config import MedusaConfig, StorageConfig, _namedtuple_from_dict
@@ -49,61 +48,6 @@ class RestoreNodeTest(unittest.TestCase):
         with open("tests/resources/restore_node_tokenmap_vnodes.json", 'r') as f:
             tokens = restore_node.get_node_tokens('node3.mydomain.net', f)
             self.assertEqual(tokens, ['2', '3'])
-
-    def test_get_sections_to_restore(self):
-
-        # nothing skipped, both tables make it to restore
-        keep_keyspaces = {}
-        keep_tables = {}
-        manifest = [
-            {'keyspace': 'k1', 'columnfamily': 't1', 'objects': []},
-            {'keyspace': 'k2', 'columnfamily': 't2', 'objects': []}
-        ]
-        to_restore = restore_node.get_fqtns_to_restore(keep_keyspaces, keep_tables, json.dumps(manifest))
-        self.assertEqual({'k1.t1', 'k2.t2'}, to_restore)
-
-        # skipping one table (must be specified as a fqtn)
-        keep_keyspaces = {}
-        keep_tables = {'k2.t2'}
-        manifest = [
-            {'keyspace': 'k1', 'columnfamily': 't1', 'objects': []},
-            {'keyspace': 'k2', 'columnfamily': 't2', 'objects': []}
-        ]
-        to_restore = restore_node.get_fqtns_to_restore(keep_keyspaces, keep_tables, json.dumps(manifest))
-        self.assertEqual({'k2.t2'}, to_restore)
-
-        # saying only table name doesn't cause a keep
-        keep_keyspaces = {}
-        keep_tables = {'t2'}
-        manifest = [
-            {'keyspace': 'k1', 'columnfamily': 't1', 'objects': []},
-            {'keyspace': 'k2', 'columnfamily': 't2', 'objects': []}
-        ]
-        to_restore = restore_node.get_fqtns_to_restore(keep_keyspaces, keep_tables, json.dumps(manifest))
-        self.assertEqual(set(), to_restore)
-
-        # keeping the whole keyspace
-        keep_keyspaces = {'k2'}
-        keep_tables = {}
-        manifest = [
-            {'keyspace': 'k1', 'columnfamily': 't1', 'objects': []},
-            {'keyspace': 'k2', 'columnfamily': 't2', 'objects': []},
-            {'keyspace': 'k2', 'columnfamily': 't3', 'objects': []}
-        ]
-        to_restore = restore_node.get_fqtns_to_restore(keep_keyspaces, keep_tables, json.dumps(manifest))
-        self.assertEqual({'k2.t2', 'k2.t3'}, to_restore)
-
-    def test_get_sections_to_restore_with_cfids(self):
-
-        # lept tables must work also if the manifest has cfids
-        keep_keyspaces = {}
-        keep_tables = {'k2.t2'}
-        manifest = [
-            {'keyspace': 'k1', 'columnfamily': 't1-bigBadCfId', 'objects': []},
-            {'keyspace': 'k2', 'columnfamily': 't2-81ffe430e50c11e99f91a15641db358f', 'objects': []},
-        ]
-        to_restore = restore_node.get_fqtns_to_restore(keep_keyspaces, keep_tables, json.dumps(manifest))
-        self.assertEqual({'k2.t2-81ffe430e50c11e99f91a15641db358f'}, to_restore)
 
     def test_keyspace_is_allowed_to_restore(self):
 


### PR DESCRIPTION
The `medusa download` command allows only to download a whole backup.

This change adds the same filtering flags as the `restore-node` command:
--keyspace <ks>
--table <ks.ta>

This allows to specify which tables or keyspaces combinations medusa will download from the storage.

By default, `medusa download` always downloads the system keyspaces. I added a new option,
`--ignore-system-keyspaces` that allows to not download them. This is very useful if you just want to download a specific keyspace or table.

I noticed that `medusa download` always creates unnecessary local directories (one per keyspace). When downloading only some keyspaces or specific tables, there's no reason all the other keyspaces directory needs to be created. I modified this behavior to only create the downloaded keyspaces directories.
