### PR TITLE
Sanitize fqdns for kubernetes deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ debian/cassandra-medusa/
 .coverage
 coverage.xml
 pytest.ini
+.python-version

--- a/medusa/backup_cluster.py
+++ b/medusa/backup_cluster.py
@@ -125,7 +125,7 @@ class BackupJob(object):
         self.cassandra = Cassandra(config) if cassandra_config is None else cassandra_config
         self.snapshot_tag = '{}{}'.format(self.cassandra.SNAPSHOT_PREFIX, self.backup_name)
         fqdn_resolver = medusa.utils.evaluate_boolean(self.config.cassandra.resolve_ip_addresses)
-        k8s_mode = medusa.utils.evaluate_boolean(config.kubernetes.enabled)
+        k8s_mode = medusa.utils.evaluate_boolean(config.kubernetes.enabled if config.kubernetes else False)
         self.fqdn_resolver = HostnameResolver(fqdn_resolver, k8s_mode)
 
     def execute(self, cql_session_provider=None):

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -106,9 +106,10 @@ class CqlSessionProvider(object):
                     session = cluster.connect()
                     return CqlSession(session,
                                       evaluate_boolean(self._cassandra_config.resolve_ip_addresses),
-                                      evaluate_boolean(self._config.kubernetes.enabled))
+                                      evaluate_boolean(
+                                          self._config.kubernetes.enabled if self._config.kubernetes else False))
                 except Exception as e:
-                    logging.debug('Failed to create session', exc_info=e)
+                    logging.warning('Failed to create session', exc_info=e)
                 delay = 5 * (2 ** (attempts + 1))
                 time.sleep(delay)
                 attempts = attempts + 1
@@ -118,7 +119,7 @@ class CqlSessionProvider(object):
             session = cluster.connect()
             return CqlSession(session,
                               evaluate_boolean(self._cassandra_config.resolve_ip_addresses),
-                              evaluate_boolean(self._config.kubernetes.enabled))
+                              evaluate_boolean(self._config.kubernetes.enabled if self._config.kubernetes else False))
 
 
 class CqlSession(object):

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -39,7 +39,7 @@ from medusa.host_man import HostMan
 from medusa.network.hostname_resolver import HostnameResolver
 from medusa.nodetool import Nodetool
 from medusa.service.snapshot import SnapshotService
-from medusa.utils import null_if_empty
+from medusa.utils import null_if_empty, evaluate_boolean
 
 
 class SnapshotPath(object):
@@ -56,26 +56,27 @@ class SnapshotPath(object):
 
 class CqlSessionProvider(object):
 
-    def __init__(self, ip_addresses, cassandra_config):
+    def __init__(self, ip_addresses, config):
         self._ip_addresses = ip_addresses
         self._auth_provider = None
         self._ssl_context = None
-        self._cassandra_config = cassandra_config
-        self._native_port = CassandraConfigReader(cassandra_config.config_file).native_port
+        self._cassandra_config = config.cassandra
+        self._config = config
+        self._native_port = CassandraConfigReader(self._cassandra_config.config_file).native_port
 
-        if null_if_empty(cassandra_config.cql_username) and null_if_empty(cassandra_config.cql_password):
-            auth_provider = PlainTextAuthProvider(username=cassandra_config.cql_username,
-                                                  password=cassandra_config.cql_password)
+        if null_if_empty(self._cassandra_config.cql_username) and null_if_empty(self._cassandra_config.cql_password):
+            auth_provider = PlainTextAuthProvider(username=self._cassandra_config.cql_username,
+                                                  password=self._cassandra_config.cql_password)
             self._auth_provider = auth_provider
 
-        if cassandra_config.certfile is not None:
+        if self._cassandra_config.certfile is not None:
             ssl_context = SSLContext(PROTOCOL_TLSv1_2)
-            ssl_context.load_verify_locations(cassandra_config.certfile)
+            ssl_context.load_verify_locations(self._cassandra_config.certfile)
             ssl_context.verify_mode = CERT_REQUIRED
