### PR TITLE
refactor: invoke CLIs as Python modules

### DIFF
--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -39,9 +39,9 @@ class AzureStorage(AbstractStorage):
         return driver
 
     def check_dependencies(self):
-        az_cli_path = AzCli.find_az_cli()
+        az_cli_cmd = AzCli.cmd()
         try:
-            subprocess.check_call([az_cli_path, "help"], stdout=PIPE, stderr=PIPE)
+            subprocess.check_call(az_cli_cmd + ["help"], stdout=PIPE, stderr=PIPE)
         except Exception:
             raise RuntimeError(
                 "Azure cli doesn't seem to be installed on this system and is a "

--- a/medusa/storage/s3_base_storage.py
+++ b/medusa/storage/s3_base_storage.py
@@ -83,12 +83,12 @@ class S3BaseStorage(AbstractStorage):
 
     def check_dependencies(self):
         if self.config.aws_cli_path == 'dynamic':
-            aws_cli_path = AwsCli.find_aws_cli()
+            aws_cli_cmd = AwsCli.cmd()
         else:
-            aws_cli_path = self.config.aws_cli_path
+            aws_cli_cmd = [self.config.aws_cli_path]
 
         try:
-            subprocess.check_call([aws_cli_path, '--version'], stdout=PIPE, stderr=PIPE)
+            subprocess.check_call(aws_cli_cmd + ['--version'], stdout=PIPE, stderr=PIPE)
         except Exception:
             raise RuntimeError(
                 "AWS cli doesn't seem to be installed on this system and is a "


### PR DESCRIPTION
Just an improvement suggestion, I think it would be more robust to let Python find the CLIs via its `PYTHONPATH`.

Basically, this does `python -m awscli` and `python -m azure.cli` with the right Python executable for `awscli` and `azure-cli` respectively.

I think the `aws_cli_path` setting should be removed or at least deprecated. Let me know what you think.

Later, it could be good to consider replacing the `awscli` by [s3transfer](https://github.com/boto/s3transfer) (the library it uses under the hood), it would more lightweight and would avoid odd issues, especially with the `max_bandwidth` config (#354), but it is not GA yet.
