### PR TITLE
Fix deprecation warnings

### DIFF
--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -336,7 +336,7 @@ def get_node_tokens(node_fqdn, token_map_file):
     token = token_map[node_fqdn]['tokens']
 
     # if vnodes, then the tokens come as an iterable
-    if isinstance(token, collections.Iterable):
+    if isinstance(token, collections.abc.Iterable):
         return list(map(str, token))
     # if there is only a single token, the token might show up as one integer
     else:

--- a/tests/storage_test.py
+++ b/tests/storage_test.py
@@ -155,7 +155,7 @@ class RestoreNodeTest(unittest.TestCase):
             # compute checksum of the whole file at once
             tf.seek(0)
             checksum_full = hashlib.md5(tf.read()).digest()
-            digest_full = base64.encodestring(checksum_full).decode('UTF-8').strip()
+            digest_full = base64.encodebytes(checksum_full).decode('UTF-8').strip()
 
             # compute checksum using default-size chunks
             tf.seek(0)


### PR DESCRIPTION
Fix the following warnings:

```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
```

```
DeprecationWarning: encodestring() is a deprecated alias since 3.1, use encodebytes()
```