### PR TITLE
Ensure each setting can be overridden

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -18,30 +18,57 @@ import pathlib
 import unittest
 
 import medusa.config
+import medusa.utils
 
 
-class RestoreNodeTest(unittest.TestCase):
+class ConfigTest(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+    def setUp(self):
+        self.medusa_config_file = pathlib.Path(__file__).parent / "resources/config/medusa.ini"
+
     def test_no_auth_env_variables(self):
+        """Ensure that CQL credentials in config file are honored"""
         os.environ.pop("CQL_USERNAME")
         os.environ.pop("CQL_PASSWORD")
-        medusa_config_file = pathlib.Path(__file__).parent / "resources/config/medusa.ini"
         args = {}
-        config = medusa.config.load_config(args, medusa_config_file)
+        config = medusa.config.load_config(args, self.medusa_config_file)
         assert config.cassandra.cql_username == "test_username"
         assert config.cassandra.cql_password == "test_password"
 
     def test_different_auth_env_variables(self):
+        """Ensure that CQL credentials env vars have an higher priority than config file"""
         os.environ["CQL_USERNAME"] = "different_username"
         os.environ["CQL_PASSWORD"] = "different_password"
-        medusa_config_file = pathlib.Path(__file__).parent / "resources/config/medusa.ini"
         args = {}
-        config = medusa.config.load_config(args, medusa_config_file)
+        config = medusa.config.load_config(args, self.medusa_config_file)
         assert config.cassandra.cql_username == "different_username"
         assert config.cassandra.cql_password == "different_password"
+
+    def test_args_settings_override(self):
+        """Ensure that each config file's section settings can be overridden with command line options"""
+        args = {
+            'bucket_name': 'Hector',
+            'cql_username': 'Priam',
+            'enabled': 'True',  # FIXME collision: grpc or kubernetes
+            'file': 'hera.log',
+            'monitoring_provider': 'local',
+            'query': 'SELECT * FROM greek_mythology',
+            'use_mgmt_api': 'True',
+            'username': 'Zeus',
+        }
+        config = medusa.config.load_config(args, self.medusa_config_file)
+        assert config.storage.bucket_name == 'Hector'
+        assert config.cassandra.cql_username == 'Priam'
+        assert medusa.utils.evaluate_boolean(config.grpc.enabled)  # FIXME collision
+        assert medusa.utils.evaluate_boolean(config.kubernetes.enabled)  # FIXME collision
+        assert config.logging.file == 'hera.log'
+        assert config.monitoring.monitoring_provider == 'local'
+        assert config.checks.query == 'SELECT * FROM greek_mythology'
+        assert medusa.utils.evaluate_boolean(config.kubernetes.use_mgmt_api)
+        assert config.ssh.username == 'Zeus'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Code was missing `[cassandra]` settings override => Make configuration file override more generic
- :warning: Collision found during testing:
  - settings are not namespaced in `args` dictionary, so `'enabled'` [is valid](https://github.com/thelastpickle/cassandra-medusa/pull/333/files#diff-698607b1b71bd82ba3f9bc12a10e05bba41fe2bfbfc35d5f6f79bdb69c9353e7R55) for both `[grpc]` and `[kubernetes]` section settings.
  - this PR does not aim to fix such collisions