### PR TITLE
Fix unit tests

### DIFF
--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # Copyright 2019 Spotify AB. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/usr/bin/env bash
 set -x
 # Keep the following rm for the sake of running the integration tests in CI
 rm -Rf .python-version

--- a/tests/storage_test_with_prefix.py
+++ b/tests/storage_test_with_prefix.py
@@ -24,7 +24,7 @@ import unittest
 
 import medusa.storage.abstract_storage
 
-from medusa.backup_node import generate_md5_hash
+from medusa.storage.abstract_storage import AbstractStorage
 from medusa.config import MedusaConfig, StorageConfig, _namedtuple_from_dict, CassandraConfig
 from medusa.index import build_indices
 from medusa.storage import Storage
@@ -158,6 +158,7 @@ class RestoreNodeTest(unittest.TestCase):
             checksum_full = hashlib.md5(tf.read()).digest()
             digest_full = base64.encodestring(checksum_full).decode('UTF-8').strip()
 
+            generate_md5_hash = AbstractStorage.generate_md5_hash
             # compute checksum using default-size chunks
             tf.seek(0)
             digest_chunk = generate_md5_hash(tf.name)


### PR DESCRIPTION
- `./run_integration_tests.sh` can't be run because the shebang is not on the first line
- there is no `generate_md5_hash` symbol in `backup_node`