### PR TITLE
Force int data type for healthcheck port

### DIFF
--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -340,15 +340,15 @@ class Cassandra(object):
 
     @property
     def storage_port(self):
-        return self._storage_port
+        return int(self._storage_port)
 
     @property
     def native_port(self):
-        return self._native_port
+        return int(self._native_port)
 
     @property
     def rpc_port(self):
-        return self._rpc_port
+        return int(self._rpc_port)
 
     class Snapshot(object):
         def __init__(self, parent, tag):


### PR DESCRIPTION
The socket test check https://github.com/thelastpickle/cassandra-medusa/blob/master/medusa/cassandra_utils.py#L618 requires an integer data type for port parameter, but yaml load returns a string https://github.com/thelastpickle/cassandra-medusa/blob/master/medusa/cassandra_utils.py#L214 so port healthcheck will always fail for that reason, we need to convert to integer before. That's the error that I got debugging this issue that affects while performing a full cluster restore:

```
    s.connect((host, port))
TypeError: an integer is required (got type str)
```