### PR TITLE
add backup-cluster command + decouple snapshots from upload

### DIFF
--- a/medusa/backup_cluster.py
+++ b/medusa/backup_cluster.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import sys
+import uuid
+import datetime
+import traceback
+
+import medusa.config
+from medusa.orchestration import Orchestration
+from medusa.monitoring import Monitoring
+from medusa.cassandra_utils import CqlSessionProvider, Cassandra
+from medusa.storage import Storage
+from medusa.network.hostname_resolver import HostnameResolver
+
+
+def orchestrate(config, backup_name, stagger, mode, temp_dir, parallel_snapshots, parallel_uploads):
+    backup = None
+    monitoring = Monitoring(config=config.monitoring)
+    try:
+        backup_start_time = datetime.datetime.now()
+        if not config.storage.fqdn:
+            err_msg = "The fqdn was not provided nor calculated properly."
+            logging.error(err_msg)
+            raise Exception(err_msg)
+
+        if not temp_dir.is_dir():
+            err_msg = '{} is not a directory'.format(temp_dir)
+            logging.error(err_msg)
+            raise Exception(err_msg)
+
+        try:
+            # Try to get a backup with backup_name. If it exists then we cannot take another backup with that name
+            storage = Storage(config=config.storage)
+            cluster_backup = storage.get_cluster_backup(backup_name)
+            if cluster_backup:
+                err_msg = 'Backup named {} already exists.'.format(backup_name)
+                logging.error(err_msg)
+                raise Exception(err_msg)
+        except KeyError:
+            info_msg = 'Starting backup {}'.format(backup_name)
+            logging.info(info_msg)
+
+        backup = BackupJob(config, backup_name, stagger, mode, temp_dir, parallel_snapshots, parallel_uploads)
+        backup.execute()
+
+        backup_end_time = datetime.datetime.now()
+        backup_duration = backup_end_time - backup_start_time
+
+        logging.debug('Emitting metrics')
+
+        logging.info('Backup duration: {}'.format(backup_duration.seconds))
+        tags = ['medusa-cluster-backup', 'cluster-backup-duration', backup_name]
+        monitoring.send(tags, backup_duration.seconds)
+
+        tags = ['medusa-cluster-backup', 'cluster-backup-error', backup_name]
+        monitoring.send(tags, 0)
+
+        logging.debug('Done emitting metrics.')
+        logging.info('Backup of the cluster done.')
+
+    except Exception as e:
+        tags = ['medusa-cluster-backup', 'cluster-backup-error', backup_name]
+        monitoring.send(tags, 1)
+
+        logging.error('This error happened during the cluster backup: {}'.format(str(e)))
+        traceback.print_exc()
+
+        if backup is not None:
+            err_msg = 'Something went wrong! Attempting to clean snapshots and exit.'
+            logging.error(err_msg)
+
+            delete_snapshot_command = ' '.join(backup.cassandra.delete_snapshot_command(backup.snapshot_tag))
+            pssh_run_success_cleanup = backup.orchestration_uploads\
+                .pssh_run(backup.hosts,
+                          delete_snapshot_command,
+                          hosts_variables={})
+            if pssh_run_success_cleanup:
+                info_msg = 'All nodes successfully cleared their snapshot.'
+                logging.info(info_msg)
+            else:
+                err_msg_cleanup = 'Some nodes failed to clear the snapshot. Cleaning snapshots manually is recommended'
+                logging.error(err_msg_cleanup)
+        sys.exit(1)
+
+
+class BackupJob(object):
+    def __init__(self, config, backup_name, stagger, mode, temp_dir, parallel_snapshots, parallel_uploads):
+        self.id = uuid.uuid4()
+        # TODO expose the argument below (Note that min(1000, <number_of_hosts>) will be used)
+        self.orchestration_snapshots = Orchestration(config, parallel_snapshots)
+        self.orchestration_uploads = Orchestration(config, parallel_uploads)
+        self.config = config
+        self.backup_name = backup_name
+        self.stagger = stagger
+        self.mode = mode
+        self.temp_dir = temp_dir
+        self.work_dir = self.temp_dir / 'medusa-job-{id}'.format(id=self.id)
+        self.hosts = {}
+        self.cassandra = Cassandra(config.cassandra)
+        self.snapshot_tag = '{}{}'.format(self.cassandra.SNAPSHOT_PREFIX, self.backup_name)
+        fqdn_resolver = medusa.config.evaluate_boolean(self.config.cassandra.resolve_ip_addresses)
+        self.fqdn_resolver = HostnameResolver(fqdn_resolver)
+
+    def execute(self):
+        # Two step: Take snapshot everywhere, then upload the backups to the external storage
+
+        # Getting the list of Cassandra nodes.
+        session_provider = CqlSessionProvider([self.config.storage.fqdn],
+                                              self.config.cassandra)
+        with session_provider.new_session() as session:
+            tokenmap = session.tokenmap()
+            self.hosts = [host for host in tokenmap.keys()]
+
+        # First let's take a snapshot on all nodes at once
+        # Here we will use parallelism of min(number of nodes, parallel_snapshots)
+        logging.info('Creating snapshots on all nodes')
+        self._create_snapshots()
+
+        # Second
+        logging.info('Uploading snapshots from nodes to external storage')
+        self._upload_backup()
+
+    def _create_snapshots(self):
+        # Run snapshot in parallel on all nodes,
+        create_snapshot_command = ' '.join(self.cassandra.create_snapshot_command(self.backup_name))
+        pssh_run_success = self.orchestration_snapshots.\
+            pssh_run(self.hosts,
+                     create_snapshot_command,
+                     hosts_variables={})
+        if not pssh_run_success:
+            # we could implement a retry.
+            err_msg = 'Some nodes failed to create the snapshot.'
+            logging.error(err_msg)
+            raise Exception(err_msg)
+
+        logging.info('A snapshot {} was created on all nodes.'.format(self.snapshot_tag))
+
+    def _upload_backup(self):
+        backup_command = self._build_backup_cmd()
+        # Run upload in parallel or sequentially according to parallel_uploads defined by the user
+        pssh_run_success = self.orchestration_uploads.pssh_run(self.hosts,
+                                                               backup_command,
+                                                               hosts_variables={})
+        if not pssh_run_success:
+            # we could implement a retry.
+            err_msg = 'Some nodes failed to upload the backup.'
+            logging.error(err_msg)
+            raise Exception(err_msg)
+
+        logging.info('A new backup {} was created on all nodes.'.format(self.backup_name))
+
+    def _build_backup_cmd(self):
+        stagger_option = '--in-stagger {}'.format(self.stagger) if self.stagger else ''
+
+        # Use %s placeholders in the below command to have them replaced by pssh using per host command substitution
+        command = 'mkdir -p {work}; cd {work} && medusa-wrapper sudo medusa -vvv backup-node ' \
+                  '--backup-name {backup_name} {stagger} --mode {mode}' \
+            .format(work=self.work_dir,
+                    backup_name=self.backup_name,
+                    stagger=stagger_option,
+                    mode=self.mode)
+
+        logging.debug('Running backup on all nodes with the following command {}'.format(command))
+
+        return command

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -25,7 +25,6 @@ import shlex
 import socket
 import subprocess
 import time
