### PR TITLE
Add wheel package to requirements.txt for offline install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ parallel-ssh==1.9.1
 # ssh2-python==0.20.0 is broken, 0.22.0+ should work.
 ssh2-python==0.19.0
 requests==2.22.0
+wheel>=0.32.0


### PR DESCRIPTION
Offline install was broken (at least on centos 7.8).

setup-tools won't install due to wheel requirements = none

-------------------

Example of install scripts for centos7.8:
yum install python3-pip python3-devel
pip3 install pipenv

wget https://github.com/thelastpickle/cassandra-medusa/archive/v0.7.1.tar.gz
tar zxvf v0.7.1.tar.gz
cd cassandra-medusa-0.7.1
pipenv --python 3
mkdir medusa_dependencies
pip3 download -r requirements.txt -d medusa_dependencies
pipenv run pip3 install -r requirements.txt --no-index --find-links medusa_dependencies/
sudo mkdir /opt/cassandra-medusa
sudo chmod go+rwX  /opt/cassandra-medusa
pipenv run python3 setup.py install --prefix=.  --root=/opt/cassandra-medusa