### PR TITLE
Add new parameter to allow overriding the fqdn for new cluster

### DIFF
--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -37,7 +37,7 @@ MAX_ATTEMPTS = 60
 
 
 def restore_node(config, temp_dir, backup_name, in_place, keep_auth, seeds, verify, keyspaces, tables,
-                 use_sstableloader=False):
+                 use_sstableloader=False, backup_fqdn=None):
 
     if in_place and keep_auth:
         logging.error('Cannot keep system_auth when restoring in-place. It would be overwritten')
@@ -47,7 +47,7 @@ def restore_node(config, temp_dir, backup_name, in_place, keep_auth, seeds, veri
 
     if not use_sstableloader:
         restore_node_locally(config, temp_dir, backup_name, in_place, keep_auth, seeds, storage,
-                             keyspaces, tables)
+                             keyspaces, tables, backup_fqdn)
     else:
         restore_node_sstableloader(config, temp_dir, backup_name, in_place, keep_auth, seeds, storage,
                                    keyspaces, tables)
@@ -57,13 +57,18 @@ def restore_node(config, temp_dir, backup_name, in_place, keep_auth, seeds, veri
         verify_restore([hostname_resolver.resolve_fqdn()], config)
 
 
-def restore_node_locally(config, temp_dir, backup_name, in_place, keep_auth, seeds, storage, keyspaces, tables):
+def restore_node_locally(config, temp_dir, backup_name, in_place, keep_auth, seeds, storage, keyspaces, tables,
+                         backup_fqdn=None):
     storage.storage_driver.prepare_download()
     differential_blob = storage.storage_driver.get_blob(
         os.path.join(config.storage.fqdn, backup_name, 'meta', 'differential'))
 
+    fqdn = config.storage.fqdn
+    if backup_fqdn is not None:
+        fqdn = backup_fqdn
+
     node_backup = storage.get_node_backup(
-        fqdn=config.storage.fqdn,
+        fqdn=fqdn,
         name=backup_name,
         differential_mode=True if differential_blob is not None else False
     )

--- a/medusa/service/grpc/restore.py
+++ b/medusa/service/grpc/restore.py
@@ -56,6 +56,7 @@ config = create_config(config_file_path)
 configure_console_logging(config.logging)
 
 backup_name = os.environ["BACKUP_NAME"]
+override_fqdn = os.environ["BACKUP_FQDN"]
 tmp_dir = Path("/tmp")
 in_place = True
 keep_auth = False
@@ -65,9 +66,12 @@ keyspaces = {}
 tables = {}
 use_sstableloader = False
 
+if override_fqdn is not None and len(override_fqdn) == 0:
+    override_fqdn = None
+
 logging.info("Starting restore of backup {}".format(backup_name))
 
 medusa.restore_node.restore_node(config, tmp_dir, backup_name, in_place, keep_auth, seeds, verify, keyspaces, tables,
-                                 use_sstableloader)
+                                 use_sstableloader, override_fqdn)
 
 logging.info("Finished restore of backup {}".format(backup_name))


### PR DESCRIPTION
If restoring to a new cluster, we need to fetch the backup from an old name (instead of the new cluster name / podname).



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1407) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1407
┆priority: Medium