-import uuid
 import yaml
 
 from subprocess import PIPE
@@ -297,6 +296,7 @@ class CassandraConfigReader(object):
 class Cassandra(object):
 
     SNAPSHOT_PATTERN = '*/*/snapshots/{}'
+    SNAPSHOT_PREFIX = 'medusa-'
 
     def __init__(self, cassandra_config, contact_point=None):
         self._start_cmd = shlex.split(cassandra_config.start_cmd)
@@ -406,34 +406,34 @@ class Cassandra(object):
         def __repr__(self):
             return '{}<{}>'.format(self.__class__.__qualname__, self._tag)
 
-    def create_snapshot(self):
-        tag = 'medusa-{}'.format(uuid.uuid4())
-        cmd = self._nodetool.nodetool + ['snapshot', '-t', tag]
-
-        if self._is_ccm == 1:
-            os.popen('ccm node1 nodetool \"snapshot -t {}\"'.format(tag)).read()
-        else:
-            logging.debug('Executing: {}'.format(' '.join(cmd)))
-            subprocess.check_call(cmd, stdout=subprocess.DEVNULL, universal_newlines=True)
+    def create_snapshot(self, backup_name):
+        cmd = self.create_snapshot_command(backup_name)
+        tag = "{}{}".format(self.SNAPSHOT_PREFIX, backup_name)
+        if not self.snapshot_exists(tag):
+            if self._is_ccm == 1:
+                os.popen(cmd).read()
+            else:
+                logging.debug('Executing: {}'.format(' '.join(cmd)))
+                subprocess.check_call(cmd, stdout=subprocess.DEVNULL, universal_newlines=True)
 
         return Cassandra.Snapshot(self, tag)
 
     def delete_snapshot(self, tag):
