### PR TITLE
Allow remote restore in Kubernetes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,11 @@ jobs:
         mv tests/integration/.coverage .
         coverage xml
 
+    - name: Setup tmate session
+      if: "failure()"
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 30
+
     - uses: codecov/codecov-action@v1
       name: Report code coverage
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
     - name: Setup Java Action
       uses: actions/setup-java@v1
       with:
-        java-version: '8.0.232'
+        java-version: '8.0.252'
         architecture: x64
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
     # Build debian packages
     strategy:
       matrix:
+        # Focal builds are broken in CI, we can only build bionic for now
         #suite: [focal, bionic]
         suite: [bionic]
         include:
@@ -65,6 +66,7 @@ jobs:
           #  os-version: ubuntu-20.04
           - suite: bionic
             os-version: ubuntu-18.04
+      fail-fast: false
     runs-on: ${{ matrix.os-version }}
     steps:
     - uses: actions/checkout@v2
@@ -271,11 +273,6 @@ jobs:
         mv tests/integration/.coverage .
         coverage xml
 
-    - name: Setup tmate session
-      if: "failure()"
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 30
-
     - uses: codecov/codecov-action@v1
       name: Report code coverage
   
@@ -310,6 +307,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     strategy:
       matrix:
+        # Focal builds are broken in CI, we can only build bionic for now
         #suite: [focal, bionic]
         suite: [bionic]
         include:
@@ -317,6 +315,7 @@ jobs:
           #  os-version: ubuntu-20.04
           - suite: bionic
             os-version: ubuntu-18.04
+      fail-fast: false
     runs-on: ${{ matrix.os-version }}
     steps:
     - uses: actions/checkout@v2

--- a/k8s/docker-entrypoint.sh
+++ b/k8s/docker-entrypoint.sh
@@ -41,7 +41,7 @@ restore() {
         echo "Skipping restore operation"    
     else
         echo "Restoring backup $BACKUP_NAME"
-        python3 -m medusa.service.grpc.restore
+        python3 -m medusa.service.grpc.restore -- "/etc/medusa/medusa.ini" $RESTORE_KEY
         echo $RESTORE_KEY > $last_restore_file
     fi
 }

--- a/medusa/network/hostname_resolver.py
+++ b/medusa/network/hostname_resolver.py
@@ -29,10 +29,9 @@ class HostnameResolver:
             logging.debug("Not resolving {} as requested".format(ip_address_to_resolve))
             return ip_address_to_resolve
 
-        fqdn = socket.getfqdn(ip_address_to_resolve)
-        returned_fqdn = fqdn
-        if self.k8s_mode and fqdn.find('.') > 0:
-            returned_fqdn = fqdn.split('.')[0]
-        logging.debug("Resolved {} to {}".format(ip_address_to_resolve, returned_fqdn))
+        hostname = socket.getfqdn(ip_address_to_resolve)
+        if self.k8s_mode:
+            hostname = socket.getnameinfo((ip_address_to_resolve, 0), socket.NI_NOFQDN)[0]
+        logging.debug("Resolved {} to {}".format(ip_address_to_resolve, hostname))
 
-        return returned_fqdn
+        return hostname

--- a/medusa/network/hostname_resolver.py
+++ b/medusa/network/hostname_resolver.py
@@ -45,7 +45,7 @@ class HostnameResolver:
             reverse_name = dns.reversename.from_address(ip_address).to_text()
             fqdns = dns.resolver.resolve(reverse_name, 'PTR')
             for fqdn in fqdns:
-                if not self.is_ipv4(fqdn.to_text().split('.')[0].replace('-','.')):
+                if not self.is_ipv4(fqdn.to_text().split('.')[0].replace('-', '.')):
                     return fqdn.to_text().split('.')[0]
 
         return ip_address

--- a/medusa/network/hostname_resolver.py
+++ b/medusa/network/hostname_resolver.py
@@ -13,8 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import socket
+import dns.resolver
+import dns.reversename
+import ipaddress
 import logging
+import socket
 
 
 class HostnameResolver:
@@ -23,15 +26,33 @@ class HostnameResolver:
         self.k8s_mode = k8s_mode
 
     def resolve_fqdn(self, ip_address=''):
+        logging.info(f"Resolving ip address {ip_address}")
         ip_address_to_resolve = ip_address if ip_address != '' else socket.gethostbyname(socket.getfqdn())
-
+        logging.info(f"ip address to resolve {ip_address_to_resolve}")
         if str(self.resolve_addresses) == "False":
             logging.debug("Not resolving {} as requested".format(ip_address_to_resolve))
             return ip_address_to_resolve
 
         hostname = socket.getfqdn(ip_address_to_resolve)
         if self.k8s_mode:
-            hostname = socket.getnameinfo((ip_address_to_resolve, 0), socket.NI_NOFQDN)[0]
+            hostname = self.compute_k8s_hostname(ip_address_to_resolve)
         logging.debug("Resolved {} to {}".format(ip_address_to_resolve, hostname))
 
         return hostname
+
+    def compute_k8s_hostname(self, ip_address):
+        if (self.is_ipv4(ip_address)):
+            reverse_name = dns.reversename.from_address(ip_address).to_text()
+            fqdns = dns.resolver.resolve(reverse_name, 'PTR')
+            for fqdn in fqdns:
+                if not self.is_ipv4(fqdn.to_text().split('.')[0].replace('-','.')):
+                    return fqdn.to_text().split('.')[0]
+
+        return ip_address
+
+    def is_ipv4(self, ip_address):
+        try:
+            ipaddress.IPv4Network(ip_address)
+            return True
+        except ValueError:
+            return False

--- a/medusa/network/hostname_resolver.py
+++ b/medusa/network/hostname_resolver.py
@@ -41,11 +41,12 @@ class HostnameResolver:
         return hostname
 
     def compute_k8s_hostname(self, ip_address):
-        if (self.is_ipv4(ip_address)):
+        if (self.is_ipv4(ip_address) or self.is_ipv6(ip_address)):
             reverse_name = dns.reversename.from_address(ip_address).to_text()
             fqdns = dns.resolver.resolve(reverse_name, 'PTR')
             for fqdn in fqdns:
-                if not self.is_ipv4(fqdn.to_text().split('.')[0].replace('-', '.')):
+                if not self.is_ipv4(fqdn.to_text().split('.')[0].replace('-', '.')) \
+                   and not self.is_ipv6(fqdn.to_text().split('.')[0].replace('-', ':')):
                     return fqdn.to_text().split('.')[0]
 
         return ip_address
@@ -53,6 +54,13 @@ class HostnameResolver:
     def is_ipv4(self, ip_address):
         try:
             ipaddress.IPv4Network(ip_address)
+            return True
+        except ValueError:
+            return False
+
+    def is_ipv6(self, ip_address):
+        try:
+            ipaddress.IPv6Network(ip_address)
             return True
         except ValueError:
             return False

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import datetime
 import logging
 import operator
@@ -252,7 +251,6 @@ class RestoreJob(object):
         for node in tokenmap.keys():
             nodes[node] = tokenmap[node]['tokens'][0]
         return sorted(nodes.items(), key=operator.itemgetter(1))
