### PR TITLE
Azure Blobs fixes -  fix differential backups & specify host parameter

### DIFF
--- a/docs/azure_blobs_setup.md
+++ b/docs/azure_blobs_setup.md
@@ -11,6 +11,14 @@ Create a new storage account or use an existing one which will be used to store 
     "key": "YOUR_KEY"
 }
 ```
+If you need to set a different host for Azure (for example the host for Azure Gov is `<storageAccount>.blob.core.usgovcloudapi.net`), please ADDITIONALLY set these two fields in the JSON file (the connection string can be found with the key):
+
+```
+"host": "YOUR_HOST"
+"connection_string": "YOUR_CONNECTION_STRING"
+
+```
+
 Place this file on all Cassandra nodes running medusa under `/etc/medusa/`and set the rigths appropriately so that onyl users running Medusa can read/modify it.
 
 ### Create a container

--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -31,6 +31,7 @@ from medusa.cassandra_utils import Cassandra
 from medusa.index import add_backup_start_to_index, add_backup_finish_to_index, set_latest_backup_in_index
 from medusa.monitoring import Monitoring
 from medusa.storage.s3_storage import is_aws_s3
+from medusa.storage.azure_storage import is_azure
 from medusa.storage.google_storage import GSUTIL_MAX_FILES_PER_CHUNK
 from medusa.storage import Storage, format_bytes_str, ManifestObject, divide_chunks
 
@@ -86,7 +87,7 @@ class NodeBackupCache(object):
                     cached_item = self._cached_objects.get(fqtn, {}).get(src.name)
 
                 threshold = self._storage_config.multi_part_upload_threshold \
-                    if is_aws_s3(self._storage_provider) else None
+                    if is_aws_s3(self._storage_provider) or is_azure(self._storage_provider) else None
                 if cached_item is None or not self._storage_driver.file_matches_cache(src, cached_item, threshold):
                     # We have no matching object in the cache matching the file
                     retained.append(src)

--- a/medusa/storage/azure_blobs_storage/azcli.py
+++ b/medusa/storage/azure_blobs_storage/azcli.py
@@ -21,11 +21,19 @@ class AzCli(object):
     def __enter__(self):
         with io.open(os.path.expanduser(self._config.key_file), 'r', encoding='utf-8') as json_fi:
             credentials = json.load(json_fi)
-        self._env = dict(
-            os.environ,
-            AZURE_STORAGE_ACCOUNT=credentials['storage_account'],
-            AZURE_STORAGE_KEY=credentials['key']
-        )
+
+        connection_string_param = credentials['connection_string']
+        if not connection_string_param:
+            self._env = dict(
+                os.environ,
+                AZURE_STORAGE_ACCOUNT=credentials['storage_account'],
+                AZURE_STORAGE_KEY=credentials['key']
+            )
+        else:
+            self._env = dict(
+                os.environ,
+                AZURE_STORAGE_CONNECTION_STRING=connection_string_param
+            )
         self._az_cli_path = self.find_az_cli()
         return self
 

--- a/medusa/storage/azure_blobs_storage/azcli.py
+++ b/medusa/storage/azure_blobs_storage/azcli.py
@@ -67,7 +67,8 @@ class AzCli(object):
         objects = []
         # Az cli expects the client to provide the MD5 hash of the upload
         for src in srcs:
-            cmd = [self._az_cli_path, "storage", "blob", "upload", "-f", str(src), "-c", bucket_name, "-n", dest, "--content-md5", AbstractStorage.generate_md5_hash(src)]
+            cmd = [self._az_cli_path, "storage", "blob", "upload", "-f", str(src), "-c", bucket_name, "-n", dest,
+                   "--content-md5", AbstractStorage.generate_md5_hash(src)]
             objects.append(self.upload_file(cmd, dest, azcli_output))
 
         return objects

--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -21,10 +21,21 @@ class AzureStorage(AbstractStorage):
         with io.open(os.path.expanduser(self.config.key_file), 'r', encoding='utf-8') as json_fi:
             credentials = json.load(json_fi)
 
-        driver = AzureBlobsStorageDriver(
-            key=credentials['storage_account'],
-            secret=credentials['key']
-        )
+        host_param = credentials['host']
+
+        if not host_param:
+            driver = AzureBlobsStorageDriver(
+                key=credentials['storage_account'],
+                secret=credentials['key']
+            )
+        else:
+            # Hack for Azure connections with a host. Libcloud has a bug in this scenario.
+            driver = AzureBlobsStorageDriver(
+                key=None,
+                secret=credentials['key'],
+                host=host_param
+            )
+            driver.connection.user_id = credentials['storage_account']
 
         return driver
 

--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -30,6 +30,7 @@ class AzureStorage(AbstractStorage):
             )
         else:
             # Hack for Azure connections with a host. Libcloud has a bug in this scenario.
+            # Link to bug submitted against libcloud: https://github.com/apache/libcloud/issues/1551
             driver = AzureBlobsStorageDriver(
                 key=None,
                 secret=credentials['key'],

--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -125,7 +125,7 @@ class AzureStorage(AbstractStorage):
 
         if multipart:
             hashes_match = (
-                    actual_hash == hash_in_manifest
+                actual_hash == hash_in_manifest
             )
         else:
             hashes_match = (

--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -21,22 +21,20 @@ class AzureStorage(AbstractStorage):
         with io.open(os.path.expanduser(self.config.key_file), 'r', encoding='utf-8') as json_fi:
             credentials = json.load(json_fi)
 
-        host_param = credentials['host']
-
-        if not host_param:
-            driver = AzureBlobsStorageDriver(
-                key=credentials['storage_account'],
-                secret=credentials['key']
-            )
-        else:
+        if 'host' in credentials:
             # Hack for Azure connections with a host. Libcloud has a bug in this scenario.
             # Link to bug submitted against libcloud: https://github.com/apache/libcloud/issues/1551
             driver = AzureBlobsStorageDriver(
                 key=None,
                 secret=credentials['key'],
-                host=host_param
+                host=credentials['host']
             )
             driver.connection.user_id = credentials['storage_account']
+        else:
+            driver = AzureBlobsStorageDriver(
+                key=credentials['storage_account'],
+                secret=credentials['key']
+            )
 
         return driver
 

--- a/medusa/storage/s3_storage.py
+++ b/medusa/storage/s3_storage.py
@@ -204,7 +204,7 @@ class S3Storage(AbstractStorage):
 
         threshold = int(threshold) if threshold else -1
 
-        # single or multi part md5 hash. Used by S3 uploads.
+        # single or multi part md5 hash. Used by S3 and Azure uploads.
         if src.stat().st_size >= threshold > 0:
             md5_hash = AbstractStorage.md5_multipart(src)
         else:


### PR DESCRIPTION
2 fixes:

1) Fix differential backups - I was getting an error that `hash_in_manifest` was None on [this line](https://github.com/thelastpickle/cassandra-medusa/pull/219/files#diff-1eca9b6310a202f9d27714f7f0330d78c90edd3445ed2ed0c3872aa165075e7dR97) when trying to run a differential backup with large files.
The fix is similar to https://github.com/thelastpickle/cassandra-medusa/pull/27, when differential backups were broken in s3. I simply copied the multipart file code currently used by s3 to fix the issue.

2) Our storage accounts are in Azure Gov so I added support to specify a `host` in the libcloud AzureBlobsStorageDriver connection, as well as a `connection_string` (which contains host information) in the AWS-cli connection. Unfortunately libclould has a bug in this scenario, so I used a workaround that I found and linked the issue I filed with them in the code (https://github.com/apache/libcloud/issues/1551) 

I verified the fix works by running a differential backup to Azure w/ multi-part files, which resulted in skipping the already-uploaded files. The integration tests should be updated as well - to test the new `host` connections you can simply set them in the `medusa-azure-credentials` file and run the azure tests.