### PR TITLE
backup-cluster default name with timestamp

### DIFF
--- a/medusa/backup_cluster.py
+++ b/medusa/backup_cluster.py
@@ -28,9 +28,10 @@ from medusa.storage import Storage
 from medusa.network.hostname_resolver import HostnameResolver
 
 
-def orchestrate(config, backup_name, seed_target, stagger, enable_md5_checks, mode, temp_dir,
+def orchestrate(config, backup_name_arg, seed_target, stagger, enable_md5_checks, mode, temp_dir,
                 parallel_snapshots, parallel_uploads):
     backup = None
+    backup_name = backup_name_arg or datetime.datetime.now().strftime('%Y%m%d%H')
     monitoring = Monitoring(config=config.monitoring)
     try:
         backup_start_time = datetime.datetime.now()

--- a/medusa/backup_cluster.py
+++ b/medusa/backup_cluster.py
@@ -31,7 +31,7 @@ from medusa.network.hostname_resolver import HostnameResolver
 def orchestrate(config, backup_name_arg, seed_target, stagger, enable_md5_checks, mode, temp_dir,
                 parallel_snapshots, parallel_uploads):
     backup = None
-    backup_name = backup_name_arg or datetime.datetime.now().strftime('%Y%m%d%H')
+    backup_name = backup_name_arg or datetime.datetime.now().strftime('%Y%m%d%H%M')
     monitoring = Monitoring(config=config.monitoring)
     try:
         backup_start_time = datetime.datetime.now()

--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -158,7 +158,7 @@ def stagger(fqdn, storage, tokenmap):
 
 def main(config, backup_name_arg, stagger_time, enable_md5_checks_flag, mode):
     start = datetime.datetime.now()
-    backup_name = backup_name_arg or start.strftime('%Y%m%d%H')
+    backup_name = backup_name_arg or start.strftime('%Y%m%d%H%M')
     monitoring = Monitoring(config=config.monitoring)
 
     try:

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -131,7 +131,7 @@ def backup(medusaconfig, backup_name, stagger, enable_md5_checks, mode):
 
 
 @cli.command(name='backup-cluster')
-@click.option('--backup-name', help='Backup name', required=True)
+@click.option('--backup-name', help='Backup name of the backup, defaults to current local timestamp')
 @click.option('--seed-target', help='Seed of the target hosts. If not provided, \
     will default to the node where the command is triggered', required=False)
 @click.option('--stagger', default=None, type=int, help='Drop initial backups if longer than a duration in seconds')

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -131,7 +131,7 @@ def backup(medusaconfig, backup_name, stagger, enable_md5_checks, mode):
 
 
 @cli.command(name='backup-cluster')
-@click.option('--backup-name', help='Backup name of the backup, defaults to current local timestamp')
+@click.option('--backup-name', help='Backup name of the backup, defaults to current datetime (formatted "%Y%m%dT%H%M")')
 @click.option('--seed-target', help='Seed of the target hosts. If not provided, \
     will default to the node where the command is triggered', required=False)
 @click.option('--stagger', default=None, type=int, help='Drop initial backups if longer than a duration in seconds')


### PR DESCRIPTION
This makes the `backup-name` optional in the `backup-cluster` command.
I have followed what is done for the `backup-node` concerning the naming scheme 