### PR TITLE
Fix failing 4.0 with encryption integration tests

### DIFF
--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -179,6 +179,7 @@ def invoke_sstableloader(config, download_dir, keep_auth, fqtns_to_restore, stor
                                           "github:apache/", "githubCOLONapacheSLASH"),
                                           '-d', hostname_resolver.resolve_fqdn() if cassandra_is_ccm == 0
                                           else '127.0.0.1',
+                                          '--conf-path', config.cassandra.config_file,
                                           '--username', cql_username,
                                           '--password', cql_password,
                                           '--no-progress',


### PR DESCRIPTION
Previous versions of Cassandra were more permissive with using the sstableloader without specifying the cipher suites nor the cassandra.yaml location (which allowed to retrieve the cipher suites).