### PR TITLE
Remove unnecessary warning regarding is_ccm

### DIFF
--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -327,7 +327,6 @@ class Cassandra(object):
         self._is_ccm = int(shlex.split(cassandra_config.is_ccm)[0])
         self._os_has_systemd = self._has_systemd()
         self._nodetool = Nodetool(cassandra_config)
-        logging.warning('is ccm : {}'.format(self._is_ccm))
         config_reader = CassandraConfigReader(cassandra_config.config_file, release_version)
         self._cassandra_config_file = cassandra_config.config_file
         self._root = config_reader.root


### PR DESCRIPTION
Every time a new cassandra is created Medusa prints a WARNING regarding the value of the is_ccm config.

`[2021-10-29 22:00:03,244] WARNING: is ccm : 0`

This appears to have always been the case the blame on this line points to the initial commit from when the code was imported from Spotify...

I can't really see the purpose for this warning so I recommend it be removed.  If it's useful to know the value of ccm this can probably be an INFO.