-
 
     @staticmethod
     def _is_restore_in_place(backup_tokenmap, target_tokenmap):

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -256,7 +256,10 @@ class RestoreJob(object):
     def _is_restore_in_place(backup_tokenmap, target_tokenmap):
         # If at least one node is part of both tokenmaps, then we're restoring in place
         # Otherwise we're restoring a remote cluster
-        return len(set(backup_tokenmap.keys()) & set(target_tokenmap.keys())) > 0
+        logging.info(f"backup tokenmap keys: {backup_tokenmap.keys()}")
+        logging.info(f"target tokenmap keys: {target_tokenmap.keys()}")
+        logging.info(f"backup tokenmap keys intersection with target tokenmap keys: {set(backup_tokenmap.keys()) & set(target_tokenmap.keys())}")
+        return len(list(set(backup_tokenmap.keys()) & set(target_tokenmap.keys()))) > 0
 
     def _get_seeds_fqdn(self):
         seeds = list()

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -258,8 +258,8 @@ class RestoreJob(object):
         # Otherwise we're restoring a remote cluster
         logging.info(f"backup tokenmap keys: {backup_tokenmap.keys()}")
         logging.info(f"target tokenmap keys: {target_tokenmap.keys()}")
-        logging.info("backup tokenmap keys intersection with target tokenmap keys: " +
-                     f"{set(backup_tokenmap.keys()) & set(target_tokenmap.keys())}")
+        logging.info("backup tokenmap keys intersection with target tokenmap keys: "
+                     + f"{set(backup_tokenmap.keys()) & set(target_tokenmap.keys())}")
         return len(list(set(backup_tokenmap.keys()) & set(target_tokenmap.keys()))) > 0
 
     def _get_seeds_fqdn(self):

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -258,7 +258,8 @@ class RestoreJob(object):
         # Otherwise we're restoring a remote cluster
         logging.info(f"backup tokenmap keys: {backup_tokenmap.keys()}")
         logging.info(f"target tokenmap keys: {target_tokenmap.keys()}")
-        logging.info(f"backup tokenmap keys intersection with target tokenmap keys: {set(backup_tokenmap.keys()) & set(target_tokenmap.keys())}")
+        logging.info("backup tokenmap keys intersection with target tokenmap keys: " +
+                     f"{set(backup_tokenmap.keys()) & set(target_tokenmap.keys())}")
         return len(list(set(backup_tokenmap.keys()) & set(target_tokenmap.keys()))) > 0
 
     def _get_seeds_fqdn(self):

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -258,7 +258,7 @@ class RestoreJob(object):
         # Otherwise we're restoring a remote cluster
         logging.info(f"backup tokenmap keys: {backup_tokenmap.keys()}")
         logging.info(f"target tokenmap keys: {target_tokenmap.keys()}")
-        return len(list(set(backup_tokenmap.keys()) & set(target_tokenmap.keys()))) > 0
+        return len(set(backup_tokenmap.keys()).intersection(set(target_tokenmap.keys()))) > 0
 
     def _get_seeds_fqdn(self):
         seeds = list()

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -258,8 +258,6 @@ class RestoreJob(object):
         # Otherwise we're restoring a remote cluster
         logging.info(f"backup tokenmap keys: {backup_tokenmap.keys()}")
         logging.info(f"target tokenmap keys: {target_tokenmap.keys()}")
-        logging.info("backup tokenmap keys intersection with target tokenmap keys: "
-                     + f"{set(backup_tokenmap.keys()) & set(target_tokenmap.keys())}")
         return len(list(set(backup_tokenmap.keys()) & set(target_tokenmap.keys()))) > 0
 
     def _get_seeds_fqdn(self):

--- a/medusa/service/grpc/client.py
+++ b/medusa/service/grpc/client.py
@@ -93,10 +93,11 @@ class Client:
 
     def backup_exists(self, name):
         try:
-            stub = medusa_pb2_grpc.MedusaStub(self.channel)
-            request = medusa_pb2.BackupStatusRequest(backupName=name)
-            stub.BackupStatus(request)
-            return True
+            backups = self.get_backups()
+            for backup in list(backups):
+                if backup.backupName == name:
+                    return True
+            return False
         except grpc.RpcError as e:
             logging.error("Failed to determine if backup exists for backup name: {} due to error: {}".format(name, e))
             return False

--- a/medusa/service/grpc/client.py
+++ b/medusa/service/grpc/client.py
@@ -109,6 +109,5 @@ class Client:
             resp = stub.PurgeBackups(request)
             return resp
         except grpc.RpcError as e:
-            logging.error("Failed to purge backupsdue to error: {}" \
-                .format(e))
+            logging.error("Failed to purge backups due to error: {}".format(e))
             return None

--- a/medusa/service/grpc/client.py
+++ b/medusa/service/grpc/client.py
@@ -108,5 +108,6 @@ class Client:
             resp = stub.PurgeBackups(request)
             return resp
         except grpc.RpcError as e:
-            logging.error("Failed to purge backupsdue to error: {}".format(e))
+            logging.error("Failed to purge backupsdue to error: {}" \
+                .format(e))
             return None