-        cmd = self._nodetool.nodetool + ['clearsnapshot', '-t', tag]
-
-        if self._is_ccm == 1:
-            os.popen('ccm node1 nodetool \"clearsnapshot -t {}\"'.format(tag)).read()
-        else:
-            logging.debug('Executing: {}'.format(' '.join(cmd)))
-            try:
-                output = subprocess.check_output(cmd, universal_newlines=True)
-                logging.debug('nodetool output: {}'.format(output))
-            except subprocess.CalledProcessError as e:
-                logging.debug('nodetool resulted in error: {}'.format(e.output))
-                logging.warning(
-                    'Medusa may have failed at cleaning up snapshot {}. '
-                    'Check if the snapshot exists and clear it manually '
-                    'by running: {}'.format(tag, ' '.join(cmd)))
+        cmd = self.delete_snapshot_command(tag)
+        if self.snapshot_exists(tag):
+            if self._is_ccm == 1:
+                os.popen(cmd).read()
+            else:
+                logging.debug('Executing: {}'.format(' '.join(cmd)))
+                try:
+                    output = subprocess.check_output(cmd, universal_newlines=True)
+                    logging.debug('nodetool output: {}'.format(output))
+                except subprocess.CalledProcessError as e:
+                    logging.debug('nodetool resulted in error: {}'.format(e.output))
+                    logging.warning(
+                        'Medusa may have failed at cleaning up snapshot {}. '
+                        'Check if the snapshot exists and clear it manually '
+                        'by running: {}'.format(tag, ' '.join(cmd)))
 
     def list_snapshotnames(self):
         return {
@@ -453,6 +453,29 @@ class Cassandra(object):
             if snapshot.is_dir() and snapshot.name == tag:
                 return True
         return False
+
+    def create_snapshot_command(self, backup_name):
+        """
+        :param backup_name: string name of the medusa backup
+        :return: Array representation of a command to create a snapshot
+        """
+        tag = '{}{}'.format(self.SNAPSHOT_PREFIX, backup_name)
+        if self._is_ccm == 1:
+            cmd = 'ccm node1 nodetool \"snapshot -t {}\"'.format(tag)
+        else:
+            cmd = self._nodetool.nodetool + ['snapshot', '-t', tag]
+        return cmd
+
+    def delete_snapshot_command(self, tag):
+        """
+        :param tag: string snapshot name
+        :return: Array repesentation of a command to delete a snapshot
+        """
+        if self._is_ccm == 1:
+            cmd = 'ccm node1 nodetool \"clearsnapshot -t {}\"'.format(tag)
+        else:
+            cmd = self._nodetool.nodetool + ['clearsnapshot', '-t', tag]
+        return cmd
 
     def _columnfamily_path(self, keyspace_name, columnfamily_name, cf_id):
         root = pathlib.Path(self._root)

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -20,6 +20,7 @@ import datetime
 import logging
 import logging.handlers
 import click
+from click_aliases import ClickAliasedGroup
 import sys
 
 # Need to get rid of the annoying pssh warning about paramiko
@@ -30,7 +31,8 @@ if not sys.warnoptions:
 from collections import defaultdict
 from pathlib import Path
 
-import medusa.backup
+import medusa.backup_node
+import medusa.backup_cluster
 import medusa.config
 import medusa.download
 import medusa.index
@@ -88,7 +90,7 @@ def configure_console_logging(verbosity, without_log_timestamp):
             logging.getLogger(loggername).setLevel(logging.CRITICAL)
 
 
-@click.group()
+@click.group(cls=ClickAliasedGroup)
 @click.option('-v', '--verbosity', help='Verbosity', default=0, count=True)
 @click.option('--without-log-timestamp', help='Do not show timestamp in logs', default=False, is_flag=True)
 @click.option('--config-file', help='Specify config file')
@@ -107,17 +109,40 @@ def cli(ctx, verbosity, without_log_timestamp, config_file, **kwargs):
     configure_file_logging(ctx.obj.logging)
 
 
-@cli.command(name='backup')
+@cli.command(aliases=['backup', 'backup-node'])
 @click.option('--backup-name', help='Custom name for the backup')
-@click.option('--stagger', default=None, type=int, help='Check for staggering initial backups for duration seconds')
+@click.option('--stagger', default=None, type=int, help='Drop initial backups if longer than a duration in seconds')
 @click.option('--mode', default="differential", type=click.Choice(['full', 'differential']))
 @pass_MedusaConfig
 def backup(medusaconfig, backup_name, stagger, mode):
     """
-    Backup Cassandra
+    Backup single Cassandra node
     """
     stagger_time = datetime.timedelta(seconds=stagger) if stagger else None
-    medusa.backup.main(medusaconfig, backup_name, stagger_time, mode)
+    medusa.backup_node.main(medusaconfig, backup_name, stagger_time, mode)
+
+
+@cli.command(name='backup-cluster')
+@click.option('--backup-name', help='Backup name', required=True)
+@click.option('--stagger', default=None, type=int, help='Drop initial backups if longer than a duration in seconds')
+@click.option('--mode', default="differential", type=click.Choice(['full', 'differential']))
+@click.option('--temp-dir', help='Directory for temporary storage', default="/tmp")
+@click.option('--parallel-snapshots', '-ps', help="Number of concurrent synchronous (blocking) "
+                                                  "ssh sessions started by pssh", default=500)
+@click.option('--parallel-uploads', '-pu', help="Number of concurrent synchronous (blocking) "
+                                                "ssh sessions started by pssh", default=1)
+@pass_MedusaConfig
+def backup_cluster(medusaconfig, backup_name, stagger, mode, temp_dir, parallel_snapshots, parallel_uploads):
+    """
+    Backup Cassandra cluster
+    """
+    medusa.backup_cluster.orchestrate(medusaconfig,
+                                      backup_name,
+                                      stagger,
+                                      mode,
+                                      Path(temp_dir),
+                                      int(parallel_snapshots),
+                                      int(parallel_uploads))
 
 
 @cli.command(name='fetch-tokenmap')
@@ -125,7 +150,7 @@ def backup(medusaconfig, backup_name, stagger, mode):
 @pass_MedusaConfig
 def fetch_tokenmap(medusaconfig, backup_name):
     """
-    Backup Cassandra
+    Get the token/node mapping for a specific backup
     """
     medusa.fetch_tokenmap.main(medusaconfig, backup_name)
 
@@ -167,10 +192,11 @@ def download(medusaconfig, backup_name, download_destination):
               multiple=True, default={})
 @click.option('--use-sstableloader', help='Use the sstableloader to load the backup into the cluster',
               default=False, is_flag=True)
