### PR TITLE
Fix region replacement in the S3 storage backend

### DIFF
--- a/medusa/storage/__init__.py
+++ b/medusa/storage/__init__.py
@@ -21,7 +21,7 @@ import operator
 import pathlib
 import re
 
-from libcloud.storage.providers import Provider, get_driver
+from libcloud.storage.providers import Provider
 from libcloud.common.types import InvalidCredsError
 from retrying import retry
 
@@ -89,9 +89,6 @@ class Storage(object):
             s3_storage.check_dependencies()
             return s3_storage
         elif self._config.storage_provider.startswith(Provider.S3):
-            if self._config.storage_provider != Provider.S3:
-                self._config['region'] = get_driver(self._config.storage_provider).region_name
-
             s3_storage = S3Storage(self._config)
             s3_storage.check_dependencies()
             return s3_storage

--- a/medusa/storage/s3_compat_storage/awscli.py
+++ b/medusa/storage/s3_compat_storage/awscli.py
@@ -22,6 +22,8 @@ import sys
 
 from retrying import retry
 
+from libcloud.storage.providers import get_driver, Provider
+
 
 class AwsCli(object):
     def __init__(self, storage):
@@ -104,8 +106,11 @@ class AwsCli(object):
         if self.endpoint_url is not None:
             cmd.extend(["--endpoint-url", self.endpoint_url])
 
-        if self._config.region is not None:
+        if self._config.region is not None and self._config.region != "default":
             cmd.extend(["--region", self._config.region])
+        elif self._config.storage_provider != Provider.S3 and self._config.region == "default":
+            # Legacy libcloud S3 providers that were tied to a specific region such as s3_us_west_oregon
+            cmd.extend(["--region", get_driver(self._config.storage_provider).region_name])
 
         return cmd
 

--- a/medusa/storage/s3_storage.py
+++ b/medusa/storage/s3_storage.py
@@ -95,8 +95,11 @@ class S3Storage(S3BaseStorage):
             raise NotImplementedError("No valid method of AWS authentication provided.")
 
         cls = get_driver(Provider.S3)
+        region = self.config.region
+        if self.config.storage_provider != Provider.S3:
+            region = get_driver(self.config.storage_provider).region_name
         driver = cls(
-            aws_access_key_id, aws_secret_access_key, token=aws_security_token, region=self.config.region
+            aws_access_key_id, aws_secret_access_key, token=aws_security_token, region=region
         )
 
         if self.config.transfer_max_bandwidth is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ PyYAML>=5.1
 cassandra-driver>=3.14.0
 psutil>=5.4.7
 ffwd>=0.0.2
-apache-libcloud<=3.3.0,>=2.8.0
+apache-libcloud<3.4.0,>=3.3.0
 lockfile>=0.12.2
 cryptography<=3.3.2,>=2.5
 pycryptodome>=3.9.9

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
         'cassandra-driver>=3.14.0',
         'psutil>=5.4.7',
         'ffwd>=0.0.2',
-        'apache-libcloud<=3.3.0,>=2.8.0',
+        'apache-libcloud<3.4.0,>=3.3.0',
         'lockfile>=0.12.2',
         'cryptography<=3.3.2,>=2.5',
         'pycryptodome>=3.9.9',

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -30,7 +30,6 @@ from subprocess import PIPE
 import signal
 from cassandra.cluster import Cluster
 from ssl import SSLContext, PROTOCOL_TLS, PROTOCOL_TLSv1, PROTOCOL_TLSv1_1, PROTOCOL_TLSv1_2, CERT_REQUIRED
-from libcloud.storage.providers import get_driver
 
 import medusa.backup_node
 import medusa.index
@@ -279,14 +278,11 @@ def i_am_using_storage_provider(context, storage_provider, client_encryption):
             "prefix": storage_prefix
         }
     elif storage_provider.startswith("s3"):
-        # Backwards compatibility for the test features
-        region = get_driver(storage_provider).region_name
         config["storage"] = {
             "host_file_separator": ",",
             "bucket_name": "tlp-medusa-dev",
             "key_file": "~/.aws/credentials",
-            "storage_provider": "s3",
-            "region": region,
+            "storage_provider": storage_provider,
             "fqdn": "127.0.0.1",
             "api_key_or_username": "",
             "api_secret_or_password": "",

--- a/tests/storage/s3_storage_test.py
+++ b/tests/storage/s3_storage_test.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from libcloud.storage.providers import get_driver
+
+
+class S3StorageTest(unittest.TestCase):
+
+    def test_legacy_provider_region_replacement(self):
+        assert get_driver("s3_us_west_oregon").region_name == "us-west-2"


### PR DESCRIPTION
Fixes #291
The refactoring of S3 compatible backends included a change on how regions are dealt with, including backwards compatibility for legacy S3 region specific storage providers such as s3_us_west_oregon. The problem with this implementation was that it tried to modify the config object although it's immutable.