### PR TITLE
Fix purge race condition

### DIFF
--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -73,6 +73,9 @@ concurrent_transfers = 1
 ; Size over which S3 uploads will be using the awscli with multi part uploads. Defaults to 100MB.
 multi_part_upload_threshold = 104857600
 
+; GC grace period for backed up files. Prevents race conditions between purge and running backups
+backup_grace_period_in_days = 10
+
 [monitoring]
 ;monitoring_provider = <Provider used for sending metrics. Currently either of "ffwd" or "local">
 

--- a/medusa/purge.py
+++ b/medusa/purge.py
@@ -43,7 +43,7 @@ def main(config, max_backup_age=0, max_backup_count=0):
         # list all backups to purge based on count conditions
         backups_to_purge |= set(backups_to_purge_by_count(backups, max_backup_count))
         # purge all candidate backups
-        purge_backups(storage, backups_to_purge)
+        purge_backups(storage, backups_to_purge, config.storage.backup_grace_period_in_days)
 
         logging.debug('Emitting metrics')
         tags = ['medusa-node-backup', 'purge-error', 'PURGE-ERROR']
@@ -83,7 +83,7 @@ def backups_to_purge_by_count(backups, max_backup_count):
 #     return list(filter(lambda backup: backup.name = backup_name, backups)) or list()
 
 
