### PR TITLE
392: Fix backup deletion with incomplete backups

### DIFF
--- a/medusa/purge.py
+++ b/medusa/purge.py
@@ -147,7 +147,7 @@ def cleanup_obsolete_files(storage, fqdn, backup_grace_period_in_days):
     total_purged_size = 0
 
     backups = storage.list_node_backups(fqdn=fqdn)
-    paths_in_manifest = get_file_paths_from_manifests_for_differential_backups(backups)
+    paths_in_manifest = get_file_paths_from_manifests_for_complete_differential_backups(backups)
     paths_in_storage = get_file_paths_from_storage(storage, fqdn)
 
     deletion_candidates = set(paths_in_storage.keys()) - paths_in_manifest
@@ -190,10 +190,11 @@ def is_older_than_gc_grace(blob_datetime, gc_grace) -> bool:
     return datetime.timestamp(blob_datetime) <= datetime.timestamp(datetime.now()) - (int(gc_grace) * 86400)
 
 
-def get_file_paths_from_manifests_for_differential_backups(backups):
+def get_file_paths_from_manifests_for_complete_differential_backups(backups):
     differential_backups = filter_differential_backups(backups)
+    complete_differential_backups = list(filter(lambda backup: backup.manifest is not None, differential_backups))
 
-    manifests = list(map(lambda backup: json.loads(backup.manifest), differential_backups))
+    manifests = list(map(lambda backup: json.loads(backup.manifest), complete_differential_backups))
 
     objects_in_manifests = [
         obj

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -856,7 +856,7 @@ Feature: Integration tests
         When I perform a backup in "differential" mode of the node named "third_backup" with md5 checks "disabled"
         Then I can see the backup named "first_backup" when I list the backups
         Then I can see the backup named "second_backup" when I list the backups
-        And I delete the manifest from the backup named "second_backup"
+        And I delete the manifest from the backup named "second_backup" from the storage
         And the backup named "second_backup" is incomplete
         Then I can see the backup named "third_backup" when I list the backups
         When I delete the backup named "first_backup"

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -1160,6 +1160,30 @@ def _i_delete_the_manifest_from_the_backup_named(context, backup_name):
             os.remove(os.path.join(path_backup_index, meta_file))
 
 
+@then(r'I delete the manifest from the backup named "{backup_name}" from the storage')
+def _i_delete_the_manifest_from_the_backup_named_from_the_storage(context, backup_name):
+    storage = Storage(config=context.medusa_config.storage)
+
+    fqdn = context.medusa_config.storage.fqdn
+    path_manifest_index_latest = "{}index/backup_index/{}/manifest_{}.json".format(
+        storage.prefix_path, backup_name, fqdn
+    )
+    path_backup_index = "{}index/backup_index/{}".format(
+        storage.prefix_path, backup_name
+    )
+    path_manifest_backup = "{}{}/{}/meta/manifest.json".format(
+        storage.prefix_path, fqdn, backup_name
+    )
+
+    storage.storage_driver.get_blob(path_manifest_backup).delete()
+    storage.storage_driver.get_blob(path_manifest_index_latest).delete()
+
+    meta_files = storage.storage_driver.list_objects(path_backup_index)
+    for meta_file in meta_files:
+        if meta_file.name.split("/")[-1].startswith("finished"):
+            storage.storage_driver.delete_object(meta_file)
+
+
 @then(r'the backup named "{backup_name}" is incomplete')
 def _the_backup_named_is_incomplete(context, backup_name):
     backups = medusa.listing.list_backups(config=context.medusa_config, show_all=True)


### PR DESCRIPTION
Fixes #392.

### Description

As described in #392, medusa crashes after deleting backups, during the cleanup phase, when incomplete backups are present.

Skipping backups that have no manifest solves the problem and shouldn't affect in progress backups if `backup_grace_period_in_days` is correctly set.

I can also add logging for incomplete backups if you find it useful.

### Testing

I ran the new integration test without the fix, and it failed.
With the fix, both integration tests and unit tests are passing.