### PR TITLE
Use custom config file when restoring data

### DIFF
--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -40,7 +40,7 @@ class CassandraUtilsTest(unittest.TestCase):
             'host_file_separator': ','
         }
         config['cassandra'] = {
-            'resolve_ip_addresses': False
+            'resolve_ip_addresses': 'False'
         }
         config["grpc"] = {
             "enabled": "0"
@@ -49,6 +49,7 @@ class CassandraUtilsTest(unittest.TestCase):
             "enabled": "0"
         }
         self.config = MedusaConfig(
+            file_path=None,
             storage=_namedtuple_from_dict(StorageConfig, config['storage']),
             monitoring={},
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
@@ -149,6 +150,7 @@ class CassandraUtilsTest(unittest.TestCase):
             "enabled": "0"
         }
         medusa_config = MedusaConfig(
+            file_path=None,
             storage=None,
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
@@ -178,6 +180,7 @@ class CassandraUtilsTest(unittest.TestCase):
             "enabled": "0"
         }
         medusa_config = MedusaConfig(
+            file_path=None,
             storage=None,
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
@@ -209,6 +212,7 @@ class CassandraUtilsTest(unittest.TestCase):
             "enabled": "0"
         }
         medusa_config = MedusaConfig(
+            file_path=None,
             storage=None,
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
@@ -241,6 +245,7 @@ class CassandraUtilsTest(unittest.TestCase):
             "enabled": "0"
         }
         medusa_config = MedusaConfig(
+            file_path=None,
             storage=None,
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
@@ -279,6 +284,7 @@ class CassandraUtilsTest(unittest.TestCase):
             "enabled": "0"
         }
         medusa_config = MedusaConfig(
+            file_path=None,
             storage=None,
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
@@ -318,6 +324,7 @@ class CassandraUtilsTest(unittest.TestCase):
             "enabled": "0"
         }
         medusa_config = MedusaConfig(
+            file_path=None,
             storage=None,
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
@@ -356,6 +363,7 @@ class CassandraUtilsTest(unittest.TestCase):
             "enabled": "0"
         }
         medusa_config = MedusaConfig(
+            file_path=None,
             storage=None,
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
@@ -395,6 +403,7 @@ class CassandraUtilsTest(unittest.TestCase):
             "enabled": "0"
         }
         medusa_config = MedusaConfig(
+            file_path=None,
             storage=None,
             monitoring=None,
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),

--- a/tests/filtering_test.py
+++ b/tests/filtering_test.py
@@ -32,6 +32,7 @@ class FilteringTest(unittest.TestCase):
             'host_file_separator': ','
         }
         self.config = MedusaConfig(
+            file_path=None,
             storage=_namedtuple_from_dict(StorageConfig, config['storage']),
             monitoring={},
             cassandra=None,

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -488,6 +488,7 @@ def i_am_using_storage_provider(context, storage_provider, client_encryption):
     }
 
     context.medusa_config = MedusaConfig(
+        file_path=None,
         storage=_namedtuple_from_dict(StorageConfig, config["storage"]),
         cassandra=_namedtuple_from_dict(CassandraConfig, config["cassandra"]),
         monitoring=_namedtuple_from_dict(MonitoringConfig, config["monitoring"]),
@@ -514,6 +515,7 @@ def i_am_using_storage_provider_with_grpc_server(context, storage_provider, clie
     )
 
     context.medusa_config = MedusaConfig(
+        file_path=None,
         storage=_namedtuple_from_dict(StorageConfig, config["storage"]),
         cassandra=_namedtuple_from_dict(CassandraConfig, config["cassandra"]),
         monitoring=_namedtuple_from_dict(MonitoringConfig, config["monitoring"]),
@@ -547,6 +549,7 @@ def i_am_using_storage_provider_with_grpc_server_and_mgmt_api(context, storage_p
     context.mgmt_api_server = MgmtApiServer.init(config, context.cluster_name)
 
     context.medusa_config = MedusaConfig(
+        file_path=None,
         storage=_namedtuple_from_dict(StorageConfig, config["storage"]),
         cassandra=_namedtuple_from_dict(CassandraConfig, config["cassandra"]),
         monitoring=_namedtuple_from_dict(MonitoringConfig, config["monitoring"]),
@@ -1289,6 +1292,7 @@ def _i_can_verify_the_restore_verify_query_returned_rows(context, query, expecte
         "expected_rows": expected_rows,
     }
     custom_config = MedusaConfig(
+        file_path=None,
         storage=context.medusa_config.storage,
         cassandra=context.medusa_config.cassandra,
         monitoring=context.medusa_config.monitoring,

--- a/tests/purge_test.py
+++ b/tests/purge_test.py
@@ -40,6 +40,7 @@ class PurgeTest(unittest.TestCase):
             'bucket_name': 'purge_test'
         }
         self.config = MedusaConfig(
+            file_path=None,
             storage=_namedtuple_from_dict(StorageConfig, config['storage']),
             monitoring={},
             cassandra=None,

--- a/tests/restore_node_test.py
+++ b/tests/restore_node_test.py
@@ -31,6 +31,7 @@ class RestoreNodeTest(unittest.TestCase):
             'host_file_separator': ','
         }
         self.config = MedusaConfig(
+            file_path=None,
             storage=_namedtuple_from_dict(StorageConfig, config['storage']),
             monitoring={},
             cassandra=None,

--- a/tests/storage_test.py
+++ b/tests/storage_test.py
@@ -59,6 +59,7 @@ class RestoreNodeTest(unittest.TestCase):
         }
 
         self.config = MedusaConfig(
+            file_path=None,
             storage=_namedtuple_from_dict(StorageConfig, config['storage']),
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             monitoring={},

--- a/tests/storage_test_with_prefix.py
+++ b/tests/storage_test_with_prefix.py
@@ -60,6 +60,7 @@ class RestoreNodeTest(unittest.TestCase):
         }
 
         self.config = MedusaConfig(
+            file_path=None,
             storage=_namedtuple_from_dict(StorageConfig, config['storage']),
             cassandra=_namedtuple_from_dict(CassandraConfig, config['cassandra']),
             monitoring={},


### PR DESCRIPTION
Close #352

To persist a custom (i.e. non default) configuration file path, a new attribute is added to `MedusaConfig`. It's not a section like the others but it allows to be self contained.
A `file_path` set to `None` means default configuration file path so we can skip the whole `--config-file ...` part when building restore command.

Unit tests added to test both default and custom configuration file path in command line.
Existing tests migrated to pytest.