### PR TITLE
Update example.ini from docs

### DIFF
--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -37,7 +37,17 @@
 ; Command ran to verify if Cassandra is running on a node. Defaults to "nodetool version"
 ;check_running = nodetool version
 
+; Disable/Enable ip address resolving.
+; Disabling this can help when fqdn resolving gives different domain names for local and remote nodes
+; which makes backup succeed but Medusa sees them as incomplete.
+; Defaults to True.
+;resolve_ip_addresses = True
 
+; When true, almost all commands executed by Medusa are prefixed with `sudo`.
+; Does not affect the use_sudo_for_restore setting in the 'storage' section.
+; See https://github.com/thelastpickle/cassandra-medusa/issues/318
+; Defaults to True
+;use_sudo = True
 
 [storage]
 storage_provider = <Storage system used for backups>
@@ -75,6 +85,18 @@ multi_part_upload_threshold = 104857600
 
 ; GC grace period for backed up files. Prevents race conditions between purge and running backups
 backup_grace_period_in_days = 10
+
+; When not using sstableloader to restore data on a node, Medusa will copy snapshot files from a
+; temporary location into the cassandra data directroy. Medusa will then attempt to change the
+; ownership of the snapshot files so the cassandra user can access them.
+; Depending on how users/file permissions are set up on the cassandra instance, the medusa user 
+; may need elevated permissions to manipulate the files in the cassandra data directory.
+;
+; This option does NOT replace the `use_sudo` option under the 'cassandra' section!
+; See: https://github.com/thelastpickle/cassandra-medusa/pull/399
+;
+; Defaults to True
+;use_sudo_for_restore = True
 
 [monitoring]
 ;monitoring_provider = <Provider used for sending metrics. Currently either of "ffwd" or "local">


### PR DESCRIPTION
I managed to completely miss the `resolve_ip_addresses = True` option as this is mentioned in the docs but wasn't present in the example ini file.

This PR updates the example ini file with options that are mentioned in the docs but were not present in the `medusa-example.ini` file. https://github.com/thelastpickle/cassandra-medusa/blob/master/docs/Configuration.md