### PR TITLE
Properly cast ports to int type when checking if Cassandra is up

### DIFF
--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -623,7 +623,7 @@ def is_open(host, port):
         is_accessible = False
     finally:
         s.close()
-        return is_accessible
+    return is_accessible
 
 
 @retry(stop_max_attempt_number=5, wait_exponential_multiplier=5000, wait_exponential_max=120000)

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -340,15 +340,15 @@ class Cassandra(object):
 
     @property
     def storage_port(self):
-        return self._storage_port
+        return int(self._storage_port)
 
     @property
     def native_port(self):
-        return self._native_port
+        return int(self._native_port)
 
     @property
     def rpc_port(self):
-        return self._rpc_port
+        return int(self._rpc_port)
 
     class Snapshot(object):
         def __init__(self, parent, tag):

--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -204,7 +204,7 @@ def invoke_sstableloader(config, download_dir, keep_auth, fqtns_to_restore, stor
                                           os.path.join(ks_path, table)]
                     if storage_port != "7000":
                         sstableloader_args.append("--storage-port")
-                        sstableloader_args.append(storage_port)
+                        sstableloader_args.append(str(storage_port))
                     if config.cassandra.sstableloader_ts is not None and \
                        config.cassandra.sstableloader_tspw is not None and \
                        config.cassandra.sstableloader_ks is not None and \


### PR DESCRIPTION
Replaces #320
Adds the fix for the sstableloader calls from #319 