### PR TITLE
Add exponential waits in retries for awscli

### DIFF
--- a/medusa/storage/s3_compat_storage/awscli.py
+++ b/medusa/storage/s3_compat_storage/awscli.py
@@ -25,6 +25,7 @@ from retrying import retry
 from libcloud.storage.providers import get_driver, Provider
 from medusa import utils
 
+MAX_UP_DOWN_LOAD_RETRIES = 5
 
 class AwsCli(object):
     def __init__(self, storage):
@@ -115,7 +116,7 @@ class AwsCli(object):
 
         return cmd
 
-    @retry(stop_max_attempt_number=5, wait_fixed=5000)
+    @retry(stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES, wait_exponential_multiplier=10000, wait_exponential_max=120000)
     def upload_file(self, cmd, dest, awscli_output):
         logging.debug(" ".join(cmd))
         with open(awscli_output, "w") as output:
@@ -139,7 +140,7 @@ class AwsCli(object):
             )
         )
 
-    @retry(stop_max_attempt_number=5, wait_fixed=5000)
+    @retry(stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES, wait_exponential_multiplier=10000, wait_exponential_max=120000)
     def download_file(self, cmd, dest, awscli_output):
         logging.debug(" ".join(cmd))
         with open(awscli_output, "w") as output:
@@ -162,7 +163,7 @@ class AwsCli(object):
             )
         )
 
-    @retry(stop_max_attempt_number=10, wait_fixed=1000)
+    @retry(stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES, wait_exponential_multiplier=10000, wait_exponential_max=120000)
     def get_blob(self, blob_name):
         # This needs to be retried as S3 is eventually consistent
         obj = self.storage.get_blob(blob_name)

--- a/medusa/storage/s3_compat_storage/awscli.py
+++ b/medusa/storage/s3_compat_storage/awscli.py
@@ -27,6 +27,7 @@ from medusa import utils
 
 MAX_UP_DOWN_LOAD_RETRIES = 5
 
+
 class AwsCli(object):
     def __init__(self, storage):
         self._config = storage.config
@@ -116,7 +117,9 @@ class AwsCli(object):
 
         return cmd
 
-    @retry(stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES, wait_exponential_multiplier=10000, wait_exponential_max=120000)
+    @retry(
+        stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES,
+        wait_exponential_multiplier=10000, wait_exponential_max=120000)
     def upload_file(self, cmd, dest, awscli_output):
         logging.debug(" ".join(cmd))
         with open(awscli_output, "w") as output:
@@ -140,7 +143,9 @@ class AwsCli(object):
             )
         )
 
-    @retry(stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES, wait_exponential_multiplier=10000, wait_exponential_max=120000)
+    @retry(
+        stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES,
+        wait_exponential_multiplier=10000, wait_exponential_max=120000)
     def download_file(self, cmd, dest, awscli_output):
         logging.debug(" ".join(cmd))
         with open(awscli_output, "w") as output:
@@ -163,7 +168,9 @@ class AwsCli(object):
             )
         )
 
-    @retry(stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES, wait_exponential_multiplier=10000, wait_exponential_max=120000)
+    @retry(
+        stop_max_attempt_number=MAX_UP_DOWN_LOAD_RETRIES,
+        wait_exponential_multiplier=10000, wait_exponential_max=120000)
     def get_blob(self, blob_name):
         # This needs to be retried as S3 is eventually consistent
         obj = self.storage.get_blob(blob_name)


