### PR TITLE
Fix S3 compatible backend uploads when no region is specified

### DIFF
--- a/medusa/storage/s3_compat_storage/awscli.py
+++ b/medusa/storage/s3_compat_storage/awscli.py
@@ -109,7 +109,7 @@ class AwsCli(object):
 
         if self._config.region is not None and self._config.region != "default":
             cmd.extend(["--region", self._config.region])
-        elif self._config.storage_provider != Provider.S3 and self._config.region == "default":
+        elif not (self._config.storage_provider in [Provider.S3, "s3_compatible"]) and self._config.region == "default":
             # Legacy libcloud S3 providers that were tied to a specific region such as s3_us_west_oregon
             cmd.extend(["--region", get_driver(self._config.storage_provider).region_name])
 

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -414,7 +414,8 @@ def i_am_using_storage_provider(context, storage_provider, client_encryption):
             "aws_cli_path": "aws",
             "host": "localhost",
             "port": 9000,
-            "secure": False
+            "secure": False,
+            "region": "default"
         }
     elif storage_provider.startswith("ibm"):
         config["storage"] = {


### PR DESCRIPTION
Fixes #335

When using the default region settings with the `s3_compatible`  storage backend, Medusa would try to get the region from libcloud in order to provide backwards compatibility with the old region specific libcloud S3 storage providers. This would obviously fail as `s3_compatible` is not a valid libcloud storage provider.

This PR fixes this by excluding the `s3_compatible` storage provider from the region resolving path and makes it so that Minio integration tests prevent regressions.