### PR TITLE
Move from Bintray to Cloudsmith

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
           fi
         fi
 
-  release-debian:
+  publish-debian:
     # We can only release if the build above succeeded first
     needs: [debian-build, build, integration-tests]
     if: github.event_name == 'release' && github.event.action == 'published'
@@ -222,41 +222,27 @@ jobs:
         sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
         sudo chmod +x /usr/local/bin/docker-compose
         sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
-    - name: Build and Upload Debian
-      env:
-        BINTRAY_USERNAME: ${{ secrets.BINTRAY_USERNAME }}
-        BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
+    - name: Build Debian
       run: |
         version=$(cat VERSION)
+        echo "VERSION=$version" >> $GITHUB_ENV
         cd packaging/docker-build
         docker-compose build "cassandra-medusa-builder-${{ matrix.suite }}" \
             && docker-compose run "cassandra-medusa-builder-${{ matrix.suite }}"
         
-        cd ../..
-        if [ -f "packages/cassandra-medusa_${version}-0~${{ matrix.suite }}0_amd64.deb" ]; then
-          echo "uploading packages/cassandra-medusa_${version}-0~${{ matrix.suite }}0_amd64.deb from ${{ matrix.suite }} to Bintray"
-          curl -T "packages/cassandra-medusa_${version}-0~${{ matrix.suite }}0_amd64.deb" \
-            -u${BINTRAY_USERNAME}:${BINTRAY_KEY} \
-            -H X-Bintray-Debian-Distribution:${{ matrix.suite }} -H X-Bintray-Debian-Component:main -H X-Bintray-Debian-Architecture:amd64 -H X-Bintray-Version:${version} \
-            https://api.bintray.com/content/thelastpickle/medusa-deb/cassandra-medusa/${version}/cassandra-medusa_${version}-0~${{ matrix.suite }}0_amd64.deb
-        else
-          echo "Error: no packages found for ${{ matrix.suite }}"
-        fi
-  
-  publish-debian:
-    needs: [release-debian]
-    if: github.event_name == 'release' && github.event.action == 'published'
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: Publish Debian version
-      env:
-        BINTRAY_USERNAME: ${{ secrets.BINTRAY_USERNAME }}
-        BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
-      run: |
-        version=$(cat VERSION)
-        echo "Publishing release ${version} in Bintray"
-        curl -X POST -u${BINTRAY_USERNAME}:${BINTRAY_KEY} https://api.bintray.com/content/thelastpickle/medusa-deb/cassandra-medusa/${version}/publish
+    - name: Push Debian to Cloudsmith
+      id: push-deb
+      uses: cloudsmith-io/action@master
+      with:
+        api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+        command: 'push'
+        format: 'deb'
+        owner: 'thelastpickle'
+        repo: 'medusa'
+        distro: 'ubuntu'
+        release: ${{ matrix.suite }}
+        republish: 'true'
+        file: "packages/cassandra-medusa_${{ env.VERSION }}-0~${{ matrix.suite }}0_amd64.deb"
 
   publish-docker:
     needs: [publish-debian]

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
 # limitations under the License.
 -->
 
