### PR TITLE
Fix medusa delete-backup fqdn

### DIFF
--- a/medusa/purge.py
+++ b/medusa/purge.py
@@ -234,7 +234,7 @@ def backups_to_purge_by_name(storage, cluster_backups, backup_names_to_purge, al
             raise KeyError('The backup {} does not exist'.format(backup_name))
 
     if not all_nodes:
-        backups_to_purge = [nb for nb in backups_to_purge if storage.config.fqdn in nb.fqdn]
+        backups_to_purge = [nb for nb in backups_to_purge if storage.config.fqdn == nb.fqdn]
 
     return backups_to_purge
 


### PR DESCRIPTION
I use k8s pod names as fqdn, so when deleting the backup of `cluster-1`, medusa also deletes the backup of `cluster-10`, `cluster-11`...



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1382) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1382
┆priority: Medium
