### PR TITLE
Add a datadog statsd monitoring backend

### DIFF
--- a/medusa/config.py
+++ b/medusa/config.py
@@ -53,7 +53,7 @@ ChecksConfig = collections.namedtuple(
 
 MonitoringConfig = collections.namedtuple(
     'MonitoringConfig',
-    ['monitoring_provider']
+    ['monitoring_provider', 'send_backup_name_tag']
 )
 
 MedusaConfig = collections.namedtuple(
@@ -152,7 +152,8 @@ def _build_default_config():
     }
 
     config['monitoring'] = {
-        'monitoring_provider': 'None'
+        'monitoring_provider': 'None',
+        'send_backup_name_tag': 'False'
     }
 
     config['grpc'] = {

--- a/medusa/monitoring/__init__.py
+++ b/medusa/monitoring/__init__.py
@@ -18,9 +18,11 @@ import logging
 from medusa.monitoring.ffwd import FfwdMonitoring
 from medusa.monitoring.noop import NoopMonitoring
 from medusa.monitoring.local import LocalMonitoring
+from medusa.monitoring.dogstatsd import DogStatsdMonitoring
 
 
 PROVIDER_FFWD = 'ffwd'
+PROVIDER_DOG_STATSD = 'dog-statsd'
 PROVIDER_NONE = 'None'
 PROVIDER_INMEM = 'local'
 
@@ -39,6 +41,9 @@ class Monitoring(object):
         elif self._config.monitoring_provider == PROVIDER_NONE:
             logging.info('Monitoring provider is noop')
             return NoopMonitoring(self._config)
+        elif self._config.monitoring_provider == PROVIDER_DOG_STATSD:
+            logging.info('Monitoring provider is dog-statsd')
+            return DogStatsdMonitoring(self._config)
         elif self._config.monitoring_provider == PROVIDER_INMEM:
             logging.info('Monitoring provider is local')
             return LocalMonitoring(self._config)

--- a/medusa/monitoring/dogstatsd.py
+++ b/medusa/monitoring/dogstatsd.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021-present Shopify. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import medusa.utils
+from datadog.dogstatsd import DogStatsd
+from medusa.monitoring.abstract import AbstractMonitoring
+
+
+class DogStatsdMonitoring(AbstractMonitoring):
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.client = DogStatsd()
+
+    def send(self, tags, value):
+        if len(tags) != 3:
+            raise AssertionError("Datadog monitoring implementation needs 3 tags: 'name', 'what' and 'backup_name'")
+
+        name, what, backup_name = tags
+        metric = '{name}.{what}'.format(name=name, what=what)
+        backup_name_tag = 'backup_name:{}'.format(backup_name)
+
+        # The backup_name  would be a rather high cardinality metrics series if backups are at all frequent.
+        # This could be a expensive metric so backup_name is droppped from the tags sent by default
+        if medusa.utils.evaluate_boolean(self.config.send_backup_name_tag):
+            self.client.gauge(metric, value, tags=[backup_name_tag])
+        else:
+            self.client.gauge(metric, value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ wheel>=0.32.0
 gevent
 greenlet
 fasteners==0.16
+datadog

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setuptools.setup(
         'grpcio-tools>=1.29.0',
         'gevent',
         'greenlet',
-        'fasteners==0.16'
+        'fasteners==0.16',
+        'datadog'
     ],
     extras_require={
         'S3': ["awscli>=1.16.291"],


### PR DESCRIPTION
This uses the datadog specific statsd package but since only the gauge
metric is used really any statsd package could be used.

The backup-name tag is not sent to datadog to reduce custom metric cost
but can be enabled via the send_backup_name_tag configuration boolean