### PR TITLE
If running in Kubernetes, replace tokens in not in_place case

### DIFF
--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -132,6 +132,9 @@ def restore_node_locally(config, temp_dir, backup_name, in_place, keep_auth, see
             cassandra.start_with_implicit_token()
         else:
             cassandra.start(tokens)
+    elif not in_place:
+        # Kubernetes will manage the lifecycle, but we still need to modify the tokens
+        cassandra.replaceTokensInCassandraYamlAndDisableBootstrap(tokens)
 
     # Clean the restored data from local temporary folder
     clean_path(download_dir, use_sudo, keep_folder=False)


### PR DESCRIPTION
And also disable bootstrap (call the same command as start would usually do, but do not start the node).

Related: #303 