--- a/medusa/service/grpc/medusa.proto
+++ b/medusa/service/grpc/medusa.proto
@@ -12,6 +12,8 @@ service Medusa {
   rpc GetBackups(GetBackupsRequest) returns (GetBackupsResponse);
 
   rpc PurgeBackups(PurgeBackupsRequest) returns (PurgeBackupsResponse);
+
+  rpc PrepareRestore(PrepareRestoreRequest) returns (PrepareRestoreResponse);
 }
 
 enum StatusType {
@@ -91,4 +93,13 @@ message PurgeBackupsResponse {
   int32     nbObjectsPurged = 2;
   int64     totalPurgedSize = 3;
   int32     totalObjectsWithinGcGrace = 4;
+}
+
+message PrepareRestoreRequest {
+  string backupName = 1;
+  string datacenter = 2;
+  string restoreKey = 3;
+}
+
+message PrepareRestoreResponse {
 }

--- a/medusa/service/grpc/medusa_pb2.py
+++ b/medusa/service/grpc/medusa_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x0cmedusa.proto\"d\n\rBackupRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\x04mode\x18\x02 \x01(\x0e\x32\x13.BackupRequest.Mode\"\"\n\x04Mode\x12\x10\n\x0c\x44IFFERENTIAL\x10\x00\x12\x08\n\x04\x46ULL\x10\x01\"A\n\x0e\x42\x61\x63kupResponse\x12\x12\n\nbackupName\x18\x01 \x01(\t\x12\x1b\n\x06status\x18\x02 \x01(\x0e\x32\x0b.StatusType\")\n\x13\x42\x61\x63kupStatusRequest\x12\x12\n\nbackupName\x18\x01 \x01(\t\"\xa0\x01\n\x14\x42\x61\x63kupStatusResponse\x12\x15\n\rfinishedNodes\x18\x01 \x03(\t\x12\x17\n\x0funfinishedNodes\x18\x02 \x03(\t\x12\x14\n\x0cmissingNodes\x18\x03 \x03(\t\x12\x11\n\tstartTime\x18\x04 \x01(\t\x12\x12\n\nfinishTime\x18\x05 \x01(\t\x12\x1b\n\x06status\x18\x06 \x01(\x0e\x32\x0b.StatusType\"#\n\x13\x44\x65leteBackupRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"A\n\x14\x44\x65leteBackupResponse\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1b\n\x06status\x18\x02 \x01(\x0e\x32\x0b.StatusType\"\x13\n\x11GetBackupsRequest\"Y\n\x12GetBackupsResponse\x12\x1f\n\x07\x62\x61\x63kups\x18\x01 \x03(\x0b\x32\x0e.BackupSummary\x12\"\n\roverallStatus\x18\x02 \x01(\x0e\x32\x0b.StatusType\"\xc2\x01\n\rBackupSummary\x12\x12\n\nbackupName\x18\x01 \x01(\t\x12\x11\n\tstartTime\x18\x02 \x01(\x03\x12\x12\n\nfinishTime\x18\x03 \x01(\x03\x12\x12\n\ntotalNodes\x18\x04 \x01(\x05\x12\x15\n\rfinishedNodes\x18\x05 \x01(\x05\x12\x1a\n\x05nodes\x18\x06 \x03(\x0b\x32\x0b.BackupNode\x12\x1b\n\x06status\x18\x07 \x01(\x0e\x32\x0b.StatusType\x12\x12\n\nbackupType\x18\x08 \x01(\t\"L\n\nBackupNode\x12\x0c\n\x04host\x18\x01 \x01(\t\x12\x0e\n\x06tokens\x18\x02 \x03(\x03\x12\x12\n\ndatacenter\x18\x03 \x01(\t\x12\x0c\n\x04rack\x18\x04 \x01(\t\"\x15\n\x13PurgeBackupsRequest\"\x84\x01\n\x14PurgeBackupsResponse\x12\x17\n\x0fnbBackupsPurged\x18\x01 \x01(\x05\x12\x17\n\x0fnbObjectsPurged\x18\x02 \x01(\x05\x12\x17\n\x0ftotalPurgedSize\x18\x03 \x01(\x03\x12!\n\x19totalObjectsWithinGcGrace\x18\x04 \x01(\x05*C\n\nStatusType\x12\x0f\n\x0bIN_PROGRESS\x10\x00\x12\x0b\n\x07SUCCESS\x10\x01\x12\n\n\x06\x46\x41ILED\x10\x02\x12\x0b\n\x07UNKNOWN\x10\x03\x32\xd1\x02\n\x06Medusa\x12)\n\x06\x42\x61\x63kup\x12\x0e.BackupRequest\x1a\x0f.BackupResponse\x12.\n\x0b\x41syncBackup\x12\x0e.BackupRequest\x1a\x0f.BackupResponse\x12;\n\x0c\x42\x61\x63kupStatus\x12\x14.BackupStatusRequest\x1a\x15.BackupStatusResponse\x12;\n\x0c\x44\x65leteBackup\x12\x14.DeleteBackupRequest\x1a\x15.DeleteBackupResponse\x12\x35\n\nGetBackups\x12\x12.GetBackupsRequest\x1a\x13.GetBackupsResponse\x12;\n\x0cPurgeBackups\x12\x14.PurgeBackupsRequest\x1a\x15.PurgeBackupsResponseb\x06proto3'
+  serialized_pb=b'\n\x0cmedusa.proto\"d\n\rBackupRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12!\n\x04mode\x18\x02 \x01(\x0e\x32\x13.BackupRequest.Mode\"\"\n\x04Mode\x12\x10\n\x0c\x44IFFERENTIAL\x10\x00\x12\x08\n\x04\x46ULL\x10\x01\"A\n\x0e\x42\x61\x63kupResponse\x12\x12\n\nbackupName\x18\x01 \x01(\t\x12\x1b\n\x06status\x18\x02 \x01(\x0e\x32\x0b.StatusType\")\n\x13\x42\x61\x63kupStatusRequest\x12\x12\n\nbackupName\x18\x01 \x01(\t\"\xa0\x01\n\x14\x42\x61\x63kupStatusResponse\x12\x15\n\rfinishedNodes\x18\x01 \x03(\t\x12\x17\n\x0funfinishedNodes\x18\x02 \x03(\t\x12\x14\n\x0cmissingNodes\x18\x03 \x03(\t\x12\x11\n\tstartTime\x18\x04 \x01(\t\x12\x12\n\nfinishTime\x18\x05 \x01(\t\x12\x1b\n\x06status\x18\x06 \x01(\x0e\x32\x0b.StatusType\"#\n\x13\x44\x65leteBackupRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"A\n\x14\x44\x65leteBackupResponse\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1b\n\x06status\x18\x02 \x01(\x0e\x32\x0b.StatusType\"\x13\n\x11GetBackupsRequest\"Y\n\x12GetBackupsResponse\x12\x1f\n\x07\x62\x61\x63kups\x18\x01 \x03(\x0b\x32\x0e.BackupSummary\x12\"\n\roverallStatus\x18\x02 \x01(\x0e\x32\x0b.StatusType\"\xc2\x01\n\rBackupSummary\x12\x12\n\nbackupName\x18\x01 \x01(\t\x12\x11\n\tstartTime\x18\x02 \x01(\x03\x12\x12\n\nfinishTime\x18\x03 \x01(\x03\x12\x12\n\ntotalNodes\x18\x04 \x01(\x05\x12\x15\n\rfinishedNodes\x18\x05 \x01(\x05\x12\x1a\n\x05nodes\x18\x06 \x03(\x0b\x32\x0b.BackupNode\x12\x1b\n\x06status\x18\x07 \x01(\x0e\x32\x0b.StatusType\x12\x12\n\nbackupType\x18\x08 \x01(\t\"L\n\nBackupNode\x12\x0c\n\x04host\x18\x01 \x01(\t\x12\x0e\n\x06tokens\x18\x02 \x03(\x03\x12\x12\n\ndatacenter\x18\x03 \x01(\t\x12\x0c\n\x04rack\x18\x04 \x01(\t\"\x15\n\x13PurgeBackupsRequest\"\x84\x01\n\x14PurgeBackupsResponse\x12\x17\n\x0fnbBackupsPurged\x18\x01 \x01(\x05\x12\x17\n\x0fnbObjectsPurged\x18\x02 \x01(\x05\x12\x17\n\x0ftotalPurgedSize\x18\x03 \x01(\x03\x12!\n\x19totalObjectsWithinGcGrace\x18\x04 \x01(\x05\"S\n\x15PrepareRestoreRequest\x12\x12\n\nbackupName\x18\x01 \x01(\t\x12\x12\n\ndatacenter\x18\x02 \x01(\t\x12\x12\n\nrestoreKey\x18\x03 \x01(\t\"\x18\n\x16PrepareRestoreResponse*C\n\nStatusType\x12\x0f\n\x0bIN_PROGRESS\x10\x00\x12\x0b\n\x07SUCCESS\x10\x01\x12\n\n\x06\x46\x41ILED\x10\x02\x12\x0b\n\x07UNKNOWN\x10\x03\x32\x94\x03\n\x06Medusa\x12)\n\x06\x42\x61\x63kup\x12\x0e.BackupRequest\x1a\x0f.BackupResponse\x12.\n\x0b\x41syncBackup\x12\x0e.BackupRequest\x1a\x0f.BackupResponse\x12;\n\x0c\x42\x61\x63kupStatus\x12\x14.BackupStatusRequest\x1a\x15.BackupStatusResponse\x12;\n\x0c\x44\x65leteBackup\x12\x14.DeleteBackupRequest\x1a\x15.DeleteBackupResponse\x12\x35\n\nGetBackups\x12\x12.GetBackupsRequest\x1a\x13.GetBackupsResponse\x12;\n\x0cPurgeBackups\x12\x14.PurgeBackupsRequest\x1a\x15.PurgeBackupsResponse\x12\x41\n\x0ePrepareRestore\x12\x16.PrepareRestoreRequest\x1a\x17.PrepareRestoreResponseb\x06proto3'
 )
 
 _STATUSTYPE = _descriptor.EnumDescriptor(
@@ -53,8 +53,8 @@ _STATUSTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=1040,
-  serialized_end=1107,
+  serialized_start=1151,
+  serialized_end=1218,
 )
 _sym_db.RegisterEnumDescriptor(_STATUSTYPE)
 
@@ -615,6 +615,77 @@ _PURGEBACKUPSRESPONSE = _descriptor.Descriptor(
   serialized_end=1038,
 )
 
+
+_PREPARERESTOREREQUEST = _descriptor.Descriptor(
+  name='PrepareRestoreRequest',
+  full_name='PrepareRestoreRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='backupName', full_name='PrepareRestoreRequest.backupName', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='datacenter', full_name='PrepareRestoreRequest.datacenter', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='restoreKey', full_name='PrepareRestoreRequest.restoreKey', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1040,
+  serialized_end=1123,
+)
+
+
+_PREPARERESTORERESPONSE = _descriptor.Descriptor(
+  name='PrepareRestoreResponse',
+  full_name='PrepareRestoreResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1125,
+  serialized_end=1149,
+)
+
 _BACKUPREQUEST.fields_by_name['mode'].enum_type = _BACKUPREQUEST_MODE
 _BACKUPREQUEST_MODE.containing_type = _BACKUPREQUEST
 _BACKUPRESPONSE.fields_by_name['status'].enum_type = _STATUSTYPE
@@ -636,6 +707,8 @@ DESCRIPTOR.message_types_by_name['BackupSummary'] = _BACKUPSUMMARY
 DESCRIPTOR.message_types_by_name['BackupNode'] = _BACKUPNODE
 DESCRIPTOR.message_types_by_name['PurgeBackupsRequest'] = _PURGEBACKUPSREQUEST
 DESCRIPTOR.message_types_by_name['PurgeBackupsResponse'] = _PURGEBACKUPSRESPONSE
+DESCRIPTOR.message_types_by_name['PrepareRestoreRequest'] = _PREPARERESTOREREQUEST
+DESCRIPTOR.message_types_by_name['PrepareRestoreResponse'] = _PREPARERESTORERESPONSE
 DESCRIPTOR.enum_types_by_name['StatusType'] = _STATUSTYPE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -723,6 +796,20 @@ PurgeBackupsResponse = _reflection.GeneratedProtocolMessageType('PurgeBackupsRes
   })
 _sym_db.RegisterMessage(PurgeBackupsResponse)
 
