### PR TITLE
Add ability to use C* Management API for snapshot management

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -8,15 +8,12 @@ There is a gRPC service for performing backups. It lives under the `medusa/servi
 
 See [medusa-operator](https://github.com/jsanda/medusa-operator) for details on setting it up to perform restores.
 
-## Jolokia
-The current implementation uses [Jolokia](https://jolokia.org/) for creating and deleting snapshots. This will eventually be made configurable, but for now the Cassandra image will need to include the Jolokia agent.
-
 # Restores
 For k8s, we do not utilize `medusa/restore_cluster.py`. The `restore_cluster` module provides an orchestration layer that is handled differently in k8s. In k8s, we only use `medusa/restore_node.py`.
 
 The image built out of this directory can be deployed in an [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) in order to do restores. With this approach, it is possible to perform in-place as well as cluster-wide restores.
 
-# gRPC Serivce
+# gRPC Service
 The gRPC API is defined in `medusa/service/grpc/medusa.proto`. At some point we might want to move the protobuf file to a different repo. Any clients, namely medusa-operator, need a copy of `medusa-proto` in order to generate client code.
 
 While the gRPC service layer was added for k8s integration, it is worth pointing out that there is nothing prevents using it outside of k8s. In fact, I created and use `medusa/service/grpc/client.py` to do ad hoc testing locally on my laptop.
@@ -38,12 +35,46 @@ $ python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. medusa.prot
 
 These steps should be integrated into the build or setup.py at some point. I am just not sure where the appropriate integrations points are yet.
 
+# Kubernetes Configuration
+There is a Kubernetes section of the Medusa configuration that will need to be set for all this to work in a K8s environment. Currently, the Cassandra image you use will need to support one of two APIs in order for the Medusa image to be able to perform backup and restore functions: JMX (via Jolokia) or the [Management API](https://github.com/datastax/management-api-for-apache-cassandra).
+
+## Jolokia
+To make use of [Jolokia](https://jolokia.org/) for creating and deleting snapshots, the Cassandra image will need to include the Jolokia agent. You will also need to configure Medusa to enable gRPC and enable Kubernetes. An example configuration:
+
+```
+[grpc]
+enabled = 1
+
+[kubernetes]
+enabled = 1
+cassandra_url = http://127.0.0.1:8778/jolokia/
+use_mgmt_api = 0
+```
+
+The `cassandra_url` value needs to be the URL to the Jolokia endpoint running in the sidecar. With configuration similar to the above, Medusa will make POST request to the Cassandra Jolkia agent to perform backup and restore operations.
+
+## Management API
+To make use of the [Management API](https://github.com/datastax/management-api-for-apache-cassandra) in Kubernetes, you will need to enable gRPC and Kubernetes (as with Jolokia above), but you will also need to set the `use_mgmt_api` flag. An example  configuration: 
+
+```
+[grpc]
+enabled = 1
+
+[kubernetes]
+enabled = 1
+cassandra_url = http://127.0.0.1:8080/api/v0/ops/node/snapshots
+use_mgmt_api = 1
+```
+
+The `cassandra_url` value needs to be the URL to the Management API [snapshot REST endpoint](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/datastax/management-api-for-apache-cassandra/master/management-api-server/doc/openapi.json&nocors#operation/takeSnapshot) enabled in your Cassandra image. With configuration similar to the above,Medusa will make POST and DELETE REST calls to the API to perform backup and restore operation.s  
+
+
 # Kubernetes Image
 The `Dockerfile` and other scripts in this directory are intended for use in Kubernetes. 
 
-For details on how to set up and configure the backup sidecar container and the restore init container, please see [cassandra-medusa-k8s](https://github.com/jsanda/cassandra-medusa-k8s).
+For details on how to set up and configure the backup sidecar container and the restore init container, please see [k8ssandra](https://github.com/k8ssandra/k8ssandra).
 
-The image can be used for backups or for restores. The `docker-entrypoint.sh` script looks at the `MEDUSA_MODE` env var to determine whehter it should run the gRPC service for backups or do a restore.
+The image can be used for backups or for restores. The `docker-entrypoint.sh` script looks at the `MEDUSA_MODE` env var to determine whether it should run the gRPC service for backups or do a restore.
 
 ## Building the Image
 If you made any changes to `medusa.proto`, then you first need to run the protobuf compiler as described above.

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -72,7 +72,7 @@ GrpcConfig = collections.namedtuple(
 
 KubernetesConfig = collections.namedtuple(
     'KubernetesConfig',
-    ['enabled', 'cassandra_url']
+    ['enabled', 'cassandra_url', 'use_mgmt_api']
 )
 
 DEFAULT_CONFIGURATION_PATH = pathlib.Path('/etc/medusa/medusa.ini')
@@ -139,7 +139,8 @@ def load_config(args, config_file):
 
     config['kubernetes'] = {
         'enabled': False,
-        'cassandra_url': 'None'
+        'cassandra_url': 'None',
+        'use_mgmt_api': False
     }
 
     if config_file:

--- a/medusa/nodetool.py
+++ b/medusa/nodetool.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class Nodetool(object):
+
+    def __init__(self, cassandra_config):
+        self._nodetool = ['nodetool']
+        if cassandra_config.nodetool_ssl == "true":
+            self._nodetool += ['--ssl']
+        if cassandra_config.nodetool_username is not None:
+            self._nodetool += ['-u', cassandra_config.nodetool_username]
+        if cassandra_config.nodetool_password is not None:
+            self._nodetool += ['-pw', cassandra_config.nodetool_password]
+        if cassandra_config.nodetool_password_file_path is not None:
+            self._nodetool += ['-pwf', cassandra_config.nodetool_password_file_path]
+        if cassandra_config.nodetool_host is not None:
+            self._nodetool += ['-h', cassandra_config.nodetool_host]
+        if cassandra_config.nodetool_port is not None:
+            self._nodetool += ['-p', cassandra_config.nodetool_port]
+
+    @property
+    def nodetool(self):
+        return self._nodetool

--- a/medusa/service/snapshot/__init__.py
+++ b/medusa/service/snapshot/__init__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import medusa.utils
+
+from medusa.service.snapshot.ccm_snapshot_service import CCMSnapshotService
+from medusa.service.snapshot.jolokia_snapshot_service import JolokiaSnapshotService
+from medusa.service.snapshot.nodetool_snapshot_service import NodetoolSnapshotService
+from medusa.service.snapshot.management_api_snapshot_service import ManagementAPISnapshotService
+
+
+class SnapshotService(object):
+    def __init__(self, *, config):
+        self._config = config
+        self.snapshot_service = self._create_snapshot_service()
+
+    def _create_snapshot_service(self):
+        if medusa.utils.evaluate_boolean(self._config.kubernetes.enabled):
+            if medusa.utils.evaluate_boolean(self._config.kubernetes.use_mgmt_api):
+                return ManagementAPISnapshotService(self._config.kubernetes)
+            else:
+                return JolokiaSnapshotService(self._config.kubernetes)
+        elif medusa.utils.evaluate_boolean(self._config.cassandra.is_ccm):
+            return CCMSnapshotService(None)
+        else:
+            return NodetoolSnapshotService(self._config.cassandra)

--- a/medusa/service/snapshot/abstract_snapshot_service.py
+++ b/medusa/service/snapshot/abstract_snapshot_service.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import abc
+
+
+class AbstractSnapshotService(abc.ABC):
+    def __init__(self, config):
+        self.config = config
+
+    @abc.abstractmethod
+    def create_snapshot(self, *, tag):
+        pass
+
+    @abc.abstractmethod
+    def delete_snapshot(self, *, tag):
+        pass

--- a/medusa/service/snapshot/ccm_snapshot_service.py
+++ b/medusa/service/snapshot/ccm_snapshot_service.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+from medusa.service.snapshot.abstract_snapshot_service import AbstractSnapshotService
+
+
+class CCMSnapshotService(AbstractSnapshotService):
+
+    def create_snapshot(self, *, tag):
+        # create the CCM command
+        cmd = 'ccm node1 nodetool \"snapshot -t {}\"'.format(tag)
+        os.popen(cmd).read()
+
+    def delete_snapshot(self, *, tag):
+        # create the CCM command
+        cmd = 'ccm node1 nodetool \"clearsnapshot -t {}\"'.format(tag)
+        os.popen(cmd).read()

--- a/medusa/service/snapshot/jolokia_snapshot_service.py
+++ b/medusa/service/snapshot/jolokia_snapshot_service.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import requests
+
+from medusa.service.snapshot.abstract_snapshot_service import AbstractSnapshotService
+
+
+class JolokiaSnapshotService(AbstractSnapshotService):
+
+    def create_snapshot(self, *, tag):
+        # get the Cassandra URL to POST the request
+        post_url = self.config.cassandra_url
+        # build the POST data
+        data = {
+            "type": "exec",
+            "mbean": "org.apache.cassandra.db:type=StorageService",
+            "operation": "takeSnapshot(java.lang.String,java.util.Map,[Ljava.lang.String;)",
+            "arguments": [tag, {}, []]
+        }
+        # send the request
+        response = requests.post(post_url, data=json.dumps(data), headers={"Content-Type": "application/json"})
+        # raise an Exception if the POST was not successful
+        if response.status_code != 200:
+            err_msg = "failed to create snapshot: {}".format(json.loads(response.text)["error"])
+            raise Exception(err_msg)
+
+    def delete_snapshot(self, *, tag):
+        # get the Cassandra URL to POST the request
+        post_url = self.config.cassandra_url
+        # build the POST data
+        data = {
+            "type": "exec",
+            "mbean": "org.apache.cassandra.db:type=StorageService",
+            "operation": "clearSnapshot",
+            "arguments": [tag, []]
+        }
+        # send the request
+        response = requests.post(post_url, data=json.dumps(data), headers={"Content-Type": "application/json"})
+        # raise an Exception if the POST was not successful
+        if response.status_code != 200:
+            err_msg = "failed to delete snapshot: {}".format(json.loads(response.text)["error"])
+            raise Exception(err_msg)

--- a/medusa/service/snapshot/management_api_snapshot_service.py
+++ b/medusa/service/snapshot/management_api_snapshot_service.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import requests
+
+from medusa.service.snapshot.abstract_snapshot_service import AbstractSnapshotService
+
+
+class ManagementAPISnapshotService(AbstractSnapshotService):
+
+    def create_snapshot(self, *, tag):
+        # get the Cassandra URL to POST the request
+        post_url = self.config.cassandra_url
+        # build the POST data
+        data = {
+            "snapshot_name": tag
+        }
+        # send the request
+        response = requests.post(post_url, data=json.dumps(data), headers={"Content-Type": "application/json"})
+        # raise an Exception if the POST was not successful
+        if response.status_code != 200:
+            err_msg = "failed to create snapshot: {}".format(response.text)
+            raise Exception(err_msg)
+
+    def delete_snapshot(self, *, tag):
+        # get the Cassandra URL to DELETE
+        delete_url = self.config.cassandra_url + "?snapshotNames=" + tag
+        # send the DELETE
+        response = requests.delete(delete_url)
+        # raise an Exception if the DELETE was not successful
+        if response.status_code != 200:
+            err_msg = "failed to delete snapshot: {}".format(response.text)
+            raise Exception(err_msg)

--- a/medusa/service/snapshot/nodetool_snapshot_service.py
+++ b/medusa/service/snapshot/nodetool_snapshot_service.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020- Datastax, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import subprocess
+
+from medusa.nodetool import Nodetool
+from medusa.service.snapshot.abstract_snapshot_service import AbstractSnapshotService
+
+
+class NodetoolSnapshotService(AbstractSnapshotService):
+
+    def __init__(self, config):
+        super().__init__(config)
+        self._nodetool = Nodetool(self.config)
+
+    def create_snapshot(self, *, tag):
+        # create the Nodetool command
+        cmd = self._nodetool.nodetool + ['snapshot', '-t', tag]
+        logging.debug('Executing: {}'.format(' '.join(cmd)))
+        subprocess.check_call(cmd, stdout=subprocess.DEVNULL, universal_newlines=True)
+
+    def delete_snapshot(self, *, tag):
+        # create the Nodetool command
+        cmd = self._nodetool.nodetool + ['clearsnapshot', '-t', tag]
+        logging.debug('Executing: {}'.format(' '.join(cmd)))
+        try:
+            output = subprocess.check_output(cmd, universal_newlines=True)
+            logging.debug('nodetool output: {}'.format(output))
+        except subprocess.CalledProcessError as e:
+            logging.debug('nodetool resulted in error: {}'.format(e.output))
+            logging.warning(
+                'Medusa may have failed at cleaning up snapshot {}. '
+                'Check if the snapshot exists and clear it manually '
+                'by running: {}'.format(tag, ' '.join(cmd)))

--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -26,7 +26,8 @@ from unittest.mock import Mock
 
 from medusa.config import MedusaConfig, StorageConfig, CassandraConfig, GrpcConfig, _namedtuple_from_dict,\
     KubernetesConfig
-from medusa.cassandra_utils import CqlSession, SnapshotPath, Nodetool, Cassandra
+from medusa.cassandra_utils import CqlSession, SnapshotPath, Cassandra
+from medusa.nodetool import Nodetool
 
 
 class CassandraUtilsTest(unittest.TestCase):

--- a/tests/integration/features/environment.py
+++ b/tests/integration/features/environment.py
@@ -40,3 +40,8 @@ def after_step(context, step):
         # NOTE: Use IPython debugger, same for pdb (basic python debugger).
         import ipdb
         ipdb.post_mortem(step.exc_traceback)
+
+
+def before_scenario(context, scenario):
+    if "skip-cassandra-2" in scenario.effective_tags and context.cassandra_version.startswith("2."):
+        scenario.skip("Skipping scenario on Cassandra 2.x")

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -686,7 +686,7 @@ Feature: Integration tests
         | minio             | without_client_encryption |
 
     @16
-    Scenario Outline: Perform a differential backup over gRPC , verify its index, then delete it over gRPC
+    Scenario Outline: Perform a differential backup over gRPC , verify its index, then delete it over gRPC with Jolokia
         Given I have a fresh ccm cluster with jolokia "<client encryption>" running named "scenario16"
         Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>" with gRPC server
         Then the gRPC server is up
@@ -723,6 +723,29 @@ Feature: Integration tests
         Then I delete the backup "grpc_backup" over gRPC and it fails
         Then I verify over gRPC the backup "grpc_backup" does not exist
         Then I shutdown the gRPC server
+
+        @local
+        Examples: Local storage
+        | storage           | client encryption |
+        | local      |  with_client_encryption |
+
+    @18 @skip-cassandra-2
+    Scenario Outline: Perform a differential backup over gRPC , verify its index, then delete it over gRPC with management API
+        Given I have a fresh ccm cluster with mgmt api "<client encryption>" named "scenario18"
+        Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>" with mgmt api
+        Then the gRPC server is up
+        When I create the "test" table in keyspace "medusa"
+        When I load 100 rows in the "medusa.test" table
+        When I run a "ccm node1 nodetool flush" command
+        When I perform a backup over gRPC in "differential" mode of the node named "grpc_backup"
+        Then the backup index exists
+        Then I verify over gRPC that the backup "grpc_backup" exists
+        Then I can see the backup index entry for "grpc_backup"
+        Then I can see the latest backup for "127.0.0.1" being called "grpc_backup"
+        Then I delete the backup "grpc_backup" over gRPC
+        Then I verify over gRPC the backup "grpc_backup" does not exist
+        Then I shutdown the gRPC server
+        Then I shutdown the mgmt api server
 
         @local
         Examples: Local storage


### PR DESCRIPTION
This PR adds the ability to use the Cassandra [Management API]() in a Kubernetes environment for performing backup and restore functionality, instead of using JMX and needing to have a Jolokia agent embedded into your Cassandra image. This capability is intended for a K8s setup, and requires specific configuration in Medusa to enable.

Included in this PR is a slight refactoring of the `create snapshot` and `delete snapshot` functions, as well as introducing a _snapshot service_ abstraction layer to allow for multiple implementations to manage snapshots in Cassandra.

This should address #262 