### PR TITLE
Remove experimental flag for Cassandra trunk (4.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,18 +61,10 @@ jobs:
           it-backend: [local, s3, gcs]
           cassandra-version: [2.2.14, 3.11.7, 'github:apache/trunk']
           experimental: [false]
-          exclude:
-            - cassandra-version: 'github:apache/trunk'
-              it-backend: local
           include:
             - python-version: 3.7
               tox-py: py37
             - python-version: 3.6
-              tox-py: py36
-            - cassandra-version: 'github:apache/trunk'
-              experimental: true
-              python-version: 3.6
-              it-backend: local
               tox-py: py36
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
After #227 and https://issues.apache.org/jira/browse/CASSANDRA-16280 we can remove the experimental flag.*

I removed the exclude / include parts of the matrix (CI workflow) and kept the experimental system in case we need it in the future. Not sure if that's the best approach, let me know your thoughts @adejanovski .