### PR TITLE
Increase retries for S3 storage

### DIFF
--- a/medusa/purge.py
+++ b/medusa/purge.py
@@ -140,9 +140,10 @@ def cleanup_obsolete_files(storage, fqdn):
     for path in paths_in_storage - paths_in_manifest:
         logging.debug("  - [{}] exists in storage, but not in manifest".format(path))
         obj = storage.storage_driver.get_blob(path)
-        nb_objects_purged += 1
-        total_purged_size += int(obj.size)
-        storage.storage_driver.delete_object(obj)
+        if obj is not None:
+            nb_objects_purged += 1
+            total_purged_size += int(obj.size)
+            storage.storage_driver.delete_object(obj)
 
     return nb_objects_purged, total_purged_size
 

--- a/medusa/storage/abstract_storage.py
+++ b/medusa/storage/abstract_storage.py
@@ -87,6 +87,7 @@ class AbstractStorage(abc.ABC):
         return medusa.storage.concurrent.upload_blobs(self, src, dest, self.bucket,
                                                       max_workers=self.config.concurrent_transfers)
 
+    @retry(stop_max_attempt_number=7, wait_exponential_multiplier=10000, wait_exponential_max=120000)
     def get_blob(self, path):
         try:
             logging.debug("[Storage] Getting object {}".format(path))

--- a/medusa/storage/s3_compat_storage/concurrent.py
+++ b/medusa/storage/s3_compat_storage/concurrent.py
@@ -26,7 +26,7 @@ from retrying import retry
 import medusa
 from medusa.storage.s3_compat_storage.awscli import AwsCli
 
-MAX_UP_DOWN_LOAD_RETRIES = 5
+MAX_UP_DOWN_LOAD_RETRIES = 10
 
 
 class StorageJob:

--- a/medusa/storage/s3_compat_storage/concurrent.py
+++ b/medusa/storage/s3_compat_storage/concurrent.py
@@ -26,7 +26,7 @@ from retrying import retry
 import medusa
 from medusa.storage.s3_compat_storage.awscli import AwsCli
 
-MAX_UP_DOWN_LOAD_RETRIES = 10
+MAX_UP_DOWN_LOAD_RETRIES = 5
 
 
 class StorageJob:
@@ -121,7 +121,7 @@ def __upload_file(storage, connection, src, dest, bucket, multi_part_upload_thre
     return medusa.storage.ManifestObject(obj.name, int(obj.size), obj.hash)
 
 
-@retry(stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES, wait_fixed=5000)
+@retry(stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES, wait_exponential_multiplier=10000, wait_exponential_max=120000)
 def _upload_single_part(connection, src, bucket, object_name):
     obj = connection.upload_object(
         str(src), container=bucket, object_name=object_name
@@ -158,6 +158,7 @@ def download_blobs(storage, src, dest, bucket, max_workers=None, multi_part_uplo
     job.execute(list(src))
 
 
+@retry(stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES, wait_exponential_multiplier=10000, wait_exponential_max=120000)
 def __download_blob(storage, connection, src, dest, bucket, multi_part_upload_threshold):
     """
     This function is called by StorageJob. It may be called concurrently by multiple threads.
@@ -193,7 +194,7 @@ def __download_blob(storage, connection, src, dest, bucket, multi_part_upload_th
         return None
 
 
-@retry(stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES, wait_fixed=5000)
+@retry(stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES, wait_exponential_multiplier=10000, wait_exponential_max=120000)
 def _download_single_part(connection, blob, blob_dest):
     index = blob.name.rfind("/")
     if index > 0:


### PR DESCRIPTION
This is an attempt to fix some issues with S3 during the purge process, where sometimes S3 throws these errors:

```
stderr: [2021-02-25 08:42:21,807] INFO: Monitoring provider is noop
[2021-02-25 08:42:21,807] INFO: Starting purge
[2021-02-25 08:42:22,760] INFO: Listing backups for ip-10-22-22-22.ec2.internal
[2021-02-25 08:42:26,653] INFO: 7 backups are candidate to be purged
[2021-02-25 08:42:26,653] INFO: Purging backup 202102230330 from node ip-10-22-22-22.ec2.internal...
[2021-02-25 08:42:27,099] INFO: Purging backup 202102222130 from node ip-10-22-22-22.ec2.internal...
[2021-02-25 08:42:27,552] INFO: Purging backup 202102230530 from node ip-10-22-22-22.ec2.internal...
[2021-02-25 08:42:27,964] INFO: Purging backup 202102222330 from node ip-10-22-22-22.ec2.internal...
[2021-02-25 08:42:28,381] INFO: Purging backup 202102230730 from node ip-10-22-22-22.ec2.internal...
[2021-02-25 08:42:28,897] INFO: Purging backup 202102221930 from node ip-10-22-22-22.ec2.internal...
[2021-02-25 08:42:29,285] INFO: Purging backup 202102230130 from node ip-10-22-22-22.ec2.internal...
[2021-02-25 08:42:29,740] INFO: Cleaning up orphaned files for ip-10-22-22-22.ec2.internal...
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/medusa/purge.py", line 46, in main
    purge_backups(storage, backups_to_purge)
  File "/usr/local/lib/python3.7/site-packages/medusa/purge.py", line 103, in purge_backups
    (cleaned_objects_count, cleaned_objects_size) = cleanup_obsolete_files(storage, fqdn)
  File "/usr/local/lib/python3.7/site-packages/medusa/purge.py", line 142, in cleanup_obsolete_files
    obj = storage.storage_driver.get_blob(path)
  File "/usr/local/lib/python3.7/site-packages/medusa/storage/abstract_storage.py", line 93, in get_blob
    return self.driver.get_object(self.bucket.name, str(path))
  File "/usr/local/lib/python3.7/site-packages/libcloud/storage/drivers/s3.py", line 370, in get_object
    response = self.connection.request(object_path, method='HEAD')
  File "/usr/local/lib/python3.7/site-packages/libcloud/common/base.py", line 655, in request
    response = responseCls(**kwargs)
  File "/usr/local/lib/python3.7/site-packages/libcloud/common/base.py", line 166, in __init__
    message=self.parse_error(),
  File "/usr/local/lib/python3.7/site-packages/libcloud/storage/drivers/s3.py", line 148, in parse_error
    driver=S3StorageDriver)
libcloud.common.types.LibcloudError: <LibcloudError in <class 'libcloud.storage.drivers.s3.S3StorageDriver'> 'Unknown error. Status code: 500'>
[2021-02-25 10:39:05,425] ERROR: This error happened during the purge: <LibcloudError in <class 'libcloud.storage.drivers.s3.S3StorageDriver'> 'Unknown error. Status code: 500'>
```

Also increasing `MAX_UP_DOWN_LOAD_RETRIES` tries to address this other issue: https://github.com/thelastpickle/cassandra-medusa/issues/190. 