### PR TITLE
[WIP] use `sudo` only during during node-restore operations.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -74,8 +74,8 @@ multi_part_upload_threshold = 104857600
 ; This option does NOT replace the `use_sudo` option under the 'cassandra' section!
 ; See: https://github.com/thelastpickle/cassandra-medusa/pull/399
 ;
-; Defaults to False
-;use_sudo_for_restore = False
+; Defaults to True
+;use_sudo_for_restore = True
 
 [monitoring]
 ;monitoring_provider = <Provider used for sending metrics. Currently either of "ffwd" or "local">

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -25,6 +25,12 @@ Modify it to match your requirements:
 ; Defaults to True.
 resolve_ip_addresses = True
 
+; When true, almost all commands executed by Medusa are prefixed with `sudo`.
+; Does not affect the use_sudo_for_restore setting in the 'storage' section.
+; See https://github.com/thelastpickle/cassandra-medusa/issues/318
+; Defaults to True
+;use_sudo = True
+
 [storage]
 storage_provider = <Storage system used for backups>
 ; storage_provider should be either of "local", "google_storage" or "s3"

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -65,6 +65,18 @@ concurrent_transfers = 1
 ; Size over which S3 uploads will be using the awscli with multi part uploads. Defaults to 100MB.
 multi_part_upload_threshold = 104857600
 
+; When not using sstableloader to restore data on a node, Medusa will copy snapshot files from a
+; temporary location into the cassandra data directroy. Medusa will then attempt to change the
+; ownership of the snapshot files so the cassandra user can access them.
+; Depending on how users/file permissions are set up on the cassandra instance, the medusa user 
+; may need elevated permissions to manipulate the files in the cassandra data directory.
+;
+; This option does NOT replace the `use_sudo` option under the 'cassandra' section!
+; See: https://github.com/thelastpickle/cassandra-medusa/pull/399
+;
+; Defaults to False
+;use_sudo_for_restore = False
+
 [monitoring]
 ;monitoring_provider = <Provider used for sending metrics. Currently either of "ffwd" or "local">
 

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -113,7 +113,7 @@ def _build_default_config():
         'fqdn': socket.getfqdn(),
         'region': 'default',
         'backup_grace_period_in_days': 10,
-        'use_sudo_for_restore': 'False'
+        'use_sudo_for_restore': 'True'
     }
 
     config['logging'] = {

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -30,7 +30,7 @@ StorageConfig = collections.namedtuple(
     ['bucket_name', 'key_file', 'prefix', 'fqdn', 'host_file_separator', 'storage_provider',
      'base_path', 'max_backup_age', 'max_backup_count', 'api_profile', 'transfer_max_bandwidth',
      'concurrent_transfers', 'multi_part_upload_threshold', 'host', 'region', 'port', 'secure', 'aws_cli_path',
-     'backup_grace_period_in_days']
+     'backup_grace_period_in_days', 'use_sudo_for_restore']
 )
 
 CassandraConfig = collections.namedtuple(
@@ -113,6 +113,7 @@ def _build_default_config():
         'fqdn': socket.getfqdn(),
         'region': 'default',
         'backup_grace_period_in_days': 10,
+        'use_sudo_for_restore': 'False'
     }
 
     config['logging'] = {

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -362,7 +362,7 @@ class RestoreJob(object):
                   '{in_place} {keep_auth} %s {verify} --backup-name {backup} --temp-dir {temp_dir} ' \
                   '{use_sstableloader} {keyspaces} {tables}' \
             .format(work=self.work_dir,
-                    sudo='sudo' if medusa.utils.evaluate_boolean(self.config.cassandra.use_sudo) else '',
+                    sudo='sudo' if medusa.utils.evaluate_boolean(self.config.storage.use_sudo_for_restore) else '',
                     config=f'--config-file {self.config.file_path}' if self.config.file_path else '',
                     in_place=in_place_option,
                     keep_auth=keep_auth_option,

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -282,7 +282,7 @@ class RestoreJob(object):
         for target, sources in self.host_map.items():
             logging.info('About to restore on {} using {} as backup source'.format(target, sources))
 
-        logging.info('This will delete all data on the target nodes and replace it with backup {}.'
+        logging.info("This will delete all data on the target nodes and replace it with backup '{}'."
                      .format(self.cluster_backup.name))
 
         proceed = None

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -362,7 +362,7 @@ class RestoreJob(object):
                   '{in_place} {keep_auth} %s {verify} --backup-name {backup} --temp-dir {temp_dir} ' \
                   '{use_sstableloader} {keyspaces} {tables}' \
             .format(work=self.work_dir,
-                    sudo='sudo' if medusa.utils.evaluate_boolean(self.config.storage.use_sudo_for_restore) else '',
+                    sudo='sudo' if medusa.utils.evaluate_boolean(self.config.cassandra.use_sudo) else '',
                     config=f'--config-file {self.config.file_path}' if self.config.file_path else '',
                     in_place=in_place_option,
                     keep_auth=keep_auth_option,

--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -95,7 +95,7 @@ def restore_node_locally(config, temp_dir, backup_name, in_place, keep_auth, see
 
     # Clean the commitlogs, the saved cache to prevent any kind of conflict
     # especially around system tables.
-    use_sudo = medusa.utils.evaluate_boolean(config.cassandra.use_sudo)
+    use_sudo = medusa.utils.evaluate_boolean(config.storage.use_sudo_for_restore)
     clean_path(cassandra.commit_logs_path, use_sudo, keep_folder=True)
     clean_path(cassandra.saved_caches_path, use_sudo, keep_folder=True)
 


### PR DESCRIPTION
I have set up my cassandra clusters such that there is no need for the `medusa` user to run as root. As such, i set `cassandra.use_sudo` to `False`.

However, when doing a cluster restore, execution abruptly failed. On each node, the failure was just after the snapshot data had been pulled down from S3 and was copied into place.

The crux of the stack trace was this:

```
subprocess.CalledProcessError: Command '['chown', '-R', 'cassandra:medusa', '/cassandra/data/myKeyspaceNameHere/myTableNameHere']' returned non-zero exit status 1.
```

Which comes from the non-sstableloader path [here](https://github.com/thelastpickle/cassandra-medusa/blob/5cb39834e7f8ad1c48641af1f1548898bacd5b51/medusa/restore_node.py#L334).

For reasons that are not relevant here, using the `cassandra.use_sudo = True` setting caused failures in other ways and was not going to work.


This pull requests expands on the work done in #318; instead of a single `use_sudo` flag for all situations / cases, I am introducing a `storage.use_sudo_for_restore` flag which _only_ uses `sudo` for the `chown` and similar file operations.
