### PR TITLE
[WIP] Sanity checking around backing up files

### DIFF
--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -326,7 +326,7 @@ def backup_snapshots(storage, manifest, node_backup, node_backup_cache, snapshot
         if _num_dirs < 1:
             _e = "Could not identify any directories where snapshot files should reside."
             logging.critical(_e)
-            raise Exception(_e)
+            raise ValueError(_e)
 
         for snapshot_path in snapshot.find_dirs():
             logging.debug("Backing up {}".format(snapshot_path))

--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -323,10 +323,7 @@ def backup_snapshots(storage, manifest, node_backup, node_backup_cache, snapshot
         # Consider find_dirs() returning nothing to be a critical failure. At no point should a cassandra snapshot
         #   exist in 0 directories on the host.
         # We can't backup what we can't find and we consider any result other than a successful backup to be a failure
-        if _num_dirs < 1:
-            _e = "Could not identify any directories where snapshot files should reside."
-            logging.critical(_e)
-            raise ValueError(_e)
+        assert _num_dirs >= 1, "Could not identify any directories where snapshot files should reside."
 
         for snapshot_path in snapshot.find_dirs():
             logging.debug("Backing up {}".format(snapshot_path))

--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -313,6 +313,21 @@ def update_monitoring(actual_backup_duration, backup_name, monitoring, node_back
 def backup_snapshots(storage, manifest, node_backup, node_backup_cache, snapshot):
     try:
         num_files = 0
+        _snapshot_file_dirs = snapshot.find_dirs()
+        _num_dirs = len(_snapshot_file_dirs)
+        logging.info("Found '{num_dir}' directories that may contain snapshot files.".format(num_dir=_num_dirs))
+
+        # Dump the list of directories if debugging
+        logging.debug("_snapshot_file_dirs: {}".format(_snapshot_file_dirs))
+
+        # Consider find_dirs() returning nothing to be a critical failure. At no point should a cassandra snapshot
+        #   exist in 0 directories on the host.
+        # We can't backup what we can't find and we consider any result other than a successful backup to be a failure
+        if _num_dirs < 1:
+            _e = "Could not identify any directories where snapshot files should reside."
+            logging.critical(_e)
+            raise Exception(_e)
+
         for snapshot_path in snapshot.find_dirs():
             logging.debug("Backing up {}".format(snapshot_path))
 

--- a/medusa/storage/__init__.py
+++ b/medusa/storage/__init__.py
@@ -355,10 +355,9 @@ class Storage(object):
         try:
             latest_backup_name = self.storage_driver.get_blob_content_as_string(index_path)
             # get_blob_content_as_string() uses None to indicate a 404 or other non-exception-worthy problem
-            if latest_backup_name is None:
-                _e = "Unable to determine the latest_backup_name from '{}'".format(index_path)
-                logging.critical(_e)
-                raise Exception(_e)
+            assert latest_backup_name is not None, "Unable to determine the latest_backup_name from '{}'".format(
+                index_path)
+
             # Otherwise, we know the name of the last backup
             logging.info("Proceeding with latest_backup_name: '{}'".format(latest_backup_name))
 

--- a/medusa/storage/__init__.py
+++ b/medusa/storage/__init__.py
@@ -351,8 +351,17 @@ class Storage(object):
 
     def latest_node_backup(self, *, fqdn):
         index_path = '{}index/latest_backup/{}/backup_name.txt'.format(self.prefix_path, fqdn)
+        logging.debug("Checking for latest backup in '{}'".format(index_path))
         try:
             latest_backup_name = self.storage_driver.get_blob_content_as_string(index_path)
+            # get_blob_content_as_string() uses None to indicate a 404 or other non-exception-worthy problem
+            if latest_backup_name is None:
+                _e = "Unable to determine the latest_backup_name from '{}'".format(index_path)
+                logging.critical(_e)
+                raise Exception(_e)
+            # Otherwise, we know the name of the last backup
+            logging.info("Proceeding with latest_backup_name: '{}'".format(latest_backup_name))
+
             differential_blob = self.storage_driver.get_blob(
                 '{}{}/{}/meta/differential'.format(self.prefix_path, fqdn, latest_backup_name))
             # Should be removed after while. Here for backwards compatibility.


### PR DESCRIPTION
While trying to deploy Medusa, i ran into a few issues. The root cause of  #390 was an issue file systems permissions and  the silent-failure property of python's `glob()`

This PR implements some of the debug logging that I wish I had had while troubleshooting and a basic sanity check to abort execution as soon as an error is observed rather than waiting for a (misleading) failure at a later point in execution.



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1398) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1398
┆priority: Medium
