### PR TITLE
ISSUE-457: Remove plaintext passwords in config

### DIFF
--- a/medusa/config.py
+++ b/medusa/config.py
@@ -211,10 +211,27 @@ def parse_config(args, config_file):
         # Use the ip address instead of the fqdn when DNS resolving is turned off
         config['storage']['fqdn'] = socket.gethostbyname(socket.getfqdn())
 
-    if "CQL_USERNAME" in os.environ:
-        config['cassandra']['cql_username'] = os.environ["CQL_USERNAME"]
-    if "CQL_PASSWORD" in os.environ:
-        config['cassandra']['cql_password'] = os.environ["CQL_PASSWORD"]
+    for config_property in ['cql_username', 'cql_password']:
+        config_property_upper_old = config_property.upper()
+        config_property_upper_new = "MEDUSA_{}".format(config_property.upper())
+        if config_property_upper_old in os.environ:
+            config['cassandra'][config_property] = os.environ[config_property_upper_old]
+            logging.warning('The {} environment variable is deprecated and has been replaced by the {} variable'
+                            .format(config_property_upper_old, config_property_upper_new))
+        if config_property_upper_new in os.environ:
+            config['cassandra'][config_property] = os.environ[config_property_upper_new]
+            logging.warning('Both {0} and {1} are defined in the environment; using the value set in {1}'
+                            .format(config_property_upper_old, config_property_upper_new))
+
+    for config_property in [
+        'nodetool_username',
+        'nodetool_password',
+        'sstableloader_tspw',
+        'sstableloader_kspw'
+    ]:
+        config_property_upper = "MEDUSA_{}".format(config_property.upper())
+        if config_property_upper in os.environ:
+            config['cassandra'][config_property] = os.environ[config_property_upper]
 
     return config
 

--- a/tests/resources/config/medusa.ini
+++ b/tests/resources/config/medusa.ini
@@ -2,8 +2,14 @@
 stop_cmd = /etc/init.d/cassandra stop
 start_cmd = /etc/init.d/cassandra start
 nodetool_version_cmd = nodetool version
-cql_username = test_username
-cql_password = test_password
+cql_username = test_cql_username
+cql_password = test_cql_password
+nodetool_username = test_nodetool_username
+nodetool_password = test_nodetool_password
+sstableloader_ts = /etc/ssl/truststore.jks
+sstableloader_tspw = test_ts_password
+sstableloader_ks = /etc/ssl/keystore.jks
+sstableloader_kspw = test_ks_password
 
 [storage]
 storage_provider = <Storage system used for backups>

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 commands =
     python setup.py check -m -s
     flake8 . --ignore=W503,E402 --exclude=medusa/service/grpc/medusa_pb2.py,.tox,venv
-    pytest --cov=medusa --cov-report=xml -v tests/
+    pytest --cov=medusa --cov-report=xml -v {posargs:tests/}
 
 [flake8]
 exclude = .tox,*.egg,build,data,scripts,env,venv


### PR DESCRIPTION
* Extended functionality for CQLSH credentials to allow nodetool credentials and keystore/truststore passwords to be defined in environment variables
* Updated environment variables to be prefixed with `MEDUSA_`
* Added deprecated warning message to `CQL_*` environment variables
* Minor change to tox configuration to allow individual unit tests to be executed



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1375) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1375
┆priority: Medium
