### PR TITLE
Add missing documentation for configuration options

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -15,6 +15,17 @@ Modify it to match your requirements:
 ;nodetool_password_file_path = <path to nodetool password file>
 ;nodetool_host = <host name or IP to use for nodetool>
 ;nodetool_port = <port number to use for nodetool>
+;certfile= <Client SSL: path to rootCa certificate>
+;usercert= <Client SSL: path to user certificate>
+;userkey= <Client SSL: path to user key>
+;sstableloader_ts = <Client SSL: full path to truststore>
+;sstableloader_tspw = <Client SSL: password of the truststore>
+;sstableloader_ks = <Client SSL: full path to keystore>
+;sstableloader_kspw = <Client SSL: password of the keystore>
+;sstableloader_bin = <Location of the sstableloader binary if not in PATH>
+
+; Enable this to add the '--ssl' parameter to nodetool. The nodetool-ssl.properties is expected to be in the normal location
+;nodetool_ssl = true
 
 ; Command ran to verify if Cassandra is running on a node. Defaults to "nodetool version"
 ;check_running = nodetool version
@@ -65,6 +76,9 @@ concurrent_transfers = 1
 ; Size over which S3 uploads will be using the awscli with multi part uploads. Defaults to 100MB.
 multi_part_upload_threshold = 104857600
 
+; GC grace period for backed up files. Prevents race conditions between purge and running backups
+backup_grace_period_in_days = 10
+
 ; When not using sstableloader to restore data on a node, Medusa will copy snapshot files from a
 ; temporary location into the cassandra data directroy. Medusa will then attempt to change the
 ; ownership of the snapshot files so the cassandra user can access them.
@@ -77,12 +91,23 @@ multi_part_upload_threshold = 104857600
 ; Defaults to True
 ;use_sudo_for_restore = True
 
+;api_profile = <AWS profile to use>
+
+;host = <Optional object storage host to connect to>
+;port = <Optional object storage port to connect to>
+
+; Configures the use of SSL to connect to the object storage system.
+;secure = True
+
+;aws_cli_path = <Location of the aws cli binary if not in PATH>
+
 [monitoring]
 ;monitoring_provider = <Provider used for sending metrics. Currently either of "ffwd" or "local">
 
 [ssh]
 ;username = <SSH username to use for restoring clusters>
 ;key_file = <SSH key for use for restoring clusters. Expected in PEM unencrypted format.>
+;port = <SSH port for use for restoring clusters. Default to port 22.
 ;cert_file = <Path of public key signed certificate file to use for authentication. The corresponding private key must also be provided via key_file parameter>
 
 [checks]
@@ -107,4 +132,16 @@ multi_part_upload_threshold = 104857600
 ; How many log files to keep
 ; backupCount = 50
 
+[grpc]
+; Set to true when running in grpc server mode.
+; Allows to propagate the exceptions instead of exiting the program.
+;enabled = False
+
+[kubernetes]
+; The following settings are only intended to be configured if Medusa is running in containers, preferably in Kubernetes.
+;enabled = False
+;cassandra_url = <URL of the management API snapshot endpoint. For example: http://127.0.0.1:8080/api/v0/ops/node/snapshots>
+
+; Enables the use of the management API to create snapshots. Falls back to using Jolokia if not enabled.
+;use_mgmt_api = True
 ```


### PR DESCRIPTION
Add documentation for the option `nodetool_ssl` as used here:

https://github.com/thelastpickle/cassandra-medusa/blob/a00a45593c44b3e4f99adaa1a89475af987c1a9b/medusa/nodetool.py#L21

Note that it may be worth it to change it to a proper boolean instead.