### PR TITLE
Use cassandra native_port for cluster connection

### DIFF
--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -56,11 +56,12 @@ class SnapshotPath(object):
 
 class CqlSessionProvider(object):
 
-    def __init__(self, ip_addresses, cassandra_config):
+    def __init__(self, ip_addresses, cassandra_config, port):
         self._ip_addresses = ip_addresses
         self._auth_provider = None
         self._ssl_context = None
         self._cassandra_config = cassandra_config
+        self._native_port = port
 
         if null_if_empty(cassandra_config.cql_username) and null_if_empty(cassandra_config.cql_password):
             auth_provider = PlainTextAuthProvider(username=cassandra_config.cql_username,
@@ -90,6 +91,7 @@ class CqlSessionProvider(object):
          """
 
         cluster = Cluster(contact_points=self._ip_addresses,
+                          port=int(self._native_port),
                           auth_provider=self._auth_provider,
                           execution_profiles=self._execution_profiles,
                           ssl_context=self._ssl_context)
@@ -333,12 +335,12 @@ class Cassandra(object):
         self._commitlog_path = config_reader.commitlog_directory
         self._saved_caches_path = config_reader.saved_caches_directory
         self._hostname = contact_point if contact_point is not None else config_reader.listen_address
-        self._cql_session_provider = CqlSessionProvider(
-            [self._hostname],
-            cassandra_config)
-
         self._storage_port = config_reader.storage_port
         self._native_port = config_reader.native_port
+        self._cql_session_provider = CqlSessionProvider(
+            [self._hostname],
+            cassandra_config,
+            self._native_port)
         self._rpc_port = config_reader.rpc_port
         self.seeds = config_reader.seeds
 

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -56,12 +56,12 @@ class SnapshotPath(object):
 
 class CqlSessionProvider(object):
 
-    def __init__(self, ip_addresses, cassandra_config, port):
+    def __init__(self, ip_addresses, cassandra_config):
         self._ip_addresses = ip_addresses
         self._auth_provider = None
         self._ssl_context = None
         self._cassandra_config = cassandra_config
-        self._native_port = port
+        self._native_port = CassandraConfigReader(cassandra_config.config_file).native_port
 
         if null_if_empty(cassandra_config.cql_username) and null_if_empty(cassandra_config.cql_password):
             auth_provider = PlainTextAuthProvider(username=cassandra_config.cql_username,
@@ -339,8 +339,7 @@ class Cassandra(object):
         self._native_port = config_reader.native_port
         self._cql_session_provider = CqlSessionProvider(
             [self._hostname],
-            cassandra_config,
-            self._native_port)
+            cassandra_config)
         self._rpc_port = config_reader.rpc_port
         self.seeds = config_reader.seeds
 


### PR DESCRIPTION
If you are using TLS and only listening for CQL TLS connections on port
9142 then medusa will fail to connect because the CqlSessionProvider
only returned a new_session using the default port (9042).