### PR TITLE
add handler for sigterm and use exec to run server.py script

### DIFF
--- a/k8s/docker-entrypoint.sh
+++ b/k8s/docker-entrypoint.sh
@@ -48,7 +48,7 @@ restore() {
 
 grpc() {
     echo "Starting Medusa gRPC service"
-    python3 -m medusa.service.grpc.server server.py
+    exec python3 -m medusa.service.grpc.server server.py
 }
 
 echo "sleeping for $DEBUG_SLEEP sec"
@@ -57,7 +57,8 @@ sleep $DEBUG_SLEEP
 if [ "$MEDUSA_MODE" == "RESTORE" ]; then
     restore
 elif [ "$MEDUSA_MODE" == "GRPC" ]; then
-    grpc
+    echo "Starting Medusa gRPC service"
+    exec python3 -m medusa.service.grpc.server server.py
 else
     echo "MEDUSA_MODE env var must be set to either RESTORE or GRPC"
     exit 1

--- a/k8s/docker-entrypoint.sh
+++ b/k8s/docker-entrypoint.sh
@@ -41,7 +41,7 @@ restore() {
         echo "Skipping restore operation"    
     else
         echo "Restoring backup $BACKUP_NAME"
-        python3 -m medusa.service.grpc.restore
+        exec python3 -m medusa.service.grpc.restore
         echo $RESTORE_KEY > $last_restore_file
     fi
 }
@@ -57,8 +57,7 @@ sleep $DEBUG_SLEEP
 if [ "$MEDUSA_MODE" == "RESTORE" ]; then
     restore
 elif [ "$MEDUSA_MODE" == "GRPC" ]; then
-    echo "Starting Medusa gRPC service"
-    exec python3 -m medusa.service.grpc.server server.py
+    grpc
 else
     echo "MEDUSA_MODE env var must be set to either RESTORE or GRPC"
     exit 1

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -17,6 +17,7 @@ import logging
 import os
 import sys
 import time
+import signal
 from collections import defaultdict
 from concurrent import futures
 from datetime import datetime
@@ -141,6 +142,10 @@ def configure_console_logging(config):
             logging.getLogger(logger_name).setLevel(logging.WARN)
 
 
+def shutdown(signum, frame):
+    logging.info("shutting down")
+    server.stop(0)
+
 if len(sys.argv) > 2:
     config_file_path = sys.argv[2]
 else:
@@ -162,10 +167,14 @@ logging.info('Starting server. Listening on port 50051.')
 server.add_insecure_port('[::]:50051')
 server.start()
 
+signal.signal(signal.SIGTERM, shutdown)
+
+server.wait_for_termination()
+
 # since server.start() will not block,
 # a sleep-loop is added to keep alive
-try:
-    while True:
-        time.sleep(86400)
-except KeyboardInterrupt:
-    server.stop(0)
+# try:
+#     while True:
+#         time.sleep(86400)
+# except KeyboardInterrupt:
+#     server.stop(0)

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -14,10 +14,8 @@
 # limitations under the License.
 
 import logging
-import os
-import sys
-import time
 import signal
+import sys
 from collections import defaultdict
 from concurrent import futures
 from datetime import datetime
@@ -29,8 +27,8 @@ from grpc_health.v1 import health_pb2_grpc
 
 import medusa.backup_node
 import medusa.config
-import medusa.purge
 import medusa.listing
+import medusa.purge
 from medusa.service.grpc import medusa_pb2
 from medusa.service.grpc import medusa_pb2_grpc
 from medusa.storage import Storage
@@ -145,6 +143,7 @@ def configure_console_logging(config):
 def shutdown(signum, frame):
     logging.info("shutting down")
     server.stop(0)
+
 
 if len(sys.argv) > 2:
     config_file_path = sys.argv[2]

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -154,10 +154,6 @@ else:
 config = create_config(config_file_path)
 configure_console_logging(config.logging)
 
-sleep_time = int(os.getenv("DEBUG_SLEEP", "0"))
-logging.debug("sleeping for {} sec".format(sleep_time))
-time.sleep(sleep_time)
-
 server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
 
 medusa_pb2_grpc.add_MedusaServicer_to_server(MedusaService(config), server)
@@ -170,11 +166,3 @@ server.start()
 signal.signal(signal.SIGTERM, shutdown)
 
 server.wait_for_termination()
-
-# since server.start() will not block,
-# a sleep-loop is added to keep alive
-# try:
-#     while True:
-#         time.sleep(86400)
-# except KeyboardInterrupt:
-#     server.stop(0)


### PR DESCRIPTION
This PR includes a couple changes:

* Adds a signal handler for SIGTERM
    * When invoked the handler logs that the server is shutting down
    * The handler calls `server.stop()` on the gRPC serve
* Use `exec` to run `server.py` so that it is not run in a subshell  