### PR TITLE
Sanitizing operator fqdn convention

### DIFF
--- a/medusa/service/grpc/restore.py
+++ b/medusa/service/grpc/restore.py
@@ -15,13 +15,33 @@
 
 import logging
 import os
+import re
 import sys
 from collections import defaultdict
 from pathlib import Path
 
 import medusa.config
-import medusa.restore_node
 import medusa.listing
+import medusa.restore_node
+
+
+def sanitize_fqdn(fqdn):
+    """
+     Ensure fqdn is trimmed to support k8s operators using a longer fqdn such as:
+     k8ssandra-dc1-default-sts-0.k8ssandra-dc1-all-pods-service.k8ssandra2022040617103007.svc.cluster.local
+
+     should result in
+     k8ssandra-dc1-default-sts-0
+
+     Retain input value if not containing a '.' or detected as physical ip address.
+     """
+
+    trimmed_fqdn = fqdn
+    if fqdn is not None and re.match(r'(^[\d]{1,3})\.([\d]{1,3})\.([\d]{1,3})\.([\d]{1,3})', fqdn) is None:
+        idx = fqdn.index('.')
+        if idx > 0:
+            trimmed_fqdn = fqdn[:idx]
+    return trimmed_fqdn
 
 
 def create_config(config_file_path):

--- a/tests/restore_cluster_test.py
+++ b/tests/restore_cluster_test.py
@@ -26,6 +26,7 @@ from unittest.mock import Mock
 from medusa.config import (MedusaConfig, StorageConfig, _namedtuple_from_dict, CassandraConfig, GrpcConfig,
                            KubernetesConfig, parse_config)
 from medusa.restore_cluster import RestoreJob, expand_repeatable_option
+from medusa.service.grpc.restore import sanitize_fqdn
 from medusa.utils import evaluate_boolean
 
 
@@ -85,6 +86,14 @@ class RestoreClusterTest(unittest.TestCase):
         }
         return config
 
+    @staticmethod
+    def test_operator_naming_sanitizer():
+        fqdn_from_operator = "k8ssandra-dc1-default-sts-0.k8ssandra-dc1-all-pods-service.k8ssandra2022040617103007" \
+                             ".svc.cluster.local"
+        fqdn_result = sanitize_fqdn(fqdn_from_operator)
+
+        assert fqdn_from_operator != fqdn_result
+
     # Test that we can properly associate source and target nodes for restore using a host list
     @mock.patch("medusa.network.hostname_resolver.HostnameResolver.resolve_fqdn")
     def test_populate_hostmap(self, resolver_mock):
@@ -112,7 +121,6 @@ class RestoreClusterTest(unittest.TestCase):
     # Test that we can properly associate source and target nodes for restore using a token map
     @mock.patch("medusa.network.hostname_resolver.HostnameResolver.resolve_fqdn")
     def test_populate_ringmap(self, resolver_mock):
-
         # resolver checks for seed target w/ resolve as well.
         seed_target = "node1.mydomain.net"
         resolver_mock.side_effect = ['node4.mydomain.net', seed_target, 'node1.mydomain.net',


### PR DESCRIPTION
A fix for issue: #464

The `cass-operator 1.10.3` fixed resolving IP addresses of pods to their hostnames. The operator fqdn contains extra information.

Expected/existing format: 

* `k8ssandra-dc1-default-sts-0`

Operator format:

* `k8ssandra-dc1-default-sts-0.k8ssandra-dc1-all-pods-service.k8ssandra2022040617103007.svc.cluster.local`

**Issue:**

Creates a situation where upon restore, Medusa will look for the backup using the operator formatted fqdn, which discards all backups taken prior to the upgrade.

**Fix**: sanitize fqdn to remove all extra parts, which aren't necessary to Medusa as it operates with `dc/namespace/cluster` format.



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1437) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1437
┆priority: Medium
