### PR TITLE
Include storage prefix during file purge process

### DIFF
--- a/medusa/purge.py
+++ b/medusa/purge.py
@@ -148,7 +148,7 @@ def cleanup_obsolete_files(storage, fqdn):
 
 
 def get_file_paths_from_storage(storage, fqdn):
-    data_directory = "{}/data".format(fqdn)
+    data_directory = "{}{}/data".format(storage.prefix_path, fqdn)
     data_files = {
         blob.name: blob
         for blob in storage.storage_driver.list_objects(str(data_directory))

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -359,6 +359,7 @@ Feature: Integration tests
         Then I cannot see the backup named "first_backup" when I list the backups
         Then I cannot see the backup named "second_backup" when I list the backups
         Then I cannot see the backup named "third_backup" when I list the backups
+        Then I cannot see purged backup files for the "test" table in keyspace "medusa"
         Then I can see the backup named "fourth_backup" when I list the backups
         Then I can see the backup named "fifth_backup" when I list the backups
         Then I can verify the backup named "fourth_backup" successfully

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -638,6 +638,36 @@ def _i_cannot_see_the_backup_named_backupname_when_i_list_the_backups(
     assert found is False
 
 
+@then('I cannot see purged backup files for the "{table_name}" table in keyspace "{keyspace}"')
+def _i_cannot_see_purged_backup_files_for_the_tablename_table_in_keyspace_keyspacename(
+    context, table_name, keyspace
+):
+    storage = Storage(config=context.medusa_config.storage)
+    path = os.path.join(
+        storage.prefix_path + context.medusa_config.storage.fqdn, "data", keyspace, table_name
+    )
+    sb_files = len(storage.storage_driver.list_objects(path))
+
+    node_backups = storage.list_node_backups()
+    # Parse its manifest
+    nb_list = list(node_backups)
+    nb_files = {}
+    for nb in nb_list:
+        manifest = json.loads(nb.manifest)
+        for section in manifest:
+            if (
+                section["keyspace"] == keyspace
+                and section["columnfamily"][: len(table_name)] == table_name
+            ):
+                for objects in section["objects"]:
+                    nb_files[objects["path"]] = 0
+
+    if sb_files != len(nb_files):
+        logging.error("{} objects found on remote storage and {} objects found on backups manifest".format(
+            sb_files, len(nb_files)))
+        assert sb_files == len(nb_files)
+
+
 @then('I can see the backup status for "{backup_name}" when I run the status command')
 def _i_can_see_backup_status_when_i_run_the_status_command(context, backup_name):
     medusa.status.status(config=context.medusa_config, backup_name=backup_name)


### PR DESCRIPTION
This attempts to fix this issue: https://github.com/thelastpickle/cassandra-medusa/issues/188

For big clusters, this incurs on big S3 costs and quite important to fix it.

I'm not sure if that's good enough, but I'm happy to help if it's not :)