-@click.option('--pssh-pool-size', help="Number of concurrent ssh sessions started by pssh", default=10)
+@click.option('--parallel-restores', '-pr', help="Number of concurrent synchronous (blocking) "
+                                                 "ssh sessions started by pssh", default=500)
 @pass_MedusaConfig
 def restore_cluster(medusaconfig, backup_name, seed_target, temp_dir, host_list, keep_auth, bypass_checks,
-                    verify, keyspaces, tables, use_sstableloader, pssh_pool_size):
+                    verify, keyspaces, tables, parallel_restores, use_sstableloader):
     """
     Restore Cassandra cluster
     """
@@ -184,7 +210,7 @@ def restore_cluster(medusaconfig, backup_name, seed_target, temp_dir, host_list,
                                        verify,
                                        set(keyspaces),
                                        set(tables),
-                                       int(pssh_pool_size),
+                                       int(parallel_restores),
                                        use_sstableloader)
 
 

--- a/medusa/orchestration.py
+++ b/medusa/orchestration.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paramiko
+import logging
+from pssh.clients.miko import ParallelSSHClient
+from medusa.storage import divide_chunks
+
+
+def display_output(host_outputs):
+    for host_out in host_outputs:
+        for line in host_out.stdout:
+            logging.info("{}-stdout: {}".format(host_out.host, line))
+        for line in host_out.stderr:
+            logging.info("{}-stderr: {}".format(host_out.host, line))
+
+
+class Orchestration(object):
+    def __init__(self, cassandra_config, pool_size=10):
+        self.pool_size = pool_size
+        self.cassandra_config = cassandra_config
+
+    def pssh_run(self, hosts, command, hosts_variables=None):
+        """
+        Runs a command on hosts list using pssh under the hood
+        Return: True (success) or False (error)
+        """
+        pssh_run_success = False
+        success = []
+        error = []
+        i = 1
+
+        username = self.cassandra_config.ssh.username if self.cassandra_config.ssh.username != '' else None
+        port = self.cassandra_config.ssh.port
+        pkey = None
+        if self.cassandra_config.ssh.key_file is not None and self.cassandra_config.ssh.key_file != '':
+            pkey = paramiko.RSAKey.from_private_key_file(self.cassandra_config.ssh.key_file)
+
+        logging.info('Executing "{command}" on following nodes {hosts} with a parallelism/pool size of {pool_size}'
+                     .format(command=command, hosts=hosts, pool_size=self.pool_size))
+
+        for parallel_hosts in divide_chunks(hosts, self.pool_size):
+
+            client = ParallelSSHClient(parallel_hosts,
+                                       forward_ssh_agent=True,
+                                       pool_size=len(parallel_hosts),
+                                       user=username,
+                                       port=port,
+                                       pkey=pkey)
+            logging.debug('Batch #{i}: Running "{command}" on nodes {hosts} parallelism of {pool_size}'
+                          .format(i=i, command=command, hosts=parallel_hosts, pool_size=len(parallel_hosts)))
+            output = client.run_command(command, host_args=hosts_variables, sudo=True)
+            client.join(output)
+
+            success = success + list(filter(lambda host_output: host_output.exit_code == 0,
+                                            list(map(lambda host_output: host_output[1], output.items()))))
+            error = error + list(filter(lambda host_output: host_output.exit_code != 0,
+                                        list(map(lambda host_output: host_output[1], output.items()))))
+
+        # Report on execution status
+        if len(success) == len(hosts):
+            logging.info('Job executing "{}" ran and finished Successfully on all nodes.'
+                         .format(command))
+            pssh_run_success = True
+        elif len(error) > 0:
+            logging.error('Job executing "{}" ran and finished with errors on following nodes: {}'
+                          .format(command, sorted(set(map(lambda host_output: host_output.host, error)))))
+            display_output(error)
+        else:
+            err_msg = 'Something unexpected happened while running pssh command'
+            logging.error(err_msg)
+            raise Exception(err_msg)
+
+        return pssh_run_success

