### PR TITLE
fix hostname_resolver.resolve_fqdn when resolve_ip_addresses is False

### DIFF
--- a/medusa/network/hostname_resolver.py
+++ b/medusa/network/hostname_resolver.py
@@ -17,16 +17,17 @@ import socket
 import logging
 
 
-class HostnameResolver():
-    def __init__(self, resolve_addresses=True):
+class HostnameResolver:
+    def __init__(self, resolve_addresses):
         self.resolve_addresses = resolve_addresses
-        logging.debug
 
     def resolve_fqdn(self, ip_address=''):
-        if str(self.resolve_addresses) == "False":
-            logging.debug("Not resolving {} as requested".format(ip_address))
-            return ip_address
+        ip_address_to_resolve = ip_address if ip_address != '' else socket.gethostbyname(socket.getfqdn())
 
-        fqdn = socket.getfqdn(ip_address)
-        logging.debug("Resolved {} to {}".format(ip_address, fqdn))
+        if str(self.resolve_addresses) == "False":
+            logging.debug("Not resolving {} as requested".format(ip_address_to_resolve))
+            return ip_address_to_resolve
+
+        fqdn = socket.getfqdn(ip_address_to_resolve)
+        logging.debug("Resolved {} to {}".format(ip_address_to_resolve, fqdn))
         return fqdn


### PR DESCRIPTION
During a restore-cluster, when `resolve_ip_addresses` is set to `False`, an empty string is passed to the hostname_resolver which returns this empty string instead of the IP address.

This causes the restore to fail, since sstableloader has then no argument to pass 
```
/opt/cassandra/default/bin/sstableloader', '-d', '',
```

Also I make some parameters mandatory to make sure that medusa behaves as configured (all calls in the codebase do have  those options so it should not break the current behaviors)