-            if cassandra_config.usercert is not None and cassandra_config.userkey is not None:
+            if self._cassandra_config.usercert is not None and self._cassandra_config.userkey is not None:
                 ssl_context.load_cert_chain(
-                    certfile=cassandra_config.usercert,
-                    keyfile=cassandra_config.userkey)
+                    certfile=self._cassandra_config.usercert,
+                    keyfile=self._cassandra_config.userkey)
             self._ssl_context = ssl_context
 
         load_balancing_policy = WhiteListRoundRobinPolicy(ip_addresses)
@@ -103,7 +104,9 @@ class CqlSessionProvider(object):
             while attempts < max_retries:
                 try:
                     session = cluster.connect()
-                    return CqlSession(session, self._cassandra_config.resolve_ip_addresses)
+                    return CqlSession(session,
+                                      evaluate_boolean(self._cassandra_config.resolve_ip_addresses),
+                                      evaluate_boolean(self._config.kubernetes.enabled))
                 except Exception as e:
                     logging.debug('Failed to create session', exc_info=e)
                 delay = 5 * (2 ** (attempts + 1))
@@ -113,15 +116,17 @@ class CqlSessionProvider(object):
                                                'after {attempts}'.format(attempts=attempts))
         else:
             session = cluster.connect()
-            return CqlSession(session, self._cassandra_config.resolve_ip_addresses)
+            return CqlSession(session,
+                              evaluate_boolean(self._cassandra_config.resolve_ip_addresses),
+                              evaluate_boolean(self._config.kubernetes.enabled))
 
 
 class CqlSession(object):
     EXCLUDED_KEYSPACES = ['system_traces']
 
-    def __init__(self, session, resolve_ip_addresses=True):
+    def __init__(self, session, resolve_ip_addresses=True, k8s_mode=False):
         self._session = session
-        self.hostname_resolver = HostnameResolver(resolve_ip_addresses)
+        self.hostname_resolver = HostnameResolver(resolve_ip_addresses, k8s_mode)
 
     def __enter__(self):
         return self
@@ -339,7 +344,7 @@ class Cassandra(object):
         self._native_port = config_reader.native_port
         self._cql_session_provider = CqlSessionProvider(
             [self._hostname],
-            cassandra_config)
+            config)
         self._rpc_port = config_reader.rpc_port
         self.seeds = config_reader.seeds
 

--- a/medusa/network/hostname_resolver.py
+++ b/medusa/network/hostname_resolver.py
@@ -18,8 +18,9 @@ import logging
 
 
 class HostnameResolver:
-    def __init__(self, resolve_addresses):
+    def __init__(self, resolve_addresses, k8s_mode):
         self.resolve_addresses = resolve_addresses
+        self.k8s_mode = k8s_mode
 
     def resolve_fqdn(self, ip_address=''):
         ip_address_to_resolve = ip_address if ip_address != '' else socket.gethostbyname(socket.getfqdn())
@@ -29,5 +30,9 @@ class HostnameResolver:
             return ip_address_to_resolve
 
         fqdn = socket.getfqdn(ip_address_to_resolve)
-        logging.debug("Resolved {} to {}".format(ip_address_to_resolve, fqdn))
-        return fqdn
+        returned_fqdn = fqdn
+        if self.k8s_mode and fqdn.find('.') > 0:
+            returned_fqdn = fqdn.split('.')[0]
+        logging.debug("Resolved {} to {}".format(ip_address_to_resolve, returned_fqdn))
+
+        return returned_fqdn

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -42,7 +42,8 @@ def orchestrate(config, backup_name, seed_target, temp_dir, host_list, keep_auth
         if seed_target is None and host_list is None:
             # if no target node is provided, nor a host list file, default to the local node as seed target
             hostname_resolver = HostnameResolver(medusa.utils.evaluate_boolean(config.cassandra.resolve_ip_addresses),
-                                                 medusa.utils.evaluate_boolean(config.kubernetes.enabled))
+                                                 medusa.utils.evaluate_boolean(
+                                                     config.kubernetes.enabled if config.kubernetes else False))
             seed_target = hostname_resolver.resolve_fqdn(socket.gethostbyname(socket.getfqdn()))
             logging.warning("Seed target was not provided, using the local hostname: {}".format(seed_target))
 
@@ -124,7 +125,7 @@ class RestoreJob(object):
         self.pssh_pool_size = parallel_restores
         self.cassandra = Cassandra(config)
         fqdn_resolver = medusa.utils.evaluate_boolean(self.config.cassandra.resolve_ip_addresses)