--- a/medusa/storage/__init__.py
+++ b/medusa/storage/__init__.py
@@ -47,6 +47,12 @@ INDEX_BLOB_WITH_TIMESTAMP_PATTERN = re.compile('.*(started|finished)_(.*)_([0-9]
 
 
 def divide_chunks(values, step):
+    """
+    Yield successive step-sized chunks from values.
+    :param values: A list of items to split into sub-lists
+    :param step: The size of sub-lists
+    :return: A list of lists of maximum 'step' size.
+    """
     for i in range(0, len(values), step):
         yield values[i:i + step]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 python-dateutil<2.8.1,>=2.1
 Click>=6.7
+click-aliases>=1.0.1
 PyYAML>=5.1
 cassandra-driver>=3.14.0
 psutil>=5.4.7

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setuptools.setup(
     install_requires=[
         'python-dateutil<2.8.1,>=2.1',
         'Click>=6.7',
+        'click-aliases>=1.0.1',
         'PyYAML>=5.1',
         'cassandra-driver>=3.14.0',
         'psutil>=5.4.7',

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -31,7 +31,7 @@ import signal
 from cassandra.cluster import Cluster
 from ssl import SSLContext, PROTOCOL_TLSv1, CERT_REQUIRED
 
-import medusa.backup
+import medusa.backup_node
 import medusa.index
 import medusa.listing
 import medusa.purge
@@ -314,7 +314,7 @@ def _i_run_a_whatever_command(context, command):
 @when(r'I perform a backup in "{backup_mode}" mode of the node named "{backup_name}"')
 def _i_perform_a_backup_of_the_node_named_backupname(context, backup_mode, backup_name):
     (actual_backup_duration, actual_start, end, node_backup, node_backup_cache, num_files, start) \
-        = medusa.backup.main(context.medusa_config, backup_name, None, backup_mode)
+        = medusa.backup_node.main(context.medusa_config, backup_name, None, backup_mode)
     context.latest_backup_cache = node_backup_cache
 
 

--- a/tests/storage_test_with_prefix.py
+++ b/tests/storage_test_with_prefix.py
@@ -24,7 +24,7 @@ import unittest
 
 import medusa.storage.abstract_storage
 
-from medusa.backup import generate_md5_hash
+from medusa.backup_node import generate_md5_hash
 from medusa.config import MedusaConfig, StorageConfig, _namedtuple_from_dict, CassandraConfig
 from medusa.index import build_indices
 from medusa.storage import Storage


### PR DESCRIPTION
Work done:

* New orchestration backups (send to all nodes) --> backup-cluster
* Change pssh_pool_size a mix of: parallel_snapshots, parallel_uploads (for backups) and parallel_restores. Not just create as many ssh commands but make them sync / blocking to enforce the parallelism to be respected
* Build 'backup-node' command as an alias of 'backup' command (add dependency to click_aliases)
* Change snapshots prefixes from '<random UUID>' to 'medusa-'
* Unify pssh_run for cluster backups and restores, created 'orchestration' module.

**Impacts**
* PSSH Pool sizes are now:
  - Blocking - previously with a pool of 10 and 500 nodes, within seconds all commands were run as pssh is not waiting for commands to finish to release one connection from the pool
  - As a consequence of the above, pools (now ie. parallelism) are as 500 by default for backup restores, thus on clusters > 500 nodes, the restore might take longer as medusa will wait for the 500 first nodes to finish (this is tunable though)
  -  Parallelism is now **1** (sequential) for backups, this is really different from the current behaviour where all nodes upload data at once. It will take longer to upload backups, with the tradeoff of a lighter impact (to no impact) to the cluster. This is tunable as well.
  - Option pssh_pool_size no longer exist (replaced by parallel_* options to remove confusion and allow a split, different values.
* `medusa backup` still works, even though for coherence reasons, we added the alias `medusa backup-node` and should (maybe) deprecate `medusa backup` that I find more confusing.


