### PR TITLE
chore: remove GCS dependency group

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -17,7 +17,7 @@ Install Medusa on each Cassandra node using one of the following methods.
 
 * if the storage backend is a locally accessible shared storage, run `sudo pip3 install cassandra-medusa`
 * if your backups are to be stored in AWS S3 or S3 compatible backends (IBM, OVHCloud, MinIO, ...), run `sudo pip3 install cassandra-medusa[S3]`
-* if your backups are to be stored in Google Cloud Storage, run `sudo pip3 install cassandra-medusa[GCS]`
+* if your backups are to be stored in Google Cloud Storage, run `sudo pip3 install cassandra-medusa`
 * if your backups are to be stored in Azure Blob Storage, run `sudo pip3 install cassandra-medusa[AZURE]`
 
 Running the installation using `sudo` is necessary to have the `/usr/local/bin/medusa` script created properly.
@@ -27,11 +27,11 @@ Running the installation using `sudo` is necessary to have the `/usr/local/bin/m
 If your Cassandra servers do not have internet access:  
 
 - on a machine with the same target os and python version, clone the cassandra-medusa repo and cd into the root directory
-- run `mkdir pip_dependencies && pip download -r requirements.txt -d medusa_dependencies` to download the dependencies into a sub directory (do the same thing with either requirements-s3.txt or requirements-gcs.txt depending on your storage)
-- run `cp requirements.txt medusa_dependencies/` (plus either requirements-s3.txt or requirements-gcs.txt)
+- run `mkdir pip_dependencies && pip download -r requirements.txt -d medusa_dependencies` to download the dependencies into a sub directory (do the same thing with either requirements-s3.txt or requirements-azure.txt depending on your storage)
+- run `cp requirements.txt medusa_dependencies/` (plus either requirements-s3.txt or requirements-azure.txt)
 - run `tar -zcf medusa_dependencies.tar.gz medusa_dependencies` to compress the dependencies
 - Upload the archive to all Cassandra nodes and decompress it
-- run `pip install -r medusa_dependencies/requirements.txt --no-index --find-links` to install the dependencies on the nodes (do the same thing with either requirements-s3.txt or requirements-gcs.txt depending on your storage)
+- run `pip install -r medusa_dependencies/requirements.txt --no-index --find-links` to install the dependencies on the nodes (do the same thing with either requirements-s3.txt or requirements-azure.txt depending on your storage)
 - install Medusa using `python setup.py install` from the cassandra-medusa source directory
 
 #### Example of Offline installation using pipenv on RHEL, centos 7

--- a/requirements-gcs.txt
+++ b/requirements-gcs.txt
@@ -1,1 +1,0 @@
-google-cloud-storage>=1.7.0

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setuptools.setup(
     ],
     extras_require={
         'S3': ["awscli>=1.16.291"],
-        'GCS': ["google-cloud-storage>=1.7.0"],
         'AZURE': ["azure-cli>=2.24.0"]
     },
     entry_points={


### PR DESCRIPTION
I have looked around and I cannot find where this package is used. `libcloud` appears to do everything. It is not even installed by the CI or [Dockerfile-gcs](https://github.com/thelastpickle/cassandra-medusa/blob/master/k8s/Dockerfile-gcs). Please do not hesitate to let me know if I am missing something



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1377) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1377
┆priority: Medium