-        k8s_mode = medusa.utils.evaluate_boolean(config.kubernetes.enabled)
+        k8s_mode = medusa.utils.evaluate_boolean(config.kubernetes.enabled if config.kubernetes else False)
         self.fqdn_resolver = HostnameResolver(fqdn_resolver, k8s_mode)
         self._version_target = version_target
 

--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -55,7 +55,8 @@ def restore_node(config, temp_dir, backup_name, in_place, keep_auth, seeds, veri
 
     if verify:
         hostname_resolver = HostnameResolver(medusa.config.evaluate_boolean(config.cassandra.resolve_ip_addresses),
-                                             medusa.utils.evaluate_boolean(config.kubernetes.enabled))
+                                             medusa.utils.evaluate_boolean(
+                                                 config.kubernetes.enabled if config.kubernetes else False))
         verify_restore([hostname_resolver.resolve_fqdn()], config)
 
 
@@ -89,7 +90,7 @@ def restore_node_locally(config, temp_dir, backup_name, in_place, keep_auth, see
     logging.info('Downloading data from backup to {}'.format(download_dir))
     download_data(config.storage, node_backup, fqtns_to_restore, destination=download_dir)
 
-    if not medusa.utils.evaluate_boolean(config.kubernetes.enabled):
+    if not medusa.utils.evaluate_boolean(config.kubernetes.enabled if config.kubernetes else False):
         logging.info('Stopping Cassandra')
         cassandra.shutdown()
         wait_for_node_to_go_down(config, cassandra.hostname)
@@ -121,7 +122,7 @@ def restore_node_locally(config, temp_dir, backup_name, in_place, keep_auth, see
     # In a Kubernetes deployment we can assume that seed nodes will be started first. It will
     # handled either by the statefulset controller or by the controller of a Cassandra
     # operator.
-    if not medusa.utils.evaluate_boolean(config.kubernetes.enabled):
+    if not medusa.utils.evaluate_boolean(config.kubernetes.enabled if config.kubernetes else False):
         if seeds is not None:
             wait_for_seeds(config, seeds)
         else:
@@ -188,7 +189,8 @@ def restore_node_sstableloader(config, temp_dir, backup_name, in_place, keep_aut
 
 def invoke_sstableloader(config, download_dir, keep_auth, fqtns_to_restore, storage_port):
     hostname_resolver = HostnameResolver(medusa.utils.evaluate_boolean(config.cassandra.resolve_ip_addresses),
-                                         medusa.utils.evaluate_boolean(config.kubernetes.enabled))
+                                         medusa.utils.evaluate_boolean(
+                                             config.kubernetes.enabled if config.kubernetes else False))
     cassandra_is_ccm = int(shlex.split(config.cassandra.is_ccm)[0])
     keyspaces = os.listdir(str(download_dir))
     for keyspace in keyspaces:

--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -54,7 +54,8 @@ def restore_node(config, temp_dir, backup_name, in_place, keep_auth, seeds, veri
                                    keyspaces, tables)
 
     if verify:
-        hostname_resolver = HostnameResolver(medusa.config.evaluate_boolean(config.cassandra.resolve_ip_addresses))
+        hostname_resolver = HostnameResolver(medusa.config.evaluate_boolean(config.cassandra.resolve_ip_addresses),
+                                             medusa.utils.evaluate_boolean(config.kubernetes.enabled))
         verify_restore([hostname_resolver.resolve_fqdn()], config)
 
 
@@ -186,7 +187,8 @@ def restore_node_sstableloader(config, temp_dir, backup_name, in_place, keep_aut
 
 
 def invoke_sstableloader(config, download_dir, keep_auth, fqtns_to_restore, storage_port):
-    hostname_resolver = HostnameResolver(medusa.utils.evaluate_boolean(config.cassandra.resolve_ip_addresses))
+    hostname_resolver = HostnameResolver(medusa.utils.evaluate_boolean(config.cassandra.resolve_ip_addresses),
+                                         medusa.utils.evaluate_boolean(config.kubernetes.enabled))
     cassandra_is_ccm = int(shlex.split(config.cassandra.is_ccm)[0])
     keyspaces = os.listdir(str(download_dir))
     for keyspace in keyspaces:

--- a/medusa/service/snapshot/__init__.py
+++ b/medusa/service/snapshot/__init__.py
@@ -26,7 +26,7 @@ class SnapshotService(object):
         self.snapshot_service = self._create_snapshot_service()
 
     def _create_snapshot_service(self):
-        if medusa.utils.evaluate_boolean(self._config.kubernetes.enabled):
+        if medusa.utils.evaluate_boolean(self._config.kubernetes.enabled if self._config.kubernetes else False):
             if medusa.utils.evaluate_boolean(self._config.kubernetes.use_mgmt_api):
                 return ManagementAPISnapshotService(self._config.kubernetes)
             else:

--- a/medusa/verify_restore.py
+++ b/medusa/verify_restore.py
@@ -79,7 +79,7 @@ def _get_cql_session_provider(config, hosts):
     else:
         cql_hosts = hosts
 
-    return CqlSessionProvider(cql_hosts, config.cassandra)
+    return CqlSessionProvider(cql_hosts, config)
 
 
 def _consume_results(cql_results):

--- a/tests/backup_cluster_test.py
+++ b/tests/backup_cluster_test.py
@@ -19,7 +19,8 @@ from enum import IntEnum
 from unittest.mock import create_autospec
 
 from medusa.cassandra_utils import Cassandra, CqlSessionProvider
-from medusa.config import (_namedtuple_from_dict, MedusaConfig, CassandraConfig, SSHConfig, StorageConfig)
+from medusa.config import (KubernetesConfig, _namedtuple_from_dict,
+                           MedusaConfig, CassandraConfig, SSHConfig, StorageConfig)
 from medusa.monitoring import Monitoring
 from medusa.orchestration import Orchestration
 from medusa.storage import Storage
@@ -64,6 +65,9 @@ class BackupClusterTest(unittest.TestCase):
             'fqdn': '127.0.0.1',
             'storage_provider': ''
         } if storage_config is None else storage_config
+        config['kubernetes'] = {
+            'enabled': 'False',
+        }
         return config
 
     @staticmethod
@@ -77,7 +81,7 @@ class BackupClusterTest(unittest.TestCase):
             checks=None,
             logging=None,
             grpc=None,
-            kubernetes=None,
+            kubernetes=_namedtuple_from_dict(KubernetesConfig, config['kubernetes']),
         )
 
     def test_backup_object_creation(self):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -65,7 +65,8 @@ class ConfigTest(unittest.TestCase):
         assert config.storage.bucket_name == 'Hector'
         assert config.cassandra.cql_username == 'Priam'
         assert medusa.utils.evaluate_boolean(config.grpc.enabled)  # FIXME collision
-        assert medusa.utils.evaluate_boolean(config.kubernetes.enabled)  # FIXME collision
+        assert medusa.utils.evaluate_boolean(
+            config.kubernetes.enabled if config.kubernetes else False)  # FIXME collision
         assert config.logging.file == 'hera.log'
         assert config.monitoring.monitoring_provider == 'local'
         assert config.checks.query == 'SELECT * FROM greek_mythology'
@@ -78,7 +79,7 @@ class ConfigTest(unittest.TestCase):
         config = medusa.config.load_config(args, self.medusa_config_file)
         assert medusa.utils.evaluate_boolean(config.cassandra.use_sudo)
         # Kubernetes must be disabled by default so use_sudo can be honored
-        assert not medusa.utils.evaluate_boolean(config.kubernetes.enabled)
+        assert not medusa.utils.evaluate_boolean(config.kubernetes.enabled if config.kubernetes else False)
 
     def test_use_sudo_kubernetes_disabled(self):
         """Ensure that use_sudo is honored when Kubernetes mode is disabled (default)"""

--- a/tests/network/hostname_resolver_test.py
+++ b/tests/network/hostname_resolver_test.py
@@ -14,8 +14,12 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import patch
 
 from medusa.network.hostname_resolver import HostnameResolver
+
+mock_fqdn = "k8ssandra-dc1-default-sts-0.k8ssandra-dc1-all-pods-service.k8ssandra2022040617103007.svc.cluster.local"
+mock_alias = "k8ssandra-dc1-default-sts-0"
 
 
 class HostnameResolverTest(unittest.TestCase):
@@ -23,9 +27,25 @@ class HostnameResolverTest(unittest.TestCase):
         super().__init__(*args, **kwargs)
 
     def test_no_address_resolving(self):
-        hostname_resolver = HostnameResolver(resolve_addresses=False)
+        hostname_resolver = HostnameResolver(resolve_addresses=False, k8s_mode=False)
         self.assertEqual("127.0.0.1", hostname_resolver.resolve_fqdn("127.0.0.1"))
 
     def test_address_resolving(self):
-        hostname_resolver = HostnameResolver(resolve_addresses=True)
+        hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=False)
         self.assertNotEqual("127.0.0.1", hostname_resolver.resolve_fqdn("127.0.0.1"))