-def purge_backups(storage, backups):
+def purge_backups(storage, backups, backup_grace_period_in_days):
     """
     Core function to purge a set of node_backups
     Used for node purge and backup delete (using a specific backup_name)
@@ -100,7 +100,9 @@ def purge_backups(storage, backups):
         fqdns.add(backup.fqdn)
 
     for fqdn in fqdns:
-        (cleaned_objects_count, cleaned_objects_size) = cleanup_obsolete_files(storage, fqdn)
+        (cleaned_objects_count, cleaned_objects_size) = cleanup_obsolete_files(storage,
+                                                                               fqdn,
+                                                                               backup_grace_period_in_days)
         nb_objects_purged += cleaned_objects_count
         total_purged_size += cleaned_objects_size
 
@@ -128,14 +130,14 @@ def purge_backup(storage, backup):
     return (purged_objects, purged_size)
 
 
-def cleanup_obsolete_files(storage, fqdn):
+def cleanup_obsolete_files(storage, fqdn, backup_grace_period_in_days):
     logging.info("Cleaning up orphaned files for {}...".format(fqdn))
     nb_objects_purged = 0
     total_purged_size = 0
 
     backups = storage.list_node_backups(fqdn=fqdn)
     paths_in_manifest = get_file_paths_from_manifests_for_differential_backups(backups)
-    paths_in_storage = get_file_paths_from_storage(storage, fqdn)
+    paths_in_storage = get_file_paths_from_storage(storage, fqdn, backup_grace_period_in_days)
 
     for path in paths_in_storage - paths_in_manifest:
         logging.debug("  - [{}] exists in storage, but not in manifest".format(path))
@@ -148,14 +150,26 @@ def cleanup_obsolete_files(storage, fqdn):
     return nb_objects_purged, total_purged_size
 
 
-def get_file_paths_from_storage(storage, fqdn):
+def get_file_paths_from_storage(storage, fqdn, backup_grace_period_in_days):
     data_directory = "{}{}/data".format(storage.prefix_path, fqdn)
     data_files = {
         blob.name: blob
-        for blob in storage.storage_driver.list_objects(str(data_directory))
+        for blob in filter_files_within_gc_grace(storage.storage_driver,
+                                                 storage.storage_driver.list_objects(str(data_directory)),
+                                                 backup_grace_period_in_days)
     }
 
     return set(data_files.keys())
+
+
+def filter_files_within_gc_grace(storage_driver, blobs, backup_grace_period_in_days):
+    return list(
+        filter(lambda blob:
+               is_older_than_gc_grace(storage_driver.get_object_datetime(blob), backup_grace_period_in_days), blobs))
+
+
+def is_older_than_gc_grace(blob_datetime, gc_grace) -> bool:
+    return datetime.timestamp(blob_datetime) <= datetime.timestamp(datetime.now()) - (int(gc_grace) * 86400)
 
 
 def get_file_paths_from_manifests_for_differential_backups(backups):
@@ -195,7 +209,7 @@ def delete_backup(config, backup_name, all_nodes):
             backups_to_purge = [nb for nb in backups_to_purge if storage.config.fqdn in nb.fqdn]
 
         logging.info('Deleting Backup {}...'.format(backup_name))
-        purge_backups(storage, backups_to_purge)
+        purge_backups(storage, backups_to_purge, config.storage.backup_grace_period_in_days)
 
         logging.debug('Emitting metrics')
         tags = ['medusa-node-backup', 'delete-error', 'DELETE-ERROR']

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -383,7 +383,7 @@ Feature: Integration tests
         Then I cannot see the backup named "first_backup" when I list the backups
         Then I cannot see the backup named "second_backup" when I list the backups
         Then I cannot see the backup named "third_backup" when I list the backups
-        Then I cannot see purged backup files for the "test" table in keyspace "medusa"
+        Then I can not see purged backup files for the "test" table in keyspace "medusa"
         Then I can see the backup named "fourth_backup" when I list the backups
         Then I can see the backup named "fifth_backup" when I list the backups
         Then I can verify the backup named "fourth_backup" with md5 checks "disabled" successfully
@@ -755,3 +755,44 @@ Feature: Integration tests
         Examples: Local storage
         | storage           | client encryption |
         | local      |  with_client_encryption |
+    
+    @19
+    Scenario Outline: Test backup gc grace period with purge
+        Given I have a fresh ccm cluster "<client encryption>" running named "scenario19"
+        Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>"
+        When I create the "test" table in keyspace "medusa"
+        When I load 100 rows in the "medusa.test" table
+        When I run a "ccm node1 nodetool flush" command
+        When I perform a backup in "differential" mode of the node named "first_backup" with md5 checks "disabled"
+        When I perform a backup in "differential" mode of the node named "second_backup" with md5 checks "disabled"
+        When I load 100 rows in the "medusa.test" table
+        When I run a "ccm node1 nodetool flush" command
+        When I run a "ccm node1 nodetool compact medusa" command
+        When I load 100 rows in the "medusa.test" table
+        When I run a "ccm node1 nodetool flush" command
+        When I perform a backup in "differential" mode of the node named "third_backup" with md5 checks "disabled"
+        When I load 100 rows in the "medusa.test" table
+        When I run a "ccm node1 nodetool flush" command
+        When I perform a backup in "differential" mode of the node named "fourth_backup" with md5 checks "disabled"
+        When I run a "ccm node1 nodetool compact medusa" command
+        When I perform a backup in "differential" mode of the node named "fifth_backup" with md5 checks "disabled"
+        Then I can see the backup named "first_backup" when I list the backups
+        Then I can see the backup named "second_backup" when I list the backups
+        Then I can see the backup named "third_backup" when I list the backups
+        Then I can see the backup named "fourth_backup" when I list the backups
+        Then I can see the backup named "fifth_backup" when I list the backups
+        Then I can verify the backup named "fifth_backup" with md5 checks "disabled" successfully
+        When I purge the backup history to retain only 2 backups
+        Then I cannot see the backup named "first_backup" when I list the backups
+        Then I cannot see the backup named "second_backup" when I list the backups
+        Then I cannot see the backup named "third_backup" when I list the backups
+        Then I can actually see purged backup files for the "test" table in keyspace "medusa"
+        Then I can see the backup named "fourth_backup" when I list the backups
+        Then I can see the backup named "fifth_backup" when I list the backups
+        Then I can verify the backup named "fourth_backup" with md5 checks "disabled" successfully
+        Then I can verify the backup named "fifth_backup" with md5 checks "disabled" successfully
+        
+        @local
+        Examples: Local storage
+        | storage                    | client encryption |
+        | local_backup_gc_grace      |  with_client_encryption |

--- a/tests/resources/config/medusa-azure_blobs.ini
+++ b/tests/resources/config/medusa-azure_blobs.ini
@@ -1,0 +1,14 @@
+[storage]
+host_file_separator = ","
+bucket_name = medusa-integration-tests
+key_file = ~/medusa_azure_credentials.json
+storage_provider = azure_blobs
+fqdn = 127.0.0.1
+base_path = /tmp
+prefix = storage_prefix
+multi_part_upload_threshold = 1024
+concurrent_transfers = 4
+backup_grace_period_in_days = 0
+
+[monitoring]
+monitoring_provider = local

--- a/tests/resources/config/medusa-google_storage.ini
+++ b/tests/resources/config/medusa-google_storage.ini
@@ -1,0 +1,12 @@
+[storage]
+host_file_separator = ","
+bucket_name = medusa-integration-tests
+key_file = ~/medusa_credentials.json
+storage_provider = google_storage
+fqdn = 127.0.0.1
+base_path = /tmp
+prefix = storage_prefix
+backup_grace_period_in_days = 0
+
+[monitoring]
+monitoring_provider = local

--- a/tests/resources/config/medusa-ibm_storage.ini
+++ b/tests/resources/config/medusa-ibm_storage.ini
@@ -1,0 +1,16 @@
+[storage]
+host_file_separator = ","
+bucket_name = medusa-experiment-2
+key_file = ~/.aws/ibm_credentials
+storage_provider = ibm_storage
+fqdn = 127.0.0.1
+base_path = /tmp
+prefix = storage_prefix
+host = s3.eu.cloud-object-storage.appdomain.cloud
+region = eu-smart
+transfer_max_bandwidth = "1MB/s"
+secure = True
+backup_grace_period_in_days = 0
+
+[monitoring]
+monitoring_provider = local

--- a/tests/resources/config/medusa-local.ini
+++ b/tests/resources/config/medusa-local.ini
@@ -1,0 +1,11 @@
+[storage]
+host_file_separator = ","
+bucket_name = medusa_it_bucket
+storage_provider = local
+fqdn = 127.0.0.1
+base_path = /tmp
+prefix = storage_prefix
+backup_grace_period_in_days = 0
+
+[monitoring]
+monitoring_provider = local

--- a/tests/resources/config/medusa-local_backup_gc_grace.ini
+++ b/tests/resources/config/medusa-local_backup_gc_grace.ini
@@ -1,0 +1,11 @@
+[storage]
+host_file_separator = ","
+bucket_name = medusa_it_bucket
+storage_provider = local
+fqdn = 127.0.0.1
+base_path = /tmp
+prefix = storage_prefix
+backup_grace_period_in_days = 1
+
+[monitoring]
+monitoring_provider = local

--- a/tests/resources/config/medusa-minio.ini
+++ b/tests/resources/config/medusa-minio.ini
@@ -1,0 +1,19 @@
+[storage]
+host_file_separator = ","
+bucket_name = medusa-dev
+key_file = ~/.aws/minio_credentials
+storage_provider = s3_compatible
+api_profile = default
+fqdn = 127.0.0.1
+base_path = /tmp
+prefix = storage_prefix
+multi_part_upload_threshold = 1024
+aws_cli_path = aws
+secure = False
+region = default
+host = localhost
+port = 9000
+backup_grace_period_in_days = 0
+
+[monitoring]
+monitoring_provider = local

--- a/tests/resources/config/medusa-s3_us_west_oregon.ini
+++ b/tests/resources/config/medusa-s3_us_west_oregon.ini
@@ -1,0 +1,14 @@
+[storage]
+host_file_separator = ","
+bucket_name = tlp-medusa-dev
+key_file = ~/.aws/medusa_credentials
+storage_provider = s3_us_west_oregon
+fqdn = 127.0.0.1
+prefix = storage_prefix
+multi_part_upload_threshold = 1024
+aws_cli_path = aws
+concurrent_transfers = 4
+backup_grace_period_in_days = 0
+
+[monitoring]
+monitoring_provider = local

--- a/tests/resources/config/medusa.ini
+++ b/tests/resources/config/medusa.ini
@@ -14,3 +14,4 @@ max_backup_count = 0
 transfer_max_bandwidth = 50MB/s
 concurrent_transfers = 1
 multi_part_upload_threshold = 104857600
+backup_grace_period_in_days = 0


### PR DESCRIPTION
Fixes #363

Protects backup files from being deleted before a configurable gc grace value.
This change prevents purge from deleting sstables of ongoing backups (which are seen as orphaned files).

This PR also reworks the integration tests to use proper config files, which simplifies the integration steps code and expands test coverage to `config.py`.