### PR TITLE
Fix required version for Click package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil<2.8.1,>=2.1
-Click>=6.7
+Click>=8.0.1
 click-aliases>=1.0.1
 PyYAML>=5.1
 cassandra-driver>=3.25.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'python-dateutil<2.8.1,>=2.1',
-        'Click>=6.7',
+        'Click>=8.0.1',
         'click-aliases>=1.0.1',
         'PyYAML>=5.1',
         'cassandra-driver>=3.25.0',


### PR DESCRIPTION
Looks like using Click package versions under 8.x causes this error invoking medusa cli:

```
$ medusa --help
Traceback (most recent call last):
  File "/usr/local/bin/medusa", line 5, in <module>
    from medusa.medusacli import cli
  File "/usr/local/lib/python3.6/dist-packages/medusa/medusacli.py", line 107, in <module>
    @click.pass_context
  File "/usr/local/lib/python3.6/dist-packages/click/decorators.py", line 304, in decorator
    return option(*(param_decls or ("--version",)), **attrs)(f)
  File "/usr/local/lib/python3.6/dist-packages/click/decorators.py", line 192, in decorator
    _param_memo(f, OptionClass(param_decls, **option_attrs))
  File "/usr/local/lib/python3.6/dist-packages/click/core.py", line 1714, in __init__
    Parameter.__init__(self, param_decls, type=type, **attrs)
TypeError: __init__() got an unexpected keyword argument 'package_name'
```

Setting the minimum version required to fix that.

For reference: https://the-asf.slack.com/archives/C0111B5KADA/p1625498223112600