### PR TITLE
Ignore all peer tables, even the v2 ones

### DIFF
--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -261,7 +261,7 @@ def maybe_restore_section(section, download_dir, cassandra_data_dir, in_place, k
 
     if not in_place:
         if section['keyspace'] == 'system':
-            if section['columnfamily'].startswith('local-') or section['columnfamily'].startswith('peers-'):
+            if section['columnfamily'].startswith('local-') or section['columnfamily'].startswith('peers'):
                 restore_section = False
         if section['keyspace'] == 'system_auth' and keep_auth:
             logging.info('Keeping section {}.{} untouched'.format(section['keyspace'], section['columnfamily']))


### PR DESCRIPTION
In C* 4.0, we now have peers_v2 (and peer_events_v2). Medusa was not filtering these _v2 tables.
One of the consequent issues was that after a restore, the peers_v2 made it into the cluster and the
CQL driver returned a weird mixture of nodes.