+
+    def test_address_for_kubernetes(self):
+        with patch('medusa.network.hostname_resolver.socket') as mock_socket:
+            mock_socket.getfqdn.return_value = mock_fqdn
+            hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
+            self.assertEqual(
+                mock_alias,
+                hostname_resolver.resolve_fqdn("127.0.0.1"))
+
+    def test_address_no_kubernetes(self):
+        with patch('medusa.network.hostname_resolver.socket') as mock_socket:
+            mock_socket.getfqdn.return_value = mock_fqdn
+            hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=False)
+            self.assertEqual(
+                mock_fqdn,
+                hostname_resolver.resolve_fqdn("127.0.0.1"))

--- a/tests/resources/config/medusa.ini
+++ b/tests/resources/config/medusa.ini
@@ -15,3 +15,6 @@ transfer_max_bandwidth = 50MB/s
 concurrent_transfers = 1
 multi_part_upload_threshold = 104857600
 backup_grace_period_in_days = 0
+
+[kubernetes]
+enabled = False

--- a/tests/restore_cluster_test.py
+++ b/tests/restore_cluster_test.py
@@ -288,7 +288,7 @@ class RestoreClusterTest(unittest.TestCase):
         # sudo is enabled by default
         assert evaluate_boolean(self.medusa_config.cassandra.use_sudo)
         # Ensure that Kubernetes mode is not enabled in default test config
