### PR TITLE
Update TLS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,12 @@ jobs:
     # Build debian packages
     strategy:
       matrix:
-        suite: [focal, bionic, xenial, stretch]
+        suite: [focal, bionic]
         include:
           - suite: focal
             os-version: ubuntu-20.04
           - suite: bionic
             os-version: ubuntu-18.04
-          - suite: xenial
-            os-version: ubuntu-16.04
-          - suite: stretch
-            os-version: ubuntu-16.04
     runs-on: ${{ matrix.os-version }}
     steps:
     - uses: actions/checkout@v2
@@ -186,7 +182,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     strategy:
       matrix:
-        suite: [focal, bionic, xenial, stretch]
+        suite: [focal, bionic]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -35,7 +35,7 @@ from retrying import retry
 from cassandra.cluster import Cluster, ExecutionProfile
 from cassandra.policies import WhiteListRoundRobinPolicy
 from cassandra.auth import PlainTextAuthProvider
-from ssl import SSLContext, PROTOCOL_TLSv1, CERT_REQUIRED
+from ssl import SSLContext, PROTOCOL_TLS, CERT_REQUIRED
 from medusa.network.hostname_resolver import HostnameResolver
 
 
@@ -64,14 +64,14 @@ class CqlSessionProvider(object):
                                                   password=cassandra_config.cql_password)
             self._auth_provider = auth_provider
 
-        if cassandra_config.certfile is not None and cassandra_config.usercert is not None and \
-           cassandra_config.userkey is not None:
-            ssl_context = SSLContext(PROTOCOL_TLSv1)
+        if cassandra_config.certfile is not None:
+            ssl_context = SSLContext(PROTOCOL_TLS)
             ssl_context.load_verify_locations(cassandra_config.certfile)
             ssl_context.verify_mode = CERT_REQUIRED
-            ssl_context.load_cert_chain(
-                certfile=cassandra_config.usercert,
-                keyfile=cassandra_config.userkey)
+            if cassandra_config.usercert is not None and cassandra_config.userkey is not None:
+                ssl_context.load_cert_chain(
+                    certfile=cassandra_config.usercert,
+                    keyfile=cassandra_config.userkey)
             self._ssl_context = ssl_context
 
         load_balancing_policy = WhiteListRoundRobinPolicy(ip_addresses)

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -3,14 +3,14 @@
 set -e
 
 case $1 in
-  ""|bionic|xenial|buster|stretch|focal)
+  ""|bionic|buster|focal)
     suites=("${1:-bionic}")
     ;;
   all)
-    suites=(focal bionic xenial buster stretch)
+    suites=(focal bionic buster)
     ;;
   *)
-    echo "Unknown distribution suite - allowed values: 'all', 'bionic', 'xenial', 'buster', 'stretch'"
+    echo "Unknown distribution suite - allowed values: 'all', 'bionic', 'buster'"
     exit 1
     ;;
 esac

--- a/packaging/docker-build/Dockerfile
+++ b/packaging/docker-build/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR ${WORKDIR}
 ENV PIP_DEFAULT_TIMEOUT 100
 RUN echo "Acquire::http::Pipeline-Depth 0;" >> /etc/apt/apt.conf
 
-# add a repo that contains a backport of dh-virtualenv 1.1 for focal, bionic, xenial
+# add a repo that contains a backport of dh-virtualenv 1.1 for focal, bionic
 RUN apt-get update && \
     apt-get install -y software-properties-common
 

--- a/packaging/docker-build/docker-compose.yml
+++ b/packaging/docker-build/docker-compose.yml
@@ -36,26 +36,6 @@ services:
       - ../..:/usr/src/app/cassandra-medusa
       - ../../packages:/usr/src/app/packages
       - ./scripts:/usr/src/app/scripts
-  cassandra-medusa-builder-xenial:
-    build:
-      context: ../..
-      dockerfile: packaging/docker-build/Dockerfile
-      args:
-        - BUILD_IMAGE=ubuntu:16.04
-    volumes:
-      - ../..:/usr/src/app/cassandra-medusa
-      - ../../packages:/usr/src/app/packages
-      - ./scripts:/usr/src/app/scripts
-  cassandra-medusa-builder-stretch:
-    build:
-      context: ../..
-      dockerfile: packaging/docker-build/Dockerfile
-      args:
-        - BUILD_IMAGE=debian:stretch
-    volumes:
-      - ../..:/usr/src/app/cassandra-medusa
-      - ../../packages:/usr/src/app/packages
-      - ./scripts:/usr/src/app/scripts
   cassandra-medusa-builder-buster:
     build:
       context: ../..

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -20,6 +20,7 @@ Feature: Integration tests
     @1
     Scenario Outline: Perform a backup, verify it, and restore it.
         Given I have a fresh ccm cluster "<client encryption>" running named "scenario1"
+        Then Test TLS version connections if "<client encryption>" is turned on
         Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>"
         When I create the "test" table in keyspace "medusa"
         When I load 100 rows in the "medusa.test" table

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from subprocess import PIPE
 import signal
 from cassandra.cluster import Cluster
-from ssl import SSLContext, PROTOCOL_TLSv1, CERT_REQUIRED
+from ssl import SSLContext, PROTOCOL_TLS, PROTOCOL_TLSv1, PROTOCOL_TLSv1_1, PROTOCOL_TLSv1_2, CERT_REQUIRED
 
 import medusa.backup_node
 import medusa.index
@@ -732,6 +732,13 @@ def _i_can_download_the_backup_single_table_successfully(context, backup_name, f
     cleanup(download_path)
 
 
+@then(r'Test TLS version connections if "{client_encryption}" is turned on')
+def _i_can_connect_using_all_tls_versions(context, client_encryption):
+    if client_encryption == 'with_client_encryption':
+        for tls_version in [PROTOCOL_TLSv1, PROTOCOL_TLSv1_1, PROTOCOL_TLSv1_2]:
+            connect_cassandra(True, tls_version)
+
+
 @when(r'I restore the backup named "{backup_name}"')
 def _i_restore_the_backup_named(context, backup_name):
     medusa.restore_node.restore_node(
@@ -1090,7 +1097,7 @@ def _i_delete_the_backup_named(context, backup_name, all_nodes=False):
                                backup_name=backup_name, all_nodes=all_nodes)
 
 
-def connect_cassandra(is_client_encryption_enable):
+def connect_cassandra(is_client_encryption_enable, tls_version=PROTOCOL_TLS):
     connected = False
     attempt = 0
     session = None
@@ -1098,7 +1105,7 @@ def connect_cassandra(is_client_encryption_enable):
 
     if is_client_encryption_enable:
 
-        ssl_context = SSLContext(PROTOCOL_TLSv1)
+        ssl_context = SSLContext(tls_version)
         ssl_context.load_verify_locations(certfile)
         ssl_context.verify_mode = CERT_REQUIRED
         ssl_context.load_cert_chain(
@@ -1114,6 +1121,9 @@ def connect_cassandra(is_client_encryption_enable):
         except cassandra.cluster.NoHostAvailable:
             attempt += 1
             time.sleep(10)
+
+    if tls_version is not PROTOCOL_TLS:  # other TLS versions used for testing, close the session
+        session.shutdown()
 
     return session
 


### PR DESCRIPTION
Allow usercert and userkey to be optional
remove Xenial and Stretch from build - deprecate python 3.5

Builds on top of #260 and replaces #177
Fixes #176 