### PR TITLE
[WIP] explicitly catch ConnectionRefusedError when determining if a host is up/down

### DIFF
--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -708,9 +708,15 @@ def is_open(host, port):
         s.settimeout(timeout)
         s.connect((host, port))
         s.shutdown(socket.SHUT_RDWR)
-        is_accessible = True
+        return True
+
+    # If cassandra is not running but the host is up, host may choose to silently drop inbound connections to the
+    #   closed port or may respond with a RST indicating that the connection was refused.
+    # ConnectionRefusedError: [Errno 111] Connection refused
+    except ConnectionRefusedError as cre:
+        logging.error("Host '{host}' is up, but port '{port}' is closed.".format(host=host, port=port), exc_info=cre)
     except socket.error as e:
-        logging.error('Port {} closed on host {}'.format(port, host), exc_info=e)
+        logging.error("Could not open socket to port '{port}' on '{host}'.".format(host=host, port=port), exc_info=e)
     finally:
         try:
             if s:

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -708,7 +708,7 @@ def is_open(host, port):
         s.settimeout(timeout)
         s.connect((host, port))
         s.shutdown(socket.SHUT_RDWR)
-        return True
+        is_accessible = True
 
     # If cassandra is not running but the host is up, host may choose to silently drop inbound connections to the
     #   closed port or may respond with a RST indicating that the connection was refused.


### PR DESCRIPTION
While rolling out Medusa @ my org, I ran into an unhandled exception: `ConnectionRefusedError`

Depending on security-group/firewall/OS configuration, a connection to a closed port may either silently fail (looks like a timeout from the connectors' point of view) or an immediate "no!" in the form of a `RST` packet.

In my case, the host that `medusa` was connecting to was up, but the cassandra process was not and hosts in this network are configured to not waste time with stealthy drops.

