### PR TITLE
Use the aws_session_token setting of the aws profile

### DIFF
--- a/medusa/storage/s3_storage.py
+++ b/medusa/storage/s3_storage.py
@@ -49,7 +49,7 @@ class S3Storage(S3BaseStorage):
 
         :return driver: EC2 driver object
         """
-        aws_security_token = ''
+        aws_session_token = ''
         aws_access_key_id = None
         # or authentication via AWS credentials file
         if self.config.key_file and os.path.exists(os.path.expanduser(self.config.key_file)):
@@ -64,6 +64,8 @@ class S3Storage(S3BaseStorage):
                 profile = aws_config[aws_profile]
                 aws_access_key_id = profile['aws_access_key_id']
                 aws_secret_access_key = profile['aws_secret_access_key']
+                if 'aws_session_token' in profile:
+                    aws_session_token = profile['aws_session_token']
         # Authentication via environment variables
         elif 'AWS_ACCESS_KEY_ID' in os.environ and \
                 'AWS_SECRET_ACCESS_KEY' in os.environ:
@@ -72,8 +74,11 @@ class S3Storage(S3BaseStorage):
             aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY']
 
             # Access token for credentials fetched from STS service:
-            if 'AWS_SECURITY_TOKEN' in os.environ:
-                aws_security_token = os.environ['AWS_SECURITY_TOKEN']
+            # AWS_SECURITY_TOKEN has been renamed AWS_SESSION_TOKEN so we need to support both
+            if 'AWS_SESSION_TOKEN' in os.environ:
+                aws_session_token = os.environ['AWS_SESSION_TOKEN']
+            elif 'AWS_SECURITY_TOKEN' in os.environ:
+                aws_session_token = os.environ['AWS_SECURITY_TOKEN']
 
         # or authentication via IAM Role credentials
         else:
@@ -89,7 +94,7 @@ class S3Storage(S3BaseStorage):
 
                 aws_access_key_id = auth_data['AccessKeyId']
                 aws_secret_access_key = auth_data['SecretAccessKey']
-                aws_security_token = auth_data['Token']
+                aws_session_token = auth_data['Token']
 
         if aws_access_key_id is None:
             raise NotImplementedError("No valid method of AWS authentication provided.")
@@ -99,7 +104,7 @@ class S3Storage(S3BaseStorage):
         if self.config.storage_provider != Provider.S3:
             region = get_driver(self.config.storage_provider).region_name
         driver = cls(
-            aws_access_key_id, aws_secret_access_key, token=aws_security_token, region=region
+            aws_access_key_id, aws_secret_access_key, token=aws_session_token, region=region
         )
 
         if self.config.transfer_max_bandwidth is not None:


### PR DESCRIPTION
### Context

To make medusa authenticate to AWS, I've initially been using environment variables to set the access key, secret key and session/security token ([this part of the code](https://github.com/thelastpickle/cassandra-medusa/blob/18562beaa4d2f4affa6ff143a923b69f748accde/medusa/storage/s3_storage.py#L68-L76)). This worked well when using `medusa` commands, as I would just have to generate the credentials before calling the command, using `aws sts` as [described here](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/), because libcloud doesn't automatically assume AMI roles.

I then wanted to use gRPC to issue operations, to be able to use some kind of API and not rely on commands output (especially to list and verify backups). The problem is that I cannot just set the previous environment variables before launching the gRPC server, since the generated credentials eventually expire.

### Description

The changes in this PR will simply allow medusa to set the session/security token, while reading the aws credentials file. The `aws_session_token` setting is coming from [the official doc](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
That way, I should be able to generate the credentials periodically and write them to this credentials file. This should work because AFAICS, the gRPC server doesn't cache the credentials but always read the aws credentials file.

### Testing

I couldn't find unit or integration tests covering this part of the code, and since I don't have much experience working with this codebase I thought would just make a PR first. Let me know if you need me to add tests.

I've also tested this change manually on a test Cassandra cluster and this worked well using the credentials file.
