### PR TITLE
Set TTL for storage connections

### DIFF
--- a/medusa/storage/concurrent.py
+++ b/medusa/storage/concurrent.py
@@ -19,6 +19,7 @@ import multiprocessing
 import os
 import pathlib
 import threading
+import time
 
 from libcloud.storage.types import ObjectDoesNotExistError
 from retrying import retry
@@ -39,6 +40,8 @@ class StorageJob:
         self.lock = threading.Lock()
         self.func = func
         self.connection_pool = []
+        self.timer = time.time()
+        self.connection_ttl = 1200
         if max_workers is None:
             self.max_workers = int(multiprocessing.cpu_count())
         else:
@@ -50,6 +53,10 @@ class StorageJob:
 
     def with_storage(self, iterable):
         with self.lock:
+            current_timer = time.time()
+            if current_timer - self.timer > self.connection_ttl:
+                self.connection_pool = []
+                self.timer = time.time()
             if not self.connection_pool:
                 connection = self.storage.connect_storage()
             else:


### PR DESCRIPTION
This should fix the issues for long running backups using temporary credentials (like AWS IAM role). Right now the problem is those connections are never recycled, and if a backup is running longer than the credentials expiration time, it'll just fail.
This PR set a max TTL for those connections of 20 minutes (it's just an arbitrary number, but should be good enough) and after this period of time, it just resets the connection pool forcing to create new fresh connections.