### PR TITLE
Build medusa cli in docker files

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -30,21 +30,22 @@ RUN apt-get update \
 
 ENV PATH=/root/.local/bin:$PATH
 
+COPY . /build/
+
 # General requirements
-COPY requirements.txt /requirements.txt
-COPY requirements-grpc-runtime.txt /requirements-grpc-runtime.txt
 RUN python3 -m pip install -U pip && pip3 install --ignore-installed --user \
-    -r /requirements.txt \
-    -r /requirements-grpc-runtime.txt
+    -r /build/requirements.txt \
+    -r /build/requirements-grpc-runtime.txt
 
 # Amazon S3
-COPY requirements-s3.txt /requirements-s3.txt
-RUN pip3 install --ignore-installed --user -r /requirements-s3.txt
+RUN pip3 install --ignore-installed --user -r /build/requirements-s3.txt
 
 # Azure
-COPY requirements-azure.txt /requirements-azure.txt
-RUN pip3 install --ignore-installed --user -r /requirements-azure.txt \
+RUN pip3 install --ignore-installed --user -r /build/requirements-azure.txt \
      && pip3 install --ignore-installed --user azure-cli
+
+# Build medusa itself so we can add the executables in the final image
+RUN pip3 install --ignore-installed --user /build
 
 # Could be python:slim, but we have a .sh entrypoint
 FROM ubuntu:18.04

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -81,6 +81,10 @@ COPY --from=base --chown=cassandra:cassandra /root/.local /home/cassandra/.local
 COPY --chown=cassandra:cassandra medusa /home/cassandra/medusa
 COPY --chown=cassandra:cassandra k8s/docker-entrypoint.sh /home/cassandra
 
+# Avoid Click locale errors when running medusa directly
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
 WORKDIR /home/cassandra
 
 ENTRYPOINT ["/home/cassandra/docker-entrypoint.sh"]

--- a/k8s/Dockerfile-azure
+++ b/k8s/Dockerfile-azure
@@ -68,6 +68,10 @@ COPY --from=base --chown=cassandra:cassandra /root/.local /home/cassandra/.local
 COPY --chown=cassandra:cassandra medusa /home/cassandra/medusa
 COPY --chown=cassandra:cassandra k8s/docker-entrypoint.sh /home/cassandra
 
+# Avoid Click locale errors when running medusa directly
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
 WORKDIR /home/cassandra
 
 ENTRYPOINT ["/home/cassandra/docker-entrypoint.sh"]

--- a/k8s/Dockerfile-azure
+++ b/k8s/Dockerfile-azure
@@ -63,6 +63,8 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
 USER cassandra
 WORKDIR /home/cassandra
 
+ENV PATH=/home/cassandra/.local/bin:$PATH
+
 COPY --from=base --chown=cassandra:cassandra /root/.local /home/cassandra/.local
 
 COPY --chown=cassandra:cassandra medusa /home/cassandra/medusa

--- a/k8s/Dockerfile-azure
+++ b/k8s/Dockerfile-azure
@@ -30,17 +30,19 @@ RUN apt-get update \
 
 ENV PATH=/root/.local/bin:$PATH
 
+COPY . /build/
+
 # General requirements
-COPY requirements.txt /requirements.txt
-COPY requirements-grpc-runtime.txt /requirements-grpc-runtime.txt
 RUN python3 -m pip install -U pip && pip3 install --ignore-installed --user \
-    -r /requirements.txt \
-    -r /requirements-grpc-runtime.txt
+    -r /build/requirements.txt \
+    -r /build/requirements-grpc-runtime.txt
 
 # Azure
-COPY requirements-azure.txt /requirements-azure.txt
-RUN pip3 install --ignore-installed --user -r /requirements-azure.txt \
+RUN pip3 install --ignore-installed --user -r /build/requirements-azure.txt \
      && pip3 install --ignore-installed --user azure-cli
+
+# Build medusa itself so we can add the executables in the final image
+RUN pip3 install --ignore-installed --user /build
 
 # Could be python:slim, but we have a .sh entrypoint
 FROM ubuntu:18.04

