### PR TITLE
Backup and DeleteBackup do not return error code

### DIFF
--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -649,3 +649,25 @@ Feature: Integration tests
         Examples: Local storage
         | storage           | client encryption |
         | local      |  with_client_encryption |
+
+    @17
+    Scenario Outline: Perform a differential backup over gRPC , verify its index, then delete it over gRPC with failures
+        Given I have a fresh ccm cluster with jolokia "<client encryption>" running named "scenario17"
+        Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>" with gRPC server
+        Then the gRPC server is up
+        When I create the "test" table in keyspace "medusa"
+        When I load 100 rows in the "medusa.test" table
+        When I run a "ccm node1 nodetool flush" command
+        When I perform a backup over gRPC in "differential" mode of the node named "grpc_backup"
+        Then the backup index exists
+        Then I verify over gRPC that the backup "grpc_backup" exists
+        When I perform a backup over gRPC in "differential" mode of the node named "grpc_backup" and it fails
+        Then I delete the backup "grpc_backup" over gRPC
+        Then I delete the backup "grpc_backup" over gRPC and it fails
+        Then I verify over gRPC the backup "grpc_backup" does not exist
+        Then I shutdown the gRPC server
+
+        @local
+        Examples: Local storage
+        | storage           | client encryption |
+        | local      |  with_client_encryption |

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -555,6 +555,14 @@ def _i_perform_a_backup_of_the_node_named_backupname(context, backup_mode, backu
 def _i_perform_grpc_backup_of_node_named_backupname(context, backup_mode, backup_name):
     context.grpc_client.backup(backup_name, backup_mode)
 
+@when(r'I perform a backup over gRPC in "{backup_mode}" mode of the node named "{backup_name}" and it fails')
+def _i_perform_grpc_backup_of_node_named_backupname_fails(context, backup_mode, backup_name):
+    try:
+        context.grpc_client.backup(backup_name, backup_mode)
+        raise AssertionError("Backup process should have failed but didn't.")
+    except Exception:
+        # This exception is required to be raised to validate the step
+        pass
 
 @then(r'I verify over gRPC that the backup "{backup_name}" exists')
 def _i_verify_over_grpc_backup_exists(context, backup_name):
@@ -571,6 +579,14 @@ def _i_verify_over_grpc_backup_exists(context, backup_name):
 def _i_delete_backup_grpc(context, backup_name):
     context.grpc_client.delete_backup(backup_name)
 
+@then(r'I delete the backup "{backup_name}" over gRPC and it fails')
+def _i_delete_backup_grpc_fail(context, backup_name):
+    try:
+        context.grpc_client.delete_backup(backup_name)
+        raise AssertionError("Backup deletion should have failed but didn't.")
+    except Exception:
+        # This exception is required to be raised to validate the step
+        pass
 
 @then(r'I verify over gRPC the backup "{backup_name}" does not exist')
 def _i_verify_over_grpc_backup_does_not_exist(context, backup_name):


### PR DESCRIPTION
In case of Exception, Backup and DeleteBackup methods in the gRPC should return an error code. Fixes https://github.com/k8ssandra/k8ssandra/issues/256