-        assert not evaluate_boolean(self.medusa_config.kubernetes.enabled)
+        assert not evaluate_boolean(self.medusa_config.kubernetes.enabled if self.medusa_config.kubernetes else False)
         assert 'sudo' in cmd
 
     def test_build_restore_command_without_sudo(self):
@@ -332,7 +332,7 @@ class RestoreClusterTest(unittest.TestCase):
         )
         restore_job = RestoreJob(Mock(), medusa_config, self.tmp_dir, None, None, False, False, None)
         cmd = restore_job._build_restore_cmd()
-        assert evaluate_boolean(medusa_config.kubernetes.enabled)
+        assert evaluate_boolean(medusa_config.kubernetes.enabled if medusa_config.kubernetes else False)
         assert 'sudo' not in cmd, 'Kubernetes mode should not generate command line with sudo'
         assert str(medusa_config_file) in cmd
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ deps =
 
 commands =
     python setup.py check -m -s
-    flake8 . --ignore=W503,E402 --exclude=medusa/service/grpc/medusa_pb2.py,.tox,venv
-    pytest --cov=medusa --cov-report=xml -v tests/
+    flake8 . --ignore=W503,E402 --exclude=medusa/service/grpc/medusa_pb2.py,.tox,venv,build
+    pytest --cov=medusa --cov-report=xml -v {posargs:tests/}
 
 [flake8]
 exclude = .tox,*.egg,build,data,scripts,env,venv


### PR DESCRIPTION
Fixes #464 
Replaces #465 

The changes here modify the way the `HostnameResolver` works by converting FQDNs to simple hostnames in Kubernetes mode.
This allows to both have shorter names but also generate the same hostnames as with cass-operator versions < 1.10.3.
It's done with a simple `fqdn.split('.')[0]` in case the Kubernetes mode is enabled and there's a dot in the fqdn.

I've tried to use a cleaner approach with `socket.gethostbyaddr()`  which returns both the fqdn and a list of aliases, but the aliases are only filled in when resolving the local pod in k8s. Resolving the IP of other pods would return an empty alias list.



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1440) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1440
┆priority: Medium
