### PR TITLE
Pin cryptography to 3.3.2 to avoid install failing on missing Rust req

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ psutil>=5.4.7
 ffwd>=0.0.2
 apache-libcloud<=3.3.0,>=2.8.0
 lockfile>=0.12.2
-pycrypto>=2.6.1
+cryptography<=3.3.2,>=2.5
+pycryptodome>=3.9.9
 retrying>=1.3.3
 # ssh2-python==0.20.0 is broken, 0.22.0+ should work.
 ssh2-python==0.19.0

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ setuptools.setup(
         'ffwd>=0.0.2',
         'apache-libcloud<=3.3.0,>=2.8.0',
         'lockfile>=0.12.2',
-        'pycrypto>=2.6.1',
+        'cryptography<=3.3.2,>=2.5',
+        'pycryptodome>=3.9.9',
         'retrying>=1.3.3',
         'parallel-ssh==1.9.1',
         'ssh2-python==0.19.0',  # <-- ssh2-python==0.20.0 is broken, 0.22.0+ should work.


### PR DESCRIPTION
Paramiko, which is pulled as a dep by pssh uses the cryptography dependency with just a lower bound (needs to be >= 2.5).
v3.4.6 of cryptography apparently have a requirement on setuptools_rust which fails the installs in several cases.