### PR TITLE
Fix corrupt backups when tables have 2i

### DIFF
--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -46,7 +46,7 @@ class NodeBackupCache(object):
             self._data_path = node_backup.data_path
             self._cached_objects = {
                 (section['keyspace'], section['columnfamily']): {
-                    pathlib.Path(object['path']).name: object
+                    self._sanitize_file_path(pathlib.Path(object['path'])): object
                     for object in section['objects']
                 }
                 for section in json.loads(node_backup.manifest)
@@ -64,6 +64,15 @@ class NodeBackupCache(object):
         self._storage_provider = storage_provider
         self._storage_config = storage_config
         self._enable_md5_checks = enable_md5_checks
+
+    def _sanitize_file_path(self, path):
+        # Secondary indexes are stored as subdirectories to the base table, starting with a dot.
+        # In order to avoid mixing 2i sstables with the base table sstables, the file name isn't enough
+        # to perform the comparison on differential backups. We need to retain the subdir name for 2i tables.
+        if path.parts[-2].startswith('.'):
+            return os.path.join(path.parts[-2], path.parts[-1])
+        else:
+            return path.name
 
     @property
     def replaced(self):
@@ -84,7 +93,7 @@ class NodeBackupCache(object):
                 fqtn = (keyspace, columnfamily)
                 cached_item = None
                 if self._storage_provider == Provider.GOOGLE_STORAGE or self._differential_mode is True:
-                    cached_item = self._cached_objects.get(fqtn, {}).get(src.name)
+                    cached_item = self._cached_objects.get(fqtn, {}).get(self._sanitize_file_path(src))
 
                 threshold = self._storage_config.multi_part_upload_threshold
                 if cached_item is None or not self._storage_driver.file_matches_cache(src,

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -22,7 +22,7 @@ Feature: Integration tests
         Given I have a fresh ccm cluster "<client encryption>" running named "scenario1"
         Then Test TLS version connections if "<client encryption>" is turned on
         Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>"
-        When I create the "test" table in keyspace "medusa"
+        When I create the "test" table with secondary index in keyspace "medusa"
         When I load 100 rows in the "medusa.test" table
         When I run a "ccm node1 nodetool flush" command
         When I load 100 rows in the "medusa.test" table
@@ -32,9 +32,9 @@ Feature: Integration tests
         Then I can download the backup named "first_backup" for all tables
         Then I can download the backup named "first_backup" for "medusa.test"
         Then I can see the backup status for "first_backup" when I run the status command
-        Then backup named "first_backup" has 16 files in the manifest for the "test" table in keyspace "medusa"
+        Then backup named "first_backup" has 32 files in the manifest for the "test" table in keyspace "medusa"
         Then the backup index exists
-        Then the backup named "first_backup" has 2 SSTables for the "test" table in keyspace "medusa"
+        Then the backup named "first_backup" has 4 SSTables for the "test" table in keyspace "medusa"
         Then I can verify the backup named "first_backup" with md5 checks "disabled" successfully
         Then I can verify the backup named "first_backup" with md5 checks "enabled" successfully
         When I load 100 rows in the "medusa.test" table
@@ -278,40 +278,41 @@ Feature: Integration tests
     Scenario Outline: Perform an differential backup, verify it, restore it and delete it
         Given I have a fresh ccm cluster "<client encryption>" running named "scenario8"
         Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>"
-        When I create the "test" table in keyspace "medusa"
+        When I create the "test" table with secondary index in keyspace "medusa"
         When I load 100 rows in the "medusa.test" table
         When I run a "ccm node1 nodetool flush" command
         When I perform a backup in "differential" mode of the node named "first_backup" with md5 checks "disabled"
         Then I can see the backup named "first_backup" when I list the backups
         Then I can verify the backup named "first_backup" with md5 checks "disabled" successfully
-        Then backup named "first_backup" has 8 files in the manifest for the "test" table in keyspace "medusa"
-        Then I can see 1 SSTables in the SSTable pool for the "test" table in keyspace "medusa"
+        Then backup named "first_backup" has 16 files in the manifest for the "test" table in keyspace "medusa"
+        Then I can see 2 SSTables in the SSTable pool for the "test" table in keyspace "medusa"
         When I load 100 rows in the "medusa.test" table
         Then I have 200 rows in the "medusa.test" table in ccm cluster "<client encryption>"
         When I run a "ccm node1 nodetool flush" command
         When I perform a backup in "differential" mode of the node named "second_backup" with md5 checks "disabled"
         Then some files from the previous backup were not reuploaded
-        Then I can see 2 SSTables in the SSTable pool for the "test" table in keyspace "medusa"
+        Then I can see 4 SSTables in the SSTable pool for the "test" table in keyspace "medusa"
         Then I can see the backup named "second_backup" when I list the backups
         Then I can see the backup status for "second_backup" when I run the status command
         Then I can verify the backup named "second_backup" with md5 checks "disabled" successfully
-        Then backup named "first_backup" has 8 files in the manifest for the "test" table in keyspace "medusa"
-        Then backup named "second_backup" has 16 files in the manifest for the "test" table in keyspace "medusa"
+        Then backup named "first_backup" has 16 files in the manifest for the "test" table in keyspace "medusa"
+        Then backup named "second_backup" has 32 files in the manifest for the "test" table in keyspace "medusa"
+        When I perform a backup in "differential" mode of the node named "third_backup" with md5 checks "enabled"
         When I load 100 rows in the "medusa.test" table
         When I run a "ccm node1 nodetool flush" command
         Then I have 300 rows in the "medusa.test" table in ccm cluster "<client encryption>"
-        When I perform a backup in "differential" mode of the node named "third_backup" with md5 checks "enabled"
+        When I perform a backup in "differential" mode of the node named "fourth_backup" with md5 checks "enabled"
         Then some files from the previous backup were not reuploaded
         Then I can see the backup named "third_backup" when I list the backups
         Then I can see the backup named "first_backup" when I list the backups
         Then I can see the backup named "second_backup" when I list the backups
         Then I can verify the backup named "third_backup" with md5 checks "disabled" successfully
-        When I restore the backup named "second_backup"
+        When I restore the backup named "third_backup"
         Then I have 200 rows in the "medusa.test" table in ccm cluster "<client encryption>"
         When I load 100 rows in the "medusa.test" table
         When I run a "ccm node1 nodetool flush" command
         Then I have 300 rows in the "medusa.test" table in ccm cluster "<client encryption>"
-        When I perform a backup in "differential" mode of the node named "fourth_backup" with md5 checks "disabled"
+        When I perform a backup in "differential" mode of the node named "fifth_backup" with md5 checks "disabled"
         Then I can see the backup named "fourth_backup" when I list the backups
         Then I can see the backup named "first_backup" when I list the backups
         Then I can see the backup named "second_backup" when I list the backups


### PR DESCRIPTION
This PR fixes an issues that was reported [here](https://forum.k8ssandra.io/t/medusa-restore-systematically-corruption-of-a-table/328/3).

Secondary indexes are stored as subdirectories of the base table directory. When looking for previously backed up files with differential backups, the file name was the only thing used (per keyspace/table) which leads to some confusion between base table files and 2i files if they have the same name and size.
This leads to corrupt backups with manifests that are missing some files, which are then not restored.

This PR retains the subdirectory for cache comparison for secondary index files, avoiding the confusion between files from the base tables and their 2i.