### PR DESCRIPTION
I've experienced recently upload issues using s3 as storage backend. This is the traceback:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/medusa/backup_node.py", line 211, in main
    cassandra, node_backup, storage, differential_mode, enable_md5, config, backup_name)
  File "/usr/local/lib/python3.7/site-packages/medusa/backup_node.py", line 261, in do_backup
    num_files = backup_snapshots(storage, manifest, node_backup, node_backup_cache, snapshot)
  File "/usr/local/lib/python3.7/site-packages/medusa/backup_node.py", line 347, in backup_snapshots
    raise e
  File "/usr/local/lib/python3.7/site-packages/medusa/backup_node.py", line 335, in backup_snapshots
    manifest_objects += storage.storage_driver.upload_blobs(src_batch, dst_path)
  File "/usr/local/lib/python3.7/site-packages/medusa/storage/s3_base_storage.py", line 102, in upload_blobs
    multi_part_upload_threshold=int(self.config.multi_part_upload_threshold),
  File "/usr/local/lib/python3.7/site-packages/medusa/storage/s3_compat_storage/concurrent.py", line 87, in upload_blobs
    return job.execute(list(src))
  File "/usr/local/lib/python3.7/site-packages/medusa/storage/s3_compat_storage/concurrent.py", line 51, in execute
    return list(executor.map(self.with_storage, iterables))
  File "/usr/lib64/python3.7/concurrent/futures/_base.py", line 598, in result_iterator
    yield fs.pop().result()
  File "/usr/lib64/python3.7/concurrent/futures/_base.py", line 435, in result
    return self.__get_result()
  File "/usr/lib64/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/usr/lib64/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.7/site-packages/medusa/storage/s3_compat_storage/concurrent.py", line 60, in with_storage
    return self.func(self.storage, connection, iterable)
  File "/usr/local/lib/python3.7/site-packages/medusa/storage/s3_compat_storage/concurrent.py", line 83, in <lambda>
    storage, connection, src_file, dest, bucket, multi_part_upload_threshold
  File "/usr/local/lib/python3.7/site-packages/medusa/storage/s3_compat_storage/concurrent.py", line 116, in __upload_file
    obj = _upload_multi_part(storage, connection, src, bucket, full_object_name)
  File "/usr/local/lib/python3.7/site-packages/medusa/storage/s3_compat_storage/concurrent.py", line 135, in _upload_multi_part
    objects = awscli.cp_upload(srcs=[src], bucket_name=bucket.name, dest=object_name)
  File "/usr/local/lib/python3.7/site-packages/medusa/storage/s3_compat_storage/awscli.py", line 90, in cp_upload
    objects.append(self.upload_file(cmd, dest, awscli_output))
  File "/usr/local/lib/python3.7/site-packages/retrying.py", line 49, in wrapped_f
    return Retrying(*dargs, **dkw).call(f, *args, **kw)
  File "/usr/local/lib/python3.7/site-packages/retrying.py", line 212, in call
    raise attempt.get()
  File "/usr/local/lib/python3.7/site-packages/retrying.py", line 247, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/usr/local/lib/python3.7/site-packages/six.py", line 703, in reraise
    raise value
  File "/usr/local/lib/python3.7/site-packages/retrying.py", line 200, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/usr/local/lib/python3.7/site-packages/medusa/storage/s3_compat_storage/awscli.py", line 132, in upload_file
    obj = self.get_blob(dest)
  File "/usr/local/lib/python3.7/site-packages/retrying.py", line 49, in wrapped_f
    return Retrying(*dargs, **dkw).call(f, *args, **kw)
  File "/usr/local/lib/python3.7/site-packages/retrying.py", line 212, in call
    raise attempt.get()
  File "/usr/local/lib/python3.7/site-packages/retrying.py", line 247, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/usr/local/lib/python3.7/site-packages/six.py", line 703, in reraise
    raise value
  File "/usr/local/lib/python3.7/site-packages/retrying.py", line 200, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/usr/local/lib/python3.7/site-packages/medusa/storage/s3_compat_storage/awscli.py", line 170, in get_blob
    raise IOError("Failed to find uploaded object {} in S3".format(blob_name))
OSError: Failed to find uploaded object cassandra-production-us-east-1/ip-10-19-12-19.ec2.internal/data/convertkit/record_entries-05ee9c405d1911e9abd40513aa198e3c/mc-2329-big-Data.db in S3
```

This happened when a new fresh node joins the cluster and has to perform the first full backup. After some hours running it stops with this error. I've tested it with the wait exponential settings in this PR in 3 different nodes and it worked like a charm. I think this is the last missing piece to reduce all the s3 flakiness.