### PR TITLE
Added credential insertion

### DIFF
--- a/k8s/docker-entrypoint.sh
+++ b/k8s/docker-entrypoint.sh
@@ -50,7 +50,25 @@ grpc() {
     echo "Starting Medusa gRPC service"
     python3 -m medusa.service.grpc.server server.py
 }
-
+# Add username/password to the medusa-config
+if [ ! -z $CASSANDRA_USERNAME ]; then
+    if ! grep "^\[cassandra\]" /etc/medusa/medusa.ini > /dev/null ; then
+        echo "[cassandra]" >> /etc/medusa/medusa.ini
+    fi
+    if grep "^cql_username" /etc/medusa/medusa.ini > /dev/null; then
+        sed -i "s/^cql_username.*/cql_username = $CASSANDRA_USERNAME/g" /etc/medusa/medusa.ini
+    else
+        sed -i "s/^\[cassandra\]/[cassandra]\ncql_username = $CASSANDRA_USERNAME/g" /etc/medusa/medusa.ini
+    fi
+    if [ -z $CASSANDRA_PASSWORD ]; then
+        CASSANDRA_PASSWORD=""
+    fi
+    if grep "^cql_password" /etc/medusa/medusa.ini > /dev/null; then
+        sed -i "s/^cql_password.*/cql_password = $CASSANDRA_PASSWORD/g" /etc/medusa/medusa.ini
+    else
+        sed -i "s/^\[cassandra\]/[cassandra]\ncql_password = $CASSANDRA_PASSWORD/g" /etc/medusa/medusa.ini
+    fi
+fi
 echo "sleeping for $DEBUG_SLEEP sec"
 sleep $DEBUG_SLEEP
 

--- a/k8s/docker-entrypoint.sh
+++ b/k8s/docker-entrypoint.sh
@@ -51,22 +51,25 @@ grpc() {
     python3 -m medusa.service.grpc.server server.py
 }
 # Add username/password to the medusa-config
+CONF_SRC=/etc/medusa/medusa.ini.old
+CONF=/etc/medusa/medusa.ini
+cp $CONF_SRC $CONF
 if [ ! -z $CASSANDRA_USERNAME ]; then
-    if ! grep "^\[cassandra\]" /etc/medusa/medusa.ini > /dev/null ; then
-        echo "[cassandra]" >> /etc/medusa/medusa.ini
+    if ! grep "^\[cassandra\]" $CONF > /dev/null ; then
+        echo -e "\n[cassandra]" >> $CONF
     fi
-    if grep "^cql_username" /etc/medusa/medusa.ini > /dev/null; then
-        sed -i "s/^cql_username.*/cql_username = $CASSANDRA_USERNAME/g" /etc/medusa/medusa.ini
+    if grep "^cql_username" $CONF > /dev/null; then
+        sed -i "s/^cql_username.*/cql_username = $CASSANDRA_USERNAME/g" $CONF
     else
-        sed -i "s/^\[cassandra\]/[cassandra]\ncql_username = $CASSANDRA_USERNAME/g" /etc/medusa/medusa.ini
+        sed -i "s/^\[cassandra\]/[cassandra]\ncql_username = $CASSANDRA_USERNAME/g" $CONF
     fi
     if [ -z $CASSANDRA_PASSWORD ]; then
         CASSANDRA_PASSWORD=""
     fi
-    if grep "^cql_password" /etc/medusa/medusa.ini > /dev/null; then
-        sed -i "s/^cql_password.*/cql_password = $CASSANDRA_PASSWORD/g" /etc/medusa/medusa.ini
+    if grep "^cql_password" $CONF > /dev/null; then
+        sed -i "s/^cql_password.*/cql_password = $CASSANDRA_PASSWORD/g" $CONF
     else
-        sed -i "s/^\[cassandra\]/[cassandra]\ncql_password = $CASSANDRA_PASSWORD/g" /etc/medusa/medusa.ini
+        sed -i "s/^\[cassandra\]/[cassandra]\ncql_password = $CASSANDRA_PASSWORD/g" $CONF
     fi
 fi
 echo "sleeping for $DEBUG_SLEEP sec"


### PR DESCRIPTION
For kubernetes case we need to be able to read cassandra credentials from environment for multiple reasons:
- when user creation is automated, we cannot always know the credentials prior to deployment.
- having secrets is always better than having plain text.
This change in the docker entrypoint will read from environment variables `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD`, then either add them to `/etc/medusa/medusa.ini` if they don't exist, or replace them if they do.

**NOTE**: if you only supply a username, the password will just be an empty string, even if the `/etc/medusa/medusa.ini` already had a password, it'll be overwritten with an empty one.