### PR TITLE
Publish storage provider specific Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,9 @@ jobs:
   publish-docker-master:
     needs: [debian-build, build, integration-tests]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    strategy:
+      matrix:
+        storage-provider: ["", "-s3", "-azure", "-gcs"]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -277,14 +280,14 @@ jobs:
         DOCKER_TOKEN: ${{ secrets.K8SSANDRA_DOCKER_HUB_PASSWORD }}
       run: |
         docker login -u $DOCKER_USERNAME -p $DOCKER_TOKEN
-        echo "Publishing release $(git rev-parse --short HEAD) in Docker Hub"
+        echo "Publishing release $(git rev-parse --short HEAD)${{ matrix.storage-provider }} in Docker Hub"
         python setup.py build
         # Push Docker image tagged with the short commit sha
-        docker build -t k8ssandra/medusa:$(git rev-parse --short HEAD) -f k8s/Dockerfile .
-        docker push k8ssandra/medusa:$(git rev-parse --short HEAD)
+        docker build -t k8ssandra/medusa:$(git rev-parse --short HEAD)${{ matrix.storage-provider }} -f k8s/Dockerfile${{ matrix.storage-provider }} .
+        docker push k8ssandra/medusa:$(git rev-parse --short HEAD)${{ matrix.storage-provider }}
         # Push Docker image tagged as "master"
-        docker tag k8ssandra/medusa:$(git rev-parse --short HEAD) k8ssandra/medusa:master
-        docker push k8ssandra/medusa:master
+        docker tag k8ssandra/medusa:$(git rev-parse --short HEAD)${{ matrix.storage-provider }} k8ssandra/medusa:master${{ matrix.storage-provider }}
+        docker push k8ssandra/medusa:master${{ matrix.storage-provider }}
     
   publish-debian:
     # We can only release if the build above succeeded first
@@ -326,6 +329,9 @@ jobs:
   publish-docker:
     needs: [publish-debian]
     if: github.event_name == 'release' && github.event.action == 'published'
+    strategy:
+      matrix:
+        storage-provider: ["", "-s3", "-azure", "-gcs"]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -338,8 +344,8 @@ jobs:
         docker login -u $DOCKER_USERNAME -p $DOCKER_TOKEN
         echo "Publishing release ${version} in Docker Hub"
         python setup.py build
-        docker build -t k8ssandra/medusa:${version} -f k8s/Dockerfile .
-        docker push k8ssandra/medusa:${version}
+        docker build -t k8ssandra/medusa:${version}${{ matrix.storage-provider }} -f k8s/Dockerfile${{ matrix.storage-provider }} .
+        docker push k8ssandra/medusa:${version}${{ matrix.storage-provider }}
 
   publish-pypi:
     # We can only release if the build above succeeded first

--- a/k8s/Dockerfile-azure
+++ b/k8s/Dockerfile-azure
@@ -37,10 +37,6 @@ RUN python3 -m pip install -U pip && pip3 install --ignore-installed --user \
     -r /requirements.txt \
     -r /requirements-grpc-runtime.txt
 
-# Amazon S3
-COPY requirements-s3.txt /requirements-s3.txt
-RUN pip3 install --ignore-installed --user -r /requirements-s3.txt
-
 # Azure
 COPY requirements-azure.txt /requirements-azure.txt
 RUN pip3 install --ignore-installed --user -r /requirements-azure.txt \
@@ -64,16 +60,6 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
 
 USER cassandra
 WORKDIR /home/cassandra
-
-# GCP sdk
-COPY --chown=cassandra:cassandra k8s/clean-cloud-sdk.sh /home/cassandra/clean-cloud-sdk.sh
-RUN wget -q https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz \
-    && tar -zxvf google-cloud-sdk.tar.gz \
-    && google-cloud-sdk/install.sh --quiet \
-    && chmod +x clean-cloud-sdk.sh && ./clean-cloud-sdk.sh
-ENV DEBUG_VERSION 1
-ENV DEBUG_SLEEP 0
-ENV PATH=/home/cassandra/.local/bin:/home/cassandra/google-cloud-sdk/bin:$PATH
 
 COPY --from=base --chown=cassandra:cassandra /root/.local /home/cassandra/.local
 

--- a/k8s/Dockerfile-gcs
+++ b/k8s/Dockerfile-gcs
@@ -37,15 +37,6 @@ RUN python3 -m pip install -U pip && pip3 install --ignore-installed --user \
     -r /requirements.txt \
     -r /requirements-grpc-runtime.txt
 
-# Amazon S3
-COPY requirements-s3.txt /requirements-s3.txt
-RUN pip3 install --ignore-installed --user -r /requirements-s3.txt
-
-# Azure
-COPY requirements-azure.txt /requirements-azure.txt
-RUN pip3 install --ignore-installed --user -r /requirements-azure.txt \
-     && pip3 install --ignore-installed --user azure-cli
-
 # Could be python:slim, but we have a .sh entrypoint
 FROM ubuntu:18.04
 

--- a/k8s/Dockerfile-s3
+++ b/k8s/Dockerfile-s3
@@ -41,11 +41,6 @@ RUN python3 -m pip install -U pip && pip3 install --ignore-installed --user \
 COPY requirements-s3.txt /requirements-s3.txt
 RUN pip3 install --ignore-installed --user -r /requirements-s3.txt
 
-# Azure
-COPY requirements-azure.txt /requirements-azure.txt
-RUN pip3 install --ignore-installed --user -r /requirements-azure.txt \
-     && pip3 install --ignore-installed --user azure-cli
-
 # Could be python:slim, but we have a .sh entrypoint
 FROM ubuntu:18.04
 
@@ -64,16 +59,6 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
 
 USER cassandra
 WORKDIR /home/cassandra
-
-# GCP sdk
-COPY --chown=cassandra:cassandra k8s/clean-cloud-sdk.sh /home/cassandra/clean-cloud-sdk.sh
-RUN wget -q https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz \
-    && tar -zxvf google-cloud-sdk.tar.gz \
-    && google-cloud-sdk/install.sh --quiet \
-    && chmod +x clean-cloud-sdk.sh && ./clean-cloud-sdk.sh
-ENV DEBUG_VERSION 1
-ENV DEBUG_SLEEP 0
-ENV PATH=/home/cassandra/.local/bin:/home/cassandra/google-cloud-sdk/bin:$PATH
 
 COPY --from=base --chown=cassandra:cassandra /root/.local /home/cassandra/.local
 


### PR DESCRIPTION
Fixes https://k8ssandra.atlassian.net/browse/K8SSAND-853

Use a matrix to generate provider specific Docker images with a smaller size, while still generating an uber docker image with the dependencies from all providers.