### PR TITLE
add codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,15 +2,8 @@ coverage:
   precision: 2
   round: down
   range: "63...100"
-  notify:
-    after_n_builds: 17
-    wait_for_ci: yes
-  status:
-    project:
-    patch:
-    changes:
-  comment:
-    layout: "reach, diff, flags, files"
-    behavior: default
-    require_changes: false  # if true: only post the comment if coverage changes
-    after_n_builds: 17
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  after_n_builds: 17

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  precision: 2
+  round: down
+  range: "63...100"
+  notify:
+    after_n_builds: 17
+    wait_for_ci: yes
+  status:
+    project:
+    patch:
+    changes:
+  comment:
+    layout: "reach, diff, flags, files"
+    behavior: default
+    require_changes: false  # if true: only post the comment if coverage changes
+    after_n_builds: 17

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,12 @@ coverage:
   precision: 2
   round: down
   range: "63...100"
+  status:
+    project:
+      default:
+        target: 63%
+        threshold: 6%
+        base: auto 
 comment:
   layout: "reach, diff, flags, files"
   behavior: default

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,8 @@ comment:
   behavior: default
   require_changes: false  # if true: only post the comment if coverage changes
   after_n_builds: 17
+codecov:
+  require_ci_to_pass: yes
+  notify:
+    after_n_builds: 17
+    wait_for_ci: yes


### PR DESCRIPTION
This PR will ensure that codecov won't try to evaluate coverage until all parallel CI runs are done, which would yield premature failures in the checks.
Also, since external PRs can't run the cloud integration tests, their coverage is reduced to ~64%. This change will allow the codecov check so succeed at 63% of coverage.