+[![Build Status](https://github.com/thelastpickle/cassandra-medusa/actions/workflows/ci.yaml/badge.svg?branch=master)](https://github.com/thelastpickle/cassandra-medusa/actions?query=branch%3Amaster)
+
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=flat-square)](https://cloudsmith.io/~thelastpickle/repos/medusa/packages/)
+
 Medusa for Apache Cassandra&trade;
 ==================================
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -8,6 +8,7 @@ Choose and initialize the storage system:
 * [Ceph Object Gateway S3 API](/docs/ceph_s3_setup.md)
 * [Azure Blob Storage setup](/docs/azure_blobs_setup.md)
 * [IBM Cloud Object Storage setup](/docs/ibm_cloud_setup.md)
+* [MinIO/S3 compatible Storage setup](/docs/minio_setup.md)
 
 Install Medusa on each Cassandra node using one of the following methods.
 
@@ -15,7 +16,7 @@ Install Medusa on each Cassandra node using one of the following methods.
 ### Online installation
 
 * if the storage backend is a locally accessible shared storage, run `sudo pip3 install cassandra-medusa`
-* if your backups are to be stored in AWS S3, IBM Cloud Object Storage or CEPH, run `sudo pip3 install cassandra-medusa[S3]`
+* if your backups are to be stored in AWS S3 or S3 compatible backends (IBM, OVHCloud, MinIO, ...), run `sudo pip3 install cassandra-medusa[S3]`
 * if your backups are to be stored in Google Cloud Storage, run `sudo pip3 install cassandra-medusa[GCS]`
 * if your backups are to be stored in Azure Blob Storage, run `sudo pip3 install cassandra-medusa[AZURE]`
 
@@ -45,27 +46,19 @@ If your Cassandra servers do not have internet access:
 
 ## Debian packages
 ### Using apt-get
-1/ Using the command line, add the following to your /etc/apt/sources.list system config file:
+1/ Using the command line, run the following:
 
 ```
-echo "deb https://dl.bintray.com/thelastpickle/medusa-deb bionic main" | sudo tee -a /etc/apt/sources.list
+curl -1sLf \
+  'https://dl.cloudsmith.io/public/thelastpickle/medusa/setup.deb.sh' \
+  | sudo -E bash
 ```
 
-Note: since Medusa 0.8 we publish releases for `xenial`, `stretch`, `bionic` and `focal`.
+In case of problem, read the full instructions on the [cloudsmith.io documentation](https://cloudsmith.io/~thelastpickle/repos/medusa/setup/#formats-deb)
 
-Or, add the repository URLs using the “Software Sources” admin UI:
+*Note: since Medusa 0.9 we publish releases for Ubuntu `bionic` and `focal` only.*
 
-```
-deb https://dl.bintray.com/thelastpickle/medusa-deb bionic main
-```
-
-2/ Install the public key:
-
-```
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 2895100917357435
-```
-
-3/ Install Medusa :
+2/ Install Medusa :
 
 ```
 sudo apt-get update
@@ -74,6 +67,6 @@ sudo apt-get install cassandra-medusa
 
 4/ (optional) Install the storage dependencies
 
-* if your backups are to be stored in AWS S3, IBM Cloud Object Storage or CEPH, run `sudo apt-get install awscli`
+* if your backups are to be stored in AWS S3 and all S3 compatible backends, run `sudo apt-get install awscli`
 * if your backups are to be stored in Azure Blob Storage, run `sudo apt-get install azure-cli`
 * if your backups are to be stored in Google Cloud Storage, [follow this quickstart guide from Google](https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu).

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -18,7 +18,9 @@ Options:
   --help                   Show this message and exit.
 
 Commands:
-  backup                          Backup Cassandra
+  backup-cluster                  Backup Cassandra on the whole cluster
+  backup                          Backup Cassandra on the current node
+  backup-node                     Backup Cassandra on the current node
   build-index                     Builds indices for all present backups
                                   and...
   download                        Download backup

--- a/docs/ibm_cloud_setup.md
+++ b/docs/ibm_cloud_setup.md
@@ -9,7 +9,7 @@ Create a new object storage bucket that will be used to store the backups using 
 aws --profile default --endpoint-url https://s3.us.cloud-object-storage.appdomain.cloud s3api create-bucket --bucket <bucket name> --create-bucket-configuration LocationConstraint=us-smart
 ```
 
-The endpoint URLs and their corresponding location constraints can be found [here](https://github.com/thelastpickle/cassandra-medusa/blob/master/medusa/libcloud/storage/drivers/ibm.py#L27-L123). Medusa was tested against `smart` storage geo replicated buckets only.
+The endpoint URLs and their corresponding location constraints can be found [here](https://github.com/thelastpickle/cassandra-medusa/blob/v0.8.1/medusa/libcloud/storage/drivers/ibm.py#L28-L123). Medusa was tested against `smart` storage geo replicated buckets only.
 
 ### Create a service credential
 
@@ -48,11 +48,16 @@ Place this file on all Apache Cassandra™ nodes running medusa under `/etc/medu
 Set the `key_file` value in the `[storage]` section of `/etc/medusa/medusa.ini` to the credentials file:  
 
 ```
+[storage]
+storage_provider = s3_compatible
 bucket_name = <bucket name>
 key_file = /etc/medusa/medusa-ibm-credentials
-region = us-smart
+; replace the following with your bucket's region and host
+region = eu-smart
+host = s3.eu.cloud-object-storage.appdomain.cloud
+secure = True
 ```
 
-Note: adjust the region in the `medusa.ini` file to match your bucket's location constraint.
+Note: adjust bucket_name and the host/region settings in the `medusa.ini` file to match your bucket's location constraint.
 
 Medusa should now be able to access the bucket and perform all required operations.

--- a/docs/minio_setup.md
+++ b/docs/minio_setup.md
@@ -1,0 +1,32 @@
+MinIO Storage setup (and other S3 compatible backends)
+======================================================
+
+### Create a bucket
+
+Create a new storage bucket in MinIO that will be used to store the backups.
+
+### Configure Medusa
+
+Copy your MinIO access credentials in a file called `medusa-minio-credentials` using the following format:
+
+```
+[default]
+aws_access_key_id = <access_key_id>
+aws_secret_access_key = <secret_access_key>
+```
+
+Place this file on all Apache Cassandra™ nodes running medusa under `/etc/medusa` and set the rights appropriately so that only users running Medusa can read/modify it.
+Set the `key_file` value in the `[storage]` section of `/etc/medusa/medusa.ini` to the credentials file:  
+
+```
+[storage]
+storage_provider = s3_compatible
+bucket_name = <bucket name>
+key_file = /etc/medusa/medusa-minio-credentials
+host = <minio host>
+port = <minio API port, default is 9000>
+secure = False
+```
+
+Medusa should now be able to access the bucket and perform all required operations.
+*Note: MinIO and other self hosted S3 compatible storage systems can only be used in unsecured (non SSL) mode with Medusa due to limitations in Apache Libcloud. Cloud hosted S3 compatible backends (such as IBM) should be able/require to use secured access.*

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -433,7 +433,8 @@ def i_am_using_storage_provider(context, storage_provider, client_encryption):
             "aws_cli_path": "aws",
             "host": "s3.eu.cloud-object-storage.appdomain.cloud",
             "region": "eu-smart",
-            "transfer_max_bandwidth": "1MB/s"
+            "transfer_max_bandwidth": "1MB/s",
+            "secure": True
         }
 
     config["cassandra"] = {


### PR DESCRIPTION
Bintray closing down on May 1st, we're moving the debian packages hosting to cloudsmith.io.

In this PR I've updated the documentations for:

- Installation instructions using the cloudsmith repo
- Fixing inaccuracies in setting up the IBM object storage backend
- Adding information on how to setup MinIO and other S3 compatible backends

There's also a fix for the IBM object storage integration tests.