### PR TITLE
Add codecov config file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  precision: 2
+  round: down
+  range: "63...100"
+  notify:
+    after_n_builds: 17
+    wait_for_ci: yes
+  status:
+    project:
+    patch:
+    changes:
+  comment:
+    layout: "reach, diff, flags, files"
+    behavior: default
+    require_changes: false  # if true: only post the comment if coverage changes
+    after_n_builds: 17


### PR DESCRIPTION
To avoid comments to be sent from codecov too early and acknowledge that external PRs can't run some integration tests, this PR adds a codecov config file that will adjust its behavior:

- reduce the expected test coverage to what we get when not running the cloud provider related tests
- wait for 17 ci parallel runs before issuing the report