### PR TITLE
fix s3 storage on us-east-1 region

### DIFF
--- a/medusa/storage/s3_storage.py
+++ b/medusa/storage/s3_storage.py
@@ -95,9 +95,7 @@ class S3Storage(S3BaseStorage):
             raise NotImplementedError("No valid method of AWS authentication provided.")
 
         cls = get_driver(Provider.S3)
-        region = self.config.region
-        if self.config.storage_provider != Provider.S3:
-            region = get_driver(self.config.storage_provider).region_name
+        region = get_driver(self.config.storage_provider).region_name
         driver = cls(
             aws_access_key_id, aws_secret_access_key, token=aws_security_token, region=region
         )


### PR DESCRIPTION
Fixes https://github.com/thelastpickle/cassandra-medusa/issues/372

I may miss something here but I see no reason to have a special treatment for the `Provider.S3` case (corresponding to the `us-east-1` region.

The `get_driver` function returns the correct region if we remove the condition  L99 in `medusa/storage/s3_storage.py `
```
>>> get_driver('s3').region_name
'us-east-1'
```