### PR TITLE
Azure Blobs fixes - fix differential backups & specify host parameter

### DIFF
--- a/docs/azure_blobs_setup.md
+++ b/docs/azure_blobs_setup.md
@@ -11,6 +11,14 @@ Create a new storage account or use an existing one which will be used to store 
     "key": "YOUR_KEY"
 }
 ```
+If you need to set a different host for Azure (for example the host for Azure Gov is `<storageAccount>.blob.core.usgovcloudapi.net`), please ADDITIONALLY set these two fields in the JSON file (the connection string can be found with the key):
+
+```
+"host": "YOUR_HOST"
+"connection_string": "YOUR_CONNECTION_STRING"
+
+```
+
 Place this file on all Cassandra nodes running medusa under `/etc/medusa/`and set the rigths appropriately so that onyl users running Medusa can read/modify it.
 
 ### Create a container

--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -31,6 +31,7 @@ from medusa.cassandra_utils import Cassandra
 from medusa.index import add_backup_start_to_index, add_backup_finish_to_index, set_latest_backup_in_index
 from medusa.monitoring import Monitoring
 from medusa.storage.s3_storage import is_aws_s3
+from medusa.storage.azure_storage import is_azure
 from medusa.storage.google_storage import GSUTIL_MAX_FILES_PER_CHUNK
 from medusa.storage import Storage, format_bytes_str, ManifestObject, divide_chunks
 
@@ -86,7 +87,7 @@ class NodeBackupCache(object):
                     cached_item = self._cached_objects.get(fqtn, {}).get(src.name)
 
                 threshold = self._storage_config.multi_part_upload_threshold \
-                    if is_aws_s3(self._storage_provider) else None
+                    if is_aws_s3(self._storage_provider) or is_azure(self._storage_provider) else None
                 if cached_item is None or not self._storage_driver.file_matches_cache(src, cached_item, threshold):
                     # We have no matching object in the cache matching the file
                     retained.append(src)

--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -21,10 +21,20 @@ class AzureStorage(AbstractStorage):
         with io.open(os.path.expanduser(self.config.key_file), 'r', encoding='utf-8') as json_fi:
             credentials = json.load(json_fi)
 
-        driver = AzureBlobsStorageDriver(
-            key=credentials['storage_account'],
-            secret=credentials['key']
-        )
+        if 'host' in credentials:
+            # Hack for Azure connections with a host. Libcloud has a bug in this scenario.
+            # Link to bug submitted against libcloud: https://github.com/apache/libcloud/issues/1551
+            driver = AzureBlobsStorageDriver(
+                key=None,
+                secret=credentials['key'],
+                host=credentials['host']
+            )
+            driver.connection.user_id = credentials['storage_account']
+        else:
+            driver = AzureBlobsStorageDriver(
+                key=credentials['storage_account'],
+                secret=credentials['key']
+            )
 
         return driver
 
@@ -81,24 +91,56 @@ class AzureStorage(AbstractStorage):
 
     @staticmethod
     def file_matches_cache(src, cached_item, threshold=None):
+        threshold = int(threshold) if threshold else -1
+
+        # single or multi part md5 hash. Used by Azure and S3 uploads.
+        if src.stat().st_size >= threshold > 0:
+            md5_hash = AbstractStorage.md5_multipart(src)
+        else:
+            md5_hash = AbstractStorage.generate_md5_hash(src)
+
         return AzureStorage.compare_with_manifest(
             actual_size=src.stat().st_size,
             size_in_manifest=cached_item['size'],
-            actual_hash=AbstractStorage.generate_md5_hash(src),
-            hash_in_manifest=cached_item['MD5']
+            actual_hash=md5_hash,
+            hash_in_manifest=cached_item['MD5'],
+            threshold=threshold
         )
 
     @staticmethod
     def compare_with_manifest(actual_size, size_in_manifest, actual_hash=None, hash_in_manifest=None, threshold=None):
+        if not threshold:
+            threshold = -1
+        else:
+            threshold = int(threshold)
+
+        if actual_size >= threshold > 0 or "-" in hash_in_manifest:
+            multipart = True
+        else:
+            multipart = False
+
         sizes_match = actual_size == size_in_manifest
 
-        hashes_match = (
-            # this case comes from comparing blob hashes to manifest entries (in context of Azure)
-            actual_hash == base64.b64decode(hash_in_manifest).hex()
-            # this comes from comparing files to a cache
-            or hash_in_manifest == base64.b64decode(actual_hash).hex()
-            # and perhaps we need the to check for match even without base64 encoding
-            or actual_hash == hash_in_manifest
-        )
+        if multipart:
+            hashes_match = (
+                actual_hash == hash_in_manifest
+            )
+        else:
+            hashes_match = (
+                # this case comes from comparing blob hashes to manifest entries (in context of Azure)
+                actual_hash == base64.b64decode(hash_in_manifest).hex()
+                # this comes from comparing files to a cache
+                or hash_in_manifest == base64.b64decode(actual_hash).hex()
+                # and perhaps we need the to check for match even without base64 encoding
+                or actual_hash == hash_in_manifest
+            )
 
         return sizes_match and hashes_match
+
+
+def is_azure(storage_name):
+    storage_name = storage_name.lower()
+    if storage_name == 'azure_blobs':
+        return True
+    else:
+        return False

--- a/medusa/storage/s3_storage.py
+++ b/medusa/storage/s3_storage.py
@@ -204,7 +204,7 @@ class S3Storage(AbstractStorage):
 
         threshold = int(threshold) if threshold else -1
 
-        # single or multi part md5 hash. Used by S3 uploads.
+        # single or multi part md5 hash. Used by S3 and Azure uploads.
         if src.stat().st_size >= threshold > 0:
             md5_hash = AbstractStorage.md5_multipart(src)
         else:


### PR DESCRIPTION
(same PR as https://github.com/thelastpickle/cassandra-medusa/pull/267 - I made this one to clean the git history, as I had merged master a few times). 

2 fixes:

Fix differential backups - I was getting an error that hash_in_manifest was None on this line when trying to run a differential backup with large files.
The fix is similar to #27, when differential backups were broken in s3. I simply copied the multipart file code currently used by s3 to fix the issue.

Our storage accounts are in Azure Gov so I added support to specify a host in the libcloud AzureBlobsStorageDriver connection, as well as a connection_string (which contains host information) in the AWS-cli connection. Unfortunately libclould has a bug in this scenario, so I used a workaround that I found and linked the issue I filed with them in the code (apache/libcloud#1551)

I verified the fix works by running a differential backup to Azure w/ multi-part files, which resulted in skipping the already-uploaded files. The integration tests should be updated as well - to test the new host connections you can simply set them in the medusa-azure-credentials file and run the azure tests.