### PR TITLE
* Updated to support python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         include:
           - python-version: 3.7
             tox-py: py37
@@ -20,6 +20,8 @@ jobs:
             tox-py: py36
           - python-version: 3.8
             tox-py: py38
+          - python-version: 3.9
+            tox-py: py39
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -95,7 +97,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          python-version: [3.6, 3.8]
+          python-version: [3.6, 3.9]
           it-backend: [local, s3, gcs, minio]
           # IBM not included by default due to lite plan quota being easily exceeded
           # Azure brought a lot of flakeyness to the integration tests - it must be investigated before we can bring it back in
@@ -103,8 +105,8 @@ jobs:
           cassandra-version: [2.2.19, 3.11.10, 'github:apache/trunk']
           experimental: [false]
           include:
-            - python-version: 3.8
-              tox-py: py38
+            - python-version: 3.9
+              tox-py: py39
             - python-version: 3.6
               tox-py: py36
     runs-on: ubuntu-18.04

--- a/debian/rules
+++ b/debian/rules
@@ -20,6 +20,7 @@ DISTRIBUTION = $(shell sed -n "s/^VERSION_CODENAME=//p" /etc/os-release)
 PACKAGEVERSION = $(VERSION)-0~$(DISTRIBUTION)0
 PY3VER = $(shell py3versions -d)
 SSH2_LIBS_SUFFIX = debian/cassandra-medusa/usr/share/cassandra-medusa/lib/$(PY3VER)/site-packages/ssh2_python.libs/
+SSH_LIBS_SUFFIX = debian/cassandra-medusa/usr/share/cassandra-medusa/lib/$(PY3VER)/site-packages/ssh_python.libs/
 
 export DH_ALWAYS_EXCLUDE = .git
 export DH_VIRTUALENV_INSTALL_ROOT = /usr/share
@@ -33,10 +34,10 @@ override_dh_virtualenv:
 	  --python /usr/bin/python3 --preinstall=setuptools==40.3.0 --preinstall=pip==20.2.3 --preinstall=wheel --builtin-venv
 
 override_dh_strip:
-	dh_strip --no-automatic-dbgsym --exclude libssh2
+	dh_strip --no-automatic-dbgsym -X libssh2 -X libssh -X libgssapi_krb5 -X libcrypto -X libkrb5 -X libk5crypto
 
 override_dh_shlibdeps:
-	dh_shlibdeps -l$(CURDIR)/$(SSH2_LIBS_SUFFIX)
+	dh_shlibdeps -l$(CURDIR)/$(SSH2_LIBS_SUFFIX):$(CURDIR)/$(SSH_LIBS_SUFFIX)
 
 override_dh_gencontrol:
 	dh_gencontrol -- -v$(PACKAGEVERSION)

--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -336,7 +336,7 @@ def get_node_tokens(node_fqdn, token_map_file):
     token = token_map[node_fqdn]['tokens']
 
     # if vnodes, then the tokens come as an iterable
-    if isinstance(token, collections.Iterable):
+    if isinstance(token, collections.abc.Iterable):
         return list(map(str, token))
     # if there is only a single token, the token might show up as one integer
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@ pycryptodome>=3.9.9
 retrying>=1.3.3
 # ssh2-python==0.20.0 is broken, 0.22.0+ should work.
 ssh2-python==0.19.0
-parallel-ssh==1.9.1
+ssh-python>=0.6.0
+parallel-ssh==1.13.0
 requests==2.22.0
 wheel>=0.32.0
 gevent

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@
 
 import setuptools
 
-
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
@@ -54,8 +53,9 @@ setuptools.setup(
         'cryptography<=3.3.2,>=2.5',
         'pycryptodome>=3.9.9',
         'retrying>=1.3.3',
-        'parallel-ssh==1.9.1',
+        'parallel-ssh==1.13.0',
         'ssh2-python==0.19.0',  # <-- ssh2-python==0.20.0 is broken, 0.22.0+ should work.
+        'ssh-python>=0.6.0',
         'requests==2.22.0',
         'protobuf>=3.12.0',
         'grpcio>=1.29.0',

--- a/tests/storage_test.py
+++ b/tests/storage_test.py
@@ -155,7 +155,7 @@ class RestoreNodeTest(unittest.TestCase):
             # compute checksum of the whole file at once
             tf.seek(0)
             checksum_full = hashlib.md5(tf.read()).digest()
-            digest_full = base64.encodestring(checksum_full).decode('UTF-8').strip()
+            digest_full = base64.encodebytes(checksum_full).decode('UTF-8').strip()
 
             # compute checksum using default-size chunks
             tf.seek(0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}
+envlist = py{36,37,38,39}
 
 [testenv] 
 deps =


### PR DESCRIPTION
### Updated requirements to support python 3.9

Updated parallel-ssh to 1.13.0 as parallel-ssh==1.9.1 failed to build under python 3.9 with following error:
```bash
pssh/native/_ssh2.c:2906:68: error: ‘PyTypeObject {aka struct _typeobject}’ has no member named ‘tp_print’; did you mean ‘tp_dict’?
     __pyx_type_4pssh_6native_5_ssh2___pyx_scope_struct___read_output.tp_print = 0;
                                                                      ^~~~~~~~
                                                                      tp_dic
```

### Corrected incompatibility in tests/storage_test.py and warning in medusa/restore_node.py