### PR TITLE
Fix a crash when restoring materialized views

### DIFF
--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -420,7 +420,7 @@ class RestoreJob(object):
         if keyspace not in session.cluster.metadata.keyspaces:
             # Keyspace doesn't exist on the target cluster. Got to create it and all the tables as well.
             session.execute(keyspace_schema['create_statement'])
-        for mv in keyspace_schema['materialized_views']:
+        for mv in keyspace_schema['materialized_views'].items():
             # MVs need to be dropped before we drop the tables
             logging.debug("Dropping MV {}.{}".format(keyspace, mv[0]))
             session.execute("DROP MATERIALIZED VIEW IF EXISTS {}.{}".format(keyspace, mv[0]))
@@ -440,7 +440,7 @@ class RestoreJob(object):
             # indices were dropped with their base tables
             logging.debug("Creating index {}.{}".format(keyspace, index[0]))
             session.execute(index[1])
-        for mv in keyspace_schema['materialized_views']:
+        for mv in keyspace_schema['materialized_views'].items():
             # Base tables are created now, we can create the MVs
             logging.debug("Creating MV {}.{}".format(keyspace, mv[0]))
             session.execute(mv[1])


### PR DESCRIPTION
~I am still in the process of testing this, but~ I wanted to get this fix out here to get some input on what is and isn't supported regarding materialized views.

Restoring schemas for MVs causes medusa to use the first/second letter of the name instead of the full name and the creation statement, resulting in this crash:

```
Traceback (most recent call last):
  File "/home/cassandra/.local/lib/python3.6/site-packages/medusa/restore_cluster.py", line 69, in orchestrate
    restore.execute()
  File "/home/cassandra/.local/lib/python3.6/site-packages/medusa/restore_cluster.py", line 150, in execute
    self._restore_data()
  File "/home/cassandra/.local/lib/python3.6/site-packages/medusa/restore_cluster.py", line 347, in _restore_data
    self._restore_schema()
  File "/home/cassandra/.local/lib/python3.6/site-packages/medusa/restore_cluster.py", line 414, in _restore_schema
    self._create_or_recreate_schema_objects(session, keyspace, schema[keyspace])
  File "/home/cassandra/.local/lib/python3.6/site-packages/medusa/restore_cluster.py", line 444, in _create_or_recreate_schema_objects
    session.execute(mv[1])
  File "/home/cassandra/.local/lib/python3.6/site-packages/medusa/cassandra_utils.py", line 209, in execute
    return self.session.execute(query)
  File "cassandra/cluster.py", line 2618, in cassandra.cluster.Session.execute
  File "cassandra/cluster.py", line 4894, in cassandra.cluster.ResponseFuture.result
cassandra.protocol.SyntaxException: <Error from server: code=2000 [Syntax error in CQL query] message="line 1:0 no viable alternative at input 'l' ([l])">
```

This PR fixes the immediate problem, but it may very well reveal more errors regarding materialized views.



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1484) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1484
┆priority: Medium