--- a/k8s/Dockerfile-gcs
+++ b/k8s/Dockerfile-gcs
@@ -30,12 +30,15 @@ RUN apt-get update \
 
 ENV PATH=/root/.local/bin:$PATH
 
+COPY . /build/
+
 # General requirements
-COPY requirements.txt /requirements.txt
-COPY requirements-grpc-runtime.txt /requirements-grpc-runtime.txt
 RUN python3 -m pip install -U pip && pip3 install --ignore-installed --user \
-    -r /requirements.txt \
-    -r /requirements-grpc-runtime.txt
+    -r /build/requirements.txt \
+    -r /build/requirements-grpc-runtime.txt
+
+# Build medusa itself so we can add the executables in the final image
+RUN pip3 install --ignore-installed --user /build
 
 # Could be python:slim, but we have a .sh entrypoint
 FROM ubuntu:18.04

--- a/k8s/Dockerfile-gcs
+++ b/k8s/Dockerfile-gcs
@@ -74,6 +74,10 @@ COPY --from=base --chown=cassandra:cassandra /root/.local /home/cassandra/.local
 COPY --chown=cassandra:cassandra medusa /home/cassandra/medusa
 COPY --chown=cassandra:cassandra k8s/docker-entrypoint.sh /home/cassandra
 
+# Avoid Click locale errors when running medusa directly
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
 WORKDIR /home/cassandra
 
 ENTRYPOINT ["/home/cassandra/docker-entrypoint.sh"]

--- a/k8s/Dockerfile-s3
+++ b/k8s/Dockerfile-s3
@@ -30,16 +30,18 @@ RUN apt-get update \
 
 ENV PATH=/root/.local/bin:$PATH
 
+COPY . /build/
+
 # General requirements
-COPY requirements.txt /requirements.txt
-COPY requirements-grpc-runtime.txt /requirements-grpc-runtime.txt
 RUN python3 -m pip install -U pip && pip3 install --ignore-installed --user \
-    -r /requirements.txt \
-    -r /requirements-grpc-runtime.txt
+    -r /build/requirements.txt \
+    -r /build/requirements-grpc-runtime.txt
 
 # Amazon S3
-COPY requirements-s3.txt /requirements-s3.txt
-RUN pip3 install --ignore-installed --user -r /requirements-s3.txt
+RUN pip3 install --ignore-installed --user -r /build/requirements-s3.txt
+
+# Build medusa itself so we can add the executables in the final image
+RUN pip3 install --ignore-installed --user /build
 
 # Could be python:slim, but we have a .sh entrypoint
 FROM ubuntu:18.04

--- a/k8s/Dockerfile-s3
+++ b/k8s/Dockerfile-s3
@@ -67,6 +67,10 @@ COPY --from=base --chown=cassandra:cassandra /root/.local /home/cassandra/.local
 COPY --chown=cassandra:cassandra medusa /home/cassandra/medusa
 COPY --chown=cassandra:cassandra k8s/docker-entrypoint.sh /home/cassandra
 
+# Avoid Click locale errors when running medusa directly
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
 WORKDIR /home/cassandra
 
 ENTRYPOINT ["/home/cassandra/docker-entrypoint.sh"]

--- a/k8s/Dockerfile-s3
+++ b/k8s/Dockerfile-s3
@@ -62,6 +62,8 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.3.2 && \
 USER cassandra
 WORKDIR /home/cassandra
 
+ENV PATH=/home/cassandra/.local/bin:$PATH
+
 COPY --from=base --chown=cassandra:cassandra /root/.local /home/cassandra/.local
 
 COPY --chown=cassandra:cassandra medusa /home/cassandra/medusa


### PR DESCRIPTION
This PR adds support for using the medusa cli inside the docker containers.

Before:

```
$ docker run -it --rm --entrypoint medusa medusa-test
docker: Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "medusa": executable file not found in $PATH: unknown.
```

After:

```
$ docker run -it --rm --entrypoint medusa medusa-test
Usage: medusa [OPTIONS] COMMAND [ARGS]...

Options:
 ( ... )
```



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1374) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1374
┆priority: Medium