+PrepareRestoreRequest = _reflection.GeneratedProtocolMessageType('PrepareRestoreRequest', (_message.Message,), {
+  'DESCRIPTOR' : _PREPARERESTOREREQUEST,
+  '__module__' : 'medusa_pb2'
+  # @@protoc_insertion_point(class_scope:PrepareRestoreRequest)
+  })
+_sym_db.RegisterMessage(PrepareRestoreRequest)
+
+PrepareRestoreResponse = _reflection.GeneratedProtocolMessageType('PrepareRestoreResponse', (_message.Message,), {
+  'DESCRIPTOR' : _PREPARERESTORERESPONSE,
+  '__module__' : 'medusa_pb2'
+  # @@protoc_insertion_point(class_scope:PrepareRestoreResponse)
+  })
+_sym_db.RegisterMessage(PrepareRestoreResponse)
+
 
 
 _MEDUSA = _descriptor.ServiceDescriptor(
@@ -732,8 +819,8 @@ _MEDUSA = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_start=1110,
-  serialized_end=1447,
+  serialized_start=1221,
+  serialized_end=1625,
   methods=[
   _descriptor.MethodDescriptor(
     name='Backup',
@@ -792,6 +879,16 @@ _MEDUSA = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_PURGEBACKUPSREQUEST,
     output_type=_PURGEBACKUPSRESPONSE,
+    serialized_options=None,
+    create_key=_descriptor._internal_create_key,
+  ),
+  _descriptor.MethodDescriptor(
+    name='PrepareRestore',
+    full_name='Medusa.PrepareRestore',
+    index=6,
+    containing_service=None,
+    input_type=_PREPARERESTOREREQUEST,
+    output_type=_PREPARERESTORERESPONSE,
     serialized_options=None,
     create_key=_descriptor._internal_create_key,
   ),

--- a/medusa/service/grpc/medusa_pb2_grpc.py
+++ b/medusa/service/grpc/medusa_pb2_grpc.py
@@ -44,6 +44,11 @@ class MedusaStub(object):
                 request_serializer=medusa__pb2.PurgeBackupsRequest.SerializeToString,
                 response_deserializer=medusa__pb2.PurgeBackupsResponse.FromString,
                 )
+        self.PrepareRestore = channel.unary_unary(
+                '/Medusa/PrepareRestore',
+                request_serializer=medusa__pb2.PrepareRestoreRequest.SerializeToString,
+                response_deserializer=medusa__pb2.PrepareRestoreResponse.FromString,
+                )
 
 
 class MedusaServicer(object):
@@ -85,6 +90,12 @@ class MedusaServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def PrepareRestore(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_MedusaServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -117,6 +128,11 @@ def add_MedusaServicer_to_server(servicer, server):
                     servicer.PurgeBackups,
                     request_deserializer=medusa__pb2.PurgeBackupsRequest.FromString,
                     response_serializer=medusa__pb2.PurgeBackupsResponse.SerializeToString,
+            ),
+            'PrepareRestore': grpc.unary_unary_rpc_method_handler(
+                    servicer.PrepareRestore,
+                    request_deserializer=medusa__pb2.PrepareRestoreRequest.FromString,
+                    response_serializer=medusa__pb2.PrepareRestoreResponse.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -227,5 +243,22 @@ class Medusa(object):
         return grpc.experimental.unary_unary(request, target, '/Medusa/PurgeBackups',
             medusa__pb2.PurgeBackupsRequest.SerializeToString,
             medusa__pb2.PurgeBackupsResponse.FromString,
+            options, channel_credentials,
+            insecure, call_credentials, compression, wait_for_ready, timeout, metadata)
+
+    @staticmethod
+    def PrepareRestore(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(request, target, '/Medusa/PrepareRestore',
+            medusa__pb2.PrepareRestoreRequest.SerializeToString,
+            medusa__pb2.PrepareRestoreResponse.FromString,
             options, channel_credentials,
             insecure, call_credentials, compression, wait_for_ready, timeout, metadata)

--- a/medusa/service/grpc/restore.py
+++ b/medusa/service/grpc/restore.py
@@ -31,6 +31,7 @@ def create_config(config_file_path):
     conf = medusa.config.load_config(defaultdict(lambda: None), config_file)
     return conf
 
+
 def configure_console_logging(config):
     root_logger = logging.getLogger('')
     root_logger.setLevel(logging.DEBUG)
@@ -47,6 +48,7 @@ def configure_console_logging(config):
         for logger_name in 'urllib3', 'google_cloud_storage.auth.transport.requests', 'paramiko', 'cassandra':
             logging.getLogger(logger_name).setLevel(logging.WARN)
 
+
 if __name__ == '__main__':
     if len(sys.argv) > 3:
         config_file_path = sys.argv[2]
@@ -60,8 +62,14 @@ if __name__ == '__main__':
         logging.info(f"Reading mapping file {RESTORE_MAPPING_LOCATION}/{restore_key}")
         with open(f"{RESTORE_MAPPING_LOCATION}/{restore_key}", 'r') as f:
             mapping = json.load(f)
-            # Mapping json structure will look like: {'in_place': true, 'host_map': {'172.24.0.3': {'source': ['172.24.0.3'], 'seed': False}, '127.0.0.1': {'source': ['172.24.0.4'], 'seed': False}, '172.24.0.6': {'source': ['172.24.0.6'], 'seed': False}}}
-            # As each mapping is specific to a Cassandra node, we're looking for the node that maps to 127.0.0.1, which will be different for each pod.
+            # Mapping json structure will look like:
+            # {'in_place': true,
+            #  'host_map':
+            #       {'172.24.0.3': {'source': ['172.24.0.3'], 'seed': False},
+            #        '127.0.0.1': {'source': ['172.24.0.4'], 'seed': False},
+            #        '172.24.0.6': {'source': ['172.24.0.6'], 'seed': False}}}
+            # As each mapping is specific to a Cassandra node, we're looking for the node that maps to 127.0.0.1,
+            # which will be different for each pod.
             os.environ["POD_IP"] = mapping["host_map"]["127.0.0.1"]["source"][0]
             in_place = mapping["in_place"]
 
@@ -87,7 +95,7 @@ if __name__ == '__main__':
             backup_found = True
             logging.info("Starting restore of backup {}".format(backup_name))
             medusa.restore_node.restore_node(config, tmp_dir, backup_name, in_place, keep_auth,
-                                            seeds, verify, keyspaces, tables, use_sstableloader)
+                                             seeds, verify, keyspaces, tables, use_sstableloader)
             logging.info("Finished restore of backup {}".format(backup_name))
             break
 

--- a/medusa/service/grpc/restore.py
+++ b/medusa/service/grpc/restore.py
@@ -70,7 +70,11 @@ if __name__ == '__main__':
             #        '172.24.0.6': {'source': ['172.24.0.6'], 'seed': False}}}
             # As each mapping is specific to a Cassandra node, we're looking for the node that maps to 127.0.0.1,
             # which will be different for each pod.
-            os.environ["POD_IP"] = mapping["host_map"]["127.0.0.1"]["source"][0]
+            # If hostname resolving is turned on, we're looking for the localhost key instead.
+            if "localhost" in mapping["host_map"].keys():
+                os.environ["POD_IP"] = mapping["host_map"]["localhost"]["source"][0]
+            else:
+                os.environ["POD_IP"] = mapping["host_map"]["127.0.0.1"]["source"][0]
             in_place = mapping["in_place"]
 
     config = create_config(config_file_path)

--- a/medusa/service/grpc/restore.py
+++ b/medusa/service/grpc/restore.py
@@ -73,8 +73,10 @@ if __name__ == '__main__':
             # If hostname resolving is turned on, we're looking for the localhost key instead.
             if "localhost" in mapping["host_map"].keys():
                 os.environ["POD_IP"] = mapping["host_map"]["localhost"]["source"][0]
-            else:
+            elif "127.0.0.1" in mapping["host_map"].keys():
                 os.environ["POD_IP"] = mapping["host_map"]["127.0.0.1"]["source"][0]
+            else:
+                os.environ["POD_IP"] = mapping["host_map"]["::1"]["source"][0]
             in_place = mapping["in_place"]
 
     config = create_config(config_file_path)

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -37,7 +37,7 @@ from medusa.purge import delete_backup
 from medusa.restore_cluster import RestoreJob
 from medusa.service.grpc import medusa_pb2
 from medusa.service.grpc import medusa_pb2_grpc
-from medusa.storage import Storage, cluster_backup
+from medusa.storage import Storage
 
 TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'
 BACKUP_MODE_DIFFERENTIAL = "differential"
@@ -264,7 +264,14 @@ class MedusaService(medusa_pb2_grpc.MedusaServicer):
             backups = get_backups(self.config, True)
             for cluster_backup in backups:
                 if cluster_backup.name == request.backupName:
-                    restore_job = RestoreJob(cluster_backup, self.config, Path("/tmp"), None, "127.0.0.1", True, False, 1, bypass_checks=True)
+                    restore_job = RestoreJob(cluster_backup,
+                                             self.config, Path("/tmp"),
+                                             None,
+                                             "127.0.0.1",
+                                             True,
+                                             False,
+                                             1,
+                                             bypass_checks=True)
                     restore_job.prepare_restore()
                     os.makedirs(RESTORE_MAPPING_LOCATION, exist_ok=True)
                     with open(f"{RESTORE_MAPPING_LOCATION}/{request.restoreKey}", "w") as f:
@@ -272,8 +279,9 @@ class MedusaService(medusa_pb2_grpc.MedusaServicer):
         except Exception as e:
             context.set_details("Failed to prepare restore: {}".format(e))
             context.set_code(grpc.StatusCode.INTERNAL)
-            logging.exception("Preparing restore {} for backup {} failed".format(request.restoreKey, request.backupName))
+            logging.exception("Failed restore prep {} for backup {}".format(request.restoreKey, request.backupName))
         return response
+
 
 # Callback function for recording unique backup results
 def record_backup_info(future):

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
+import os
 import signal
 import sys
 from collections import defaultdict
@@ -32,13 +34,15 @@ from medusa.backup_manager import BackupMan
 from medusa.config import load_config
 from medusa.listing import get_backups
 from medusa.purge import delete_backup
+from medusa.restore_cluster import RestoreJob
 from medusa.service.grpc import medusa_pb2
 from medusa.service.grpc import medusa_pb2_grpc
-from medusa.storage import Storage
+from medusa.storage import Storage, cluster_backup
 
 TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'
 BACKUP_MODE_DIFFERENTIAL = "differential"
 BACKUP_MODE_FULL = "full"
+RESTORE_MAPPING_LOCATION = "/var/lib/cassandra/.restore_mapping"
 
 
 class Server:
@@ -253,6 +257,23 @@ class MedusaService(medusa_pb2_grpc.MedusaServicer):
             logging.exception("Purging backups failed")
         return response
 
+    def PrepareRestore(self, request, context):
+        logging.info("Preparing restore {} for backup {}".format(request.restoreKey, request.backupName))
+        response = medusa_pb2.PrepareRestoreResponse()
+        try:
+            backups = get_backups(self.config, True)
+            for cluster_backup in backups:
+                if cluster_backup.name == request.backupName:
+                    restore_job = RestoreJob(cluster_backup, self.config, Path("/tmp"), None, "127.0.0.1", True, False, 1, bypass_checks=True)
+                    restore_job.prepare_restore()
+                    os.makedirs(RESTORE_MAPPING_LOCATION, exist_ok=True)
+                    with open(f"{RESTORE_MAPPING_LOCATION}/{request.restoreKey}", "w") as f:
+                        f.write(json.dumps({'in_place': restore_job.in_place, 'host_map': restore_job.host_map}))
+        except Exception as e:
+            context.set_details("Failed to prepare restore: {}".format(e))
+            context.set_code(grpc.StatusCode.INTERNAL)
+            logging.exception("Preparing restore {} for backup {} failed".format(request.restoreKey, request.backupName))
+        return response
 
 # Callback function for recording unique backup results
 def record_backup_info(future):

--- a/medusa/storage/google_storage.py
+++ b/medusa/storage/google_storage.py
@@ -105,7 +105,10 @@ class GoogleStorage(AbstractStorage):
         # we made src_paths a list of Path objects, but we need strings for copying
         # plus, we must not forget to point them to the bucket
         srcs = ['gs://{}/{}'.format(self.bucket.name, str(p)) for p in src_paths]
-        return gsutil.cp(srcs=srcs, dst=new_dest)
+        return gsutil.cp(
+            srcs=srcs,
+            dst=new_dest,
+            parallel_process_count=self.config.concurrent_transfers)
 
     def get_object_datetime(self, blob):
         logging.debug("Blob {} last modification time is {}".format(blob.name, blob.extra["last_modified"]))

--- a/packaging/docker-build/docker-entrypoint.sh
+++ b/packaging/docker-build/docker-entrypoint.sh
@@ -15,7 +15,7 @@
 
 set -ex
 
-export SSH2_LIBS_SUFFIX
+#export SSH2_LIBS_SUFFIX
 
 # build Debian
 # copy built packages into a mounted volume

--- a/packaging/docker-build/docker-entrypoint.sh
+++ b/packaging/docker-build/docker-entrypoint.sh
@@ -15,7 +15,7 @@
 
 set -ex
 
-#export SSH2_LIBS_SUFFIX
+export SSH2_LIBS_SUFFIX
 
 # build Debian
 # copy built packages into a mounted volume

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ greenlet
 fasteners==0.16
 datadog
 botocore>=1.13.27
+dnspython>=2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ cryptography<=3.3.2,>=2.5
 pycryptodome>=3.9.9
 retrying>=1.3.3
 ssh2-python==0.22.0
-ssh-python>=0.6.0
+ssh-python>=0.8.0
 parallel-ssh==2.2.0
 requests==2.22.0
 wheel>=0.32.0

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
         'retrying>=1.3.3',
         'parallel-ssh==2.2.0',
         'ssh2-python==0.22.0',
-        'ssh-python>=0.6.0',
+        'ssh-python>=0.8.0',
         'requests==2.22.0',
         'protobuf>=3.12.0',
         'grpcio>=1.29.0',

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setuptools.setup(
         'fasteners==0.16',
         'datadog',
         'botocore>=1.13.27',
+        'dnspython>=2.2.1',
     ],
     extras_require={
         'S3': ["awscli>=1.16.291"],

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -109,6 +109,7 @@ class ConfigTest(unittest.TestCase):
             'query': 'SELECT * FROM greek_mythology',
             'use_mgmt_api': 'True',
             'username': 'Zeus',
+            'fqdn': 'localhost',
         }
         config = medusa.config.load_config(args, self.medusa_config_file)
         assert config.storage.bucket_name == 'Hector'

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -733,7 +733,7 @@ Feature: Integration tests
         When I perform a backup over gRPC in "differential" mode of the node named "grpc_backup_1" and it fails
         Then I delete the backup "grpc_backup_1" over gRPC
         Then I delete the backup "grpc_backup_1" over gRPC and it fails
-        Then I verify over gRPC the backup "grpc_backup_1" does not exist
+        Then I verify over gRPC that the backup "grpc_backup_1" does not exist
         Then I shutdown the gRPC server
 
         @local
@@ -920,7 +920,7 @@ Feature: Integration tests
         Then I can see the latest backup for "127.0.0.1" being called "grpc_backup_23"
         Then I verify over gRPC that the backup "grpc_backup_23" has expected status SUCCESS
         Then I delete the backup "grpc_backup_23" over gRPC
-        Then I verify over gRPC the backup "grpc_backup_23" does not exist
+        Then I verify over gRPC that the backup "grpc_backup_23" does not exist
         Then I verify that backup manager has removed the backup "grpc_backup_23"
         Then I shutdown the gRPC server
 

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -758,7 +758,7 @@ Feature: Integration tests
         Then I verify over gRPC that the backup "grpc_backup_2_2" exists and is of type "differential"
         Then I can see the backup index entry for "grpc_backup_2_2"
         Then I can see the latest backup for "127.0.0.1" being called "grpc_backup_2_2"
-        When I perform a purge over gRPC with a max backup count of 1
+        When I perform a purge over gRPC
         Then 1 backup has been purged
         Then I verify over gRPC that the backup "grpc_backup_2" does not exist
         Then I shutdown the gRPC server

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -704,6 +704,7 @@ Feature: Integration tests
         Then I verify over gRPC that the backup "grpc_backup_2" exists and is of type "differential"
         Then I can see the backup index entry for "grpc_backup_2"
         Then I can see the latest backup for "127.0.0.1" being called "grpc_backup_2"
+        Then I wait for 10 seconds
         When I perform a backup over gRPC in "differential" mode of the node named "grpc_backup_2_2"
         Then I verify over gRPC that the backup "grpc_backup_2_2" exists and is of type "differential"
         Then I can see the backup index entry for "grpc_backup_2_2"
@@ -754,6 +755,7 @@ Feature: Integration tests
         Then I verify over gRPC that the backup "grpc_backup_2" exists and is of type "differential"
         Then I can see the backup index entry for "grpc_backup_2"
         Then I can see the latest backup for "127.0.0.1" being called "grpc_backup_2"
+        Then I wait for 10 seconds
         When I perform a backup over gRPC in "differential" mode of the node named "grpc_backup_2_2"
         Then I verify over gRPC that the backup "grpc_backup_2_2" exists and is of type "differential"
         Then I can see the backup index entry for "grpc_backup_2_2"

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ast import And
 import datetime
 import glob
 import json

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -1285,6 +1285,11 @@ def _backup_has_been_purged(context, nb_purged_backups):
     assert context.purge_result.nbBackupsPurged == int(nb_purged_backups)
 
 
+@then(r'I wait for {pause_duration} seconds')
+def _i_wait_for_seconds(context, pause_duration):
+    time.sleep(int(pause_duration))
+
+
 def connect_cassandra(is_client_encryption_enable, tls_version=PROTOCOL_TLS):
     connected = False
     attempt = 0

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ast import And
 import datetime
 import glob
 import json

--- a/tests/network/hostname_resolver_test.py
+++ b/tests/network/hostname_resolver_test.py
@@ -13,14 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dns.rdtypes.ANY.PTR
+import dns.name
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock, Mock
 
 from medusa.network.hostname_resolver import HostnameResolver
 
 mock_fqdn = "k8ssandra-dc1-default-sts-0.k8ssandra-dc1-all-pods-service.k8ssandra2022040617103007.svc.cluster.local"
+mock_invalid_fqdn = "127-0-0-1.k8ssandra-dc1-all-pods-service.k8ssandra2022040617103007.svc.cluster.local"
 mock_alias = "k8ssandra-dc1-default-sts-0"
-
+mock_resolve = Mock()
+mock_resolve.to_text = MagicMock(return_value=mock_fqdn)
+mock_resolve_invalid = Mock()
+mock_resolve_invalid.to_text = MagicMock(return_value=mock_invalid_fqdn)
+mock_reverse = Mock()
+mock_reverse.to_text = MagicMock(return_value="1.0.0.127-in-addr.arpa.") 
 
 class HostnameResolverTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
@@ -36,11 +44,27 @@ class HostnameResolverTest(unittest.TestCase):
 
     def test_address_for_kubernetes(self):
         with patch('medusa.network.hostname_resolver.socket') as mock_socket:
-            mock_socket.getfqdn.return_value = mock_fqdn
-            hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
-            self.assertEqual(
-                mock_alias,
-                hostname_resolver.resolve_fqdn("127.0.0.1"))
+            with patch('medusa.network.hostname_resolver.dns.resolver') as mock_resolver:
+                with patch('medusa.network.hostname_resolver.dns.reversename') as mock_reverser:
+                    mock_socket.getfqdn.return_value = mock_fqdn
+                    mock_resolver.resolve.return_value = [mock_resolve]
+                    mock_reverser.reverse.return_value = mock_reverse
+                    hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
+                    self.assertEqual(
+                        mock_alias,
+                        hostname_resolver.resolve_fqdn("127.0.0.1"))
+
+    def test_invalid_address_for_kubernetes(self):
+        with patch('medusa.network.hostname_resolver.socket') as mock_socket:
+            with patch('medusa.network.hostname_resolver.dns.resolver') as mock_resolver:
+                with patch('medusa.network.hostname_resolver.dns.reversename') as mock_reverser:
+                    mock_socket.getfqdn.return_value = mock_invalid_fqdn
+                    mock_resolver.resolve.return_value = [mock_resolve_invalid]
+                    mock_reverser.reverse.return_value = mock_reverse
+                    hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
+                    self.assertNotEqual(
+                        mock_alias,
+                        hostname_resolver.resolve_fqdn("127.0.0.1"))
 
     def test_address_no_kubernetes(self):
         with patch('medusa.network.hostname_resolver.socket') as mock_socket:

--- a/tests/network/hostname_resolver_test.py
+++ b/tests/network/hostname_resolver_test.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dns.rdtypes.ANY.PTR
-import dns.name
 import unittest
 from unittest.mock import patch, MagicMock, Mock
 
@@ -28,7 +26,8 @@ mock_resolve.to_text = MagicMock(return_value=mock_fqdn)
 mock_resolve_invalid = Mock()
 mock_resolve_invalid.to_text = MagicMock(return_value=mock_invalid_fqdn)
 mock_reverse = Mock()
-mock_reverse.to_text = MagicMock(return_value="1.0.0.127-in-addr.arpa.") 
+mock_reverse.to_text = MagicMock(return_value="1.0.0.127-in-addr.arpa.")
+
 
 class HostnameResolverTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):

--- a/tests/network/hostname_resolver_test.py
+++ b/tests/network/hostname_resolver_test.py
@@ -20,11 +20,14 @@ from medusa.network.hostname_resolver import HostnameResolver
 
 mock_fqdn = "k8ssandra-dc1-default-sts-0.k8ssandra-dc1-all-pods-service.k8ssandra2022040617103007.svc.cluster.local"
 mock_invalid_fqdn = "127-0-0-1.k8ssandra-dc1-all-pods-service.k8ssandra2022040617103007.svc.cluster.local"
+mock_invalid_ipv6_fqdn = "2001-db8-85a3-8d3-1319-8a2e-370-7348.k8ssandra-dc1-all-pods-service.test.svc.cluster.local"
 mock_alias = "k8ssandra-dc1-default-sts-0"
 mock_resolve = Mock()
 mock_resolve.to_text = MagicMock(return_value=mock_fqdn)
 mock_resolve_invalid = Mock()
 mock_resolve_invalid.to_text = MagicMock(return_value=mock_invalid_fqdn)
+mock_resolve_invalid_ipv6 = Mock()
+mock_resolve_invalid_ipv6.to_text = MagicMock(return_value=mock_invalid_ipv6_fqdn)
 mock_reverse = Mock()
 mock_reverse.to_text = MagicMock(return_value="1.0.0.127-in-addr.arpa.")
 
@@ -46,7 +49,7 @@ class HostnameResolverTest(unittest.TestCase):
             with patch('medusa.network.hostname_resolver.dns.resolver') as mock_resolver:
                 with patch('medusa.network.hostname_resolver.dns.reversename') as mock_reverser:
                     mock_socket.getfqdn.return_value = mock_fqdn
-                    mock_resolver.resolve.return_value = [mock_resolve]
+                    mock_resolver.resolve.return_value = [mock_resolve_invalid, mock_resolve_invalid_ipv6, mock_resolve]
                     mock_reverser.reverse.return_value = mock_reverse
                     hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
                     self.assertEqual(
@@ -58,12 +61,36 @@ class HostnameResolverTest(unittest.TestCase):
             with patch('medusa.network.hostname_resolver.dns.resolver') as mock_resolver:
                 with patch('medusa.network.hostname_resolver.dns.reversename') as mock_reverser:
                     mock_socket.getfqdn.return_value = mock_invalid_fqdn
-                    mock_resolver.resolve.return_value = [mock_resolve_invalid]
+                    mock_resolver.resolve.return_value = [mock_resolve_invalid_ipv6]
                     mock_reverser.reverse.return_value = mock_reverse
                     hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
                     self.assertNotEqual(
                         mock_alias,
                         hostname_resolver.resolve_fqdn("127.0.0.1"))
+
+    def test_valid_address_for_kubernetes_ipv6(self):
+        with patch('medusa.network.hostname_resolver.socket') as mock_socket:
+            with patch('medusa.network.hostname_resolver.dns.resolver') as mock_resolver:
+                with patch('medusa.network.hostname_resolver.dns.reversename') as mock_reverser:
+                    mock_socket.getfqdn.return_value = mock_invalid_fqdn
+                    mock_resolver.resolve.return_value = [mock_resolve]
+                    mock_reverser.reverse.return_value = mock_reverse
+                    hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
+                    self.assertEqual(
+                        mock_alias,
+                        hostname_resolver.resolve_fqdn("::1"))
+
+    def test_invalid_address_for_kubernetes_ipv6(self):
+        with patch('medusa.network.hostname_resolver.socket') as mock_socket:
+            with patch('medusa.network.hostname_resolver.dns.resolver') as mock_resolver:
+                with patch('medusa.network.hostname_resolver.dns.reversename') as mock_reverser:
+                    mock_socket.getfqdn.return_value = mock_invalid_fqdn
+                    mock_resolver.resolve.return_value = [mock_resolve_invalid_ipv6]
+                    mock_reverser.reverse.return_value = mock_reverse
+                    hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
+                    self.assertNotEqual(
+                        mock_alias,
+                        hostname_resolver.resolve_fqdn("::1"))
 
     def test_address_no_kubernetes(self):
         with patch('medusa.network.hostname_resolver.socket') as mock_socket:

--- a/tests/resources/config/medusa-azure_blobs.ini
+++ b/tests/resources/config/medusa-azure_blobs.ini
@@ -1,7 +1,9 @@
 [cassandra]
 nodetool_flags = "-Dcom.sun.jndi.rmiURLParsing=legacy"
+use_sudo = false
 
 [storage]
+use_sudo_for_restore = false
 host_file_separator = ","
 bucket_name = medusa-integration-tests
 key_file = ~/medusa_azure_credentials.json
@@ -16,3 +18,4 @@ max_backup_count = 1
 
 [monitoring]
 monitoring_provider = local
+

--- a/tests/resources/config/medusa-google_storage.ini
+++ b/tests/resources/config/medusa-google_storage.ini
@@ -1,7 +1,10 @@
 [cassandra]
 nodetool_flags = "-Dcom.sun.jndi.rmiURLParsing=legacy"
+use_sudo = false
 
 [storage]
+use_sudo_for_restore = false
+
 host_file_separator = ","
 bucket_name = medusa-integration-tests
 key_file = ~/medusa_credentials.json

--- a/tests/resources/config/medusa-ibm_storage.ini
+++ b/tests/resources/config/medusa-ibm_storage.ini
@@ -1,7 +1,9 @@
 [cassandra]
 nodetool_flags = "-Dcom.sun.jndi.rmiURLParsing=legacy"
+use_sudo = false
 
 [storage]
+use_sudo_for_restore = false
 host_file_separator = ","
 bucket_name = medusa-experiment-2
 key_file = ~/.aws/ibm_credentials

--- a/tests/resources/config/medusa-kubernetes.ini
+++ b/tests/resources/config/medusa-kubernetes.ini
@@ -5,8 +5,10 @@ nodetool_version_cmd = nodetool -Dcom.sun.jndi.rmiURLParsing=legacy version
 cql_username = test_username
 cql_password = test_password
 nodetool_flags = "-Dcom.sun.jndi.rmiURLParsing=legacy"
+use_sudo = false
 
 [storage]
+use_sudo_for_restore = false
 storage_provider = <Storage system used for backups>
 bucket_name = cassandra_backups
 key_file = /etc/medusa/credentials

--- a/tests/resources/config/medusa-kubernetes.ini
+++ b/tests/resources/config/medusa-kubernetes.ini
@@ -18,6 +18,7 @@ transfer_max_bandwidth = 50MB/s
 concurrent_transfers = 1
 multi_part_upload_threshold = 104857600
 backup_grace_period_in_days = 0
+fqdn = localhost
 
 [kubernetes]
 enabled = true

--- a/tests/resources/config/medusa-local.ini
+++ b/tests/resources/config/medusa-local.ini
@@ -1,7 +1,9 @@
 [cassandra]
 nodetool_flags = "-Dcom.sun.jndi.rmiURLParsing=legacy"
+use_sudo = false
 
 [storage]
+use_sudo_for_restore = false
 host_file_separator = ","
 bucket_name = medusa_it_bucket
 storage_provider = local

--- a/tests/resources/config/medusa-local_backup_gc_grace.ini
+++ b/tests/resources/config/medusa-local_backup_gc_grace.ini
@@ -1,7 +1,9 @@
 [cassandra]
 nodetool_flags = "-Dcom.sun.jndi.rmiURLParsing=legacy"
+use_sudo = false
 
 [storage]
+use_sudo_for_restore = false
 host_file_separator = ","
 bucket_name = medusa_it_bucket
 storage_provider = local

--- a/tests/resources/config/medusa-minio.ini
+++ b/tests/resources/config/medusa-minio.ini
@@ -1,7 +1,9 @@
 [cassandra]
 nodetool_flags = "-Dcom.sun.jndi.rmiURLParsing=legacy"
+use_sudo = false
 
 [storage]
+use_sudo_for_restore = false
 host_file_separator = ","
 bucket_name = medusa-dev
 key_file = ~/.aws/minio_credentials

--- a/tests/resources/config/medusa-s3_us_west_oregon.ini
+++ b/tests/resources/config/medusa-s3_us_west_oregon.ini
@@ -1,7 +1,9 @@
 [cassandra]
 nodetool_flags = "-Dcom.sun.jndi.rmiURLParsing=legacy"
+use_sudo = false
 
 [storage]
+use_sudo_for_restore = false
 host_file_separator = ","
 bucket_name = tlp-medusa-dev
 key_file = ~/.aws/medusa_credentials

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
 
 commands =
     python setup.py check -m -s
-    flake8 . --ignore=W503,E402 --exclude=medusa/service/grpc/medusa_pb2.py,medusa/service/grpc/medusa_pb2_grpc.py,.tox,venv,build,dist
+    flake8 . --ignore=W503,E402 --exclude=medusa/service/grpc/medusa_pb2.py,medusa/service/grpc/medusa_pb2_grpc.py,.tox,venv,build,dist,debian
     pytest --cov=medusa --cov-report=xml -v {posargs:tests/}
 
 [flake8]


### PR DESCRIPTION
This PR changes the way restores are performed in Kubernetes.
They are associated with [this k8ssandra-operator PR](https://github.com/k8ssandra/k8ssandra-operator/pull/454).

Restore orchestration was refactored to allow computing the restore mappings without triggering the restore itself. This restore mapping will be stored under `/var/lib/cassandra/.restore_mapping/<restore key>` when the newly created `PrepareRestore()` gRPC operation is invoked.
Then the medusa-restore container will run `medusa/service/grpc/restore.py` as previously, but it was modified to read the mapping file from the restore preparation phase to find which fqdn it should restore from.
The restore mapping bits were simplified to work both with in place and remote restores (nodes are ordered by smallest token and associated one by one).



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1383) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1383
┆priority: Medium
