### PR TITLE
debian: Fix build with pbuilder(-dist)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends:
   python3-all,
   python3-all-dev,
   python3-setuptools,
+  python3-venv,
   dh-virtualenv (>= 1.0),
   build-essential
 Standards-Version: 3.9.5

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Build-Depends:
   python3-setuptools,
   python3-venv,
   dh-virtualenv (>= 1.0),
+  libevent-dev,
   build-essential
 Standards-Version: 3.9.5
 

--- a/debian/rules
+++ b/debian/rules
@@ -27,7 +27,10 @@ export DH_VIRTUALENV_INSTALL_ROOT = /usr/share
 	dh $@ --with python-virtualenv
 
 override_dh_virtualenv:
-	dh_virtualenv --python /usr/bin/python3 --preinstall=setuptools==40.3.0 --preinstall=pip==20.2.3 --preinstall=wheel --builtin-venv
+	dh_virtualenv \
+	  --extra-pip-arg "--ignore-installed" \
+	  --extra-pip-arg "--no-cache-dir" \
+	  --python /usr/bin/python3 --preinstall=setuptools==40.3.0 --preinstall=pip==20.2.3 --preinstall=wheel --builtin-venv
 
 override_dh_strip:
 	dh_strip --no-automatic-dbgsym --exclude libssh2

--- a/debian/rules
+++ b/debian/rules
@@ -18,6 +18,8 @@
 VERSION = $(shell dpkg-parsechangelog --show-field Version)
 DISTRIBUTION = $(shell sed -n "s/^VERSION_CODENAME=//p" /etc/os-release)
 PACKAGEVERSION = $(VERSION)-0~$(DISTRIBUTION)0
+PY3VER = $(shell py3versions -d)
+SSH2_LIBS_SUFFIX = debian/cassandra-medusa/usr/share/cassandra-medusa/lib/$(PY3VER)/site-packages/ssh2_python.libs/
 
 export DH_ALWAYS_EXCLUDE = .git
 export DH_VIRTUALENV_INSTALL_ROOT = /usr/share

--- a/packaging/docker-build/docker-compose.yml
+++ b/packaging/docker-build/docker-compose.yml
@@ -21,8 +21,6 @@ services:
       dockerfile: packaging/docker-build/Dockerfile
       args:
         - BUILD_IMAGE=ubuntu:18.04
-    environment:
-      - SSH2_LIBS_SUFFIX=debian/cassandra-medusa/usr/share/cassandra-medusa/lib/python3.6/site-packages/ssh2_python.libs/
     volumes:
       - ../..:/usr/src/app/cassandra-medusa
       - ../../packages:/usr/src/app/packages
@@ -37,8 +35,6 @@ services:
       - ../..:/usr/src/app/cassandra-medusa
       - ../../packages:/usr/src/app/packages
       - ./scripts:/usr/src/app/scripts
-    environment:
-      - SSH2_LIBS_SUFFIX=debian/cassandra-medusa/usr/share/cassandra-medusa/lib/python3.5/site-packages/ssh2_python.libs/
   cassandra-medusa-builder-stretch:
     build:
       context: ../..
@@ -49,8 +45,6 @@ services:
       - ../..:/usr/src/app/cassandra-medusa
       - ../../packages:/usr/src/app/packages
       - ./scripts:/usr/src/app/scripts
-    environment:
-      - SSH2_LIBS_SUFFIX=debian/cassandra-medusa/usr/share/cassandra-medusa/lib/python3.5/site-packages/ssh2_python.libs/
   cassandra-medusa-builder-buster:
     build:
       context: ../..
@@ -61,8 +55,6 @@ services:
       - ../..:/usr/src/app/cassandra-medusa
       - ../../packages:/usr/src/app/packages
       - ./scripts:/usr/src/app/scripts
-    environment:
-      - SSH2_LIBS_SUFFIX=debian/cassandra-medusa/usr/share/cassandra-medusa/lib/python3.7/site-packages/ssh2_python.libs/
   release:
     build:
       context: ../..

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ parallel-ssh==1.9.1
 ssh2-python==0.19.0
 requests==2.22.0
 wheel>=0.32.0
+gevent
+greenlet

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,9 @@ setuptools.setup(
         'retrying>=1.3.3',
         'parallel-ssh==1.9.1',
         'ssh2-python==0.19.0',  # <-- ssh2-python==0.20.0 is broken, 0.22.0+ should work.
-        'requests==2.22.0'
+        'requests==2.22.0',
+        'gevent',
+        'greenlet'
     ],
     extras_require={
         'S3': ["awscli>=1.16.291"],


### PR DESCRIPTION
Beside various other flaws in this packaging strategy, it was not possible to build the package in a clean environment. Usually Debian packages are build with sbuild (on the official debian servers or enthusiast) or the much easier to use pbuilder(-dist) - and not some kind of unclean docker container.

These changes are now adjusting the debian build rules to allow a build via:

    # only the first time:
    pbuilder-dist buster amd64 create
    
    # (optional) regularly install newest updates in the builder environment
    find "$HOME"/pbuilder/buster-base.tgz -mmin +1440 -exec pbuilder-dist buster amd64 update \;
    
    # create .dsc - here from within the actual source directory
    debuild -S
    
    # or when the source directory is clean:
    dpkg-source -b .
    
    # start the actual build (which unfortunately needs network access - which is usually not allowed for Debian package builds)
    pbuilder-dist buster amd64 build --use-network yes ../cassandra-medusa_0.7.1.dsc

The result will then (with the default config) end up in ~/pbuilder/buster_result

The docker-build scripts were not touched. But I would highly recommend not to continue to build these packages in unclean environments