### PR TITLE
Invoke sstableloader with the transport port that is specified in the cassandra config

### DIFF
--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -177,7 +177,8 @@ def restore_node_sstableloader(config, temp_dir, backup_name, in_place, keep_aut
         download_dir = temp_dir / 'medusa-restore-{}'.format(uuid.uuid4())
         logging.info('Downloading data from backup to {}'.format(download_dir))
         download_data(config.storage, node_backup, fqtns_to_restore, destination=download_dir)
-        invoke_sstableloader(config, download_dir, keep_auth, fqtns_to_restore, cassandra.storage_port)
+        invoke_sstableloader(config, download_dir, keep_auth, fqtns_to_restore, cassandra.storage_port,
+                             cassandra.native_port)
         logging.info('Finished loading backup from {}'.format(fqdn))
 
     # Clean the restored data from local temporary folder
@@ -187,7 +188,7 @@ def restore_node_sstableloader(config, temp_dir, backup_name, in_place, keep_aut
     return node_backup
 
 
-def invoke_sstableloader(config, download_dir, keep_auth, fqtns_to_restore, storage_port):
+def invoke_sstableloader(config, download_dir, keep_auth, fqtns_to_restore, storage_port, native_port):
     hostname_resolver = HostnameResolver(medusa.utils.evaluate_boolean(config.cassandra.resolve_ip_addresses),
                                          medusa.utils.evaluate_boolean(
                                              config.kubernetes.enabled if config.kubernetes else False))
@@ -210,6 +211,7 @@ def invoke_sstableloader(config, download_dir, keep_auth, fqtns_to_restore, stor
                                           '--username', cql_username,
                                           '--password', cql_password,
                                           '--no-progress',
+                                          '--port', str(native_port),
                                           os.path.join(ks_path, table)]
                     if storage_port != 7000:
                         sstableloader_args.append("--storage-port")


### PR DESCRIPTION
Without it, you get errors when the port is not `9042`.

Below is a simulated invocation as medusa would execute it.

```
cassandra@ip-<hidden>:/$ sstableloader -d <hidden> --conf-path /etc/cassandra/cassandra.yaml --username cassandra --password <hidden> /tmp/medusa-restore-0696823c-ffe0-43cf-bc63-57c427138a7f/system_distributed/view_build_status-5582b59f8e4e35e1b9133acada51eb04 -ks /config/ssl/keystore.jks -kspw <hidden>
WARN  10:44:23,021 Small cdc volume detected at /opt/cassandra/data/cdc_raw; setting cdc_total_space_in_mb to 2184.  You can override this in cassandra.yaml
WARN  10:44:23,205 Only 43.651GiB free across all data volumes. Consider adding more capacity to your cluster or removing obsolete snapshots
All host(s) tried for query failed (tried: /<hidden>:0 (com.datastax.driver.core.exceptions.TransportException: [/<hidden>] Cannot connect))
com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed (tried: /<hidden>:0 (com.datastax.driver.core.exceptions.TransportException: [/<hidden>] Cannot connect))
	at com.datastax.driver.core.ControlConnection.reconnectInternal(ControlConnection.java:233)
	at com.datastax.driver.core.ControlConnection.connect(ControlConnection.java:79)
	at com.datastax.driver.core.Cluster$Manager.init(Cluster.java:1424)
	at com.datastax.driver.core.Cluster.init(Cluster.java:163)
	at com.datastax.driver.core.Cluster.connectAsync(Cluster.java:334)
	at com.datastax.driver.core.Cluster.connectAsync(Cluster.java:309)
	at com.datastax.driver.core.Cluster.connect(Cluster.java:251)
	at org.apache.cassandra.utils.NativeSSTableLoaderClient.init(NativeSSTableLoaderClient.java:73)
	at org.apache.cassandra.io.sstable.SSTableLoader.stream(SSTableLoader.java:159)
	at org.apache.cassandra.tools.BulkLoader.load(BulkLoader.java:80)
	at org.apache.cassandra.tools.BulkLoader.main(BulkLoader.java:48)
Exception in thread "main" org.apache.cassandra.tools.BulkLoadException: com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed (tried: /<hidden>:0 (com.datastax.driver.core.exceptions.TransportException: [/<hidden>] Cannot connect))
	at org.apache.cassandra.tools.BulkLoader.load(BulkLoader.java:93)
	at org.apache.cassandra.tools.BulkLoader.main(BulkLoader.java:48)
Caused by: com.datastax.driver.core.exceptions.NoHostAvailableException: All host(s) tried for query failed (tried: /<hidden>:0 (com.datastax.driver.core.exceptions.TransportException: [/<hidden>] Cannot connect))
	at com.datastax.driver.core.ControlConnection.reconnectInternal(ControlConnection.java:233)
	at com.datastax.driver.core.ControlConnection.connect(ControlConnection.java:79)
	at com.datastax.driver.core.Cluster$Manager.init(Cluster.java:1424)
	at com.datastax.driver.core.Cluster.init(Cluster.java:163)
	at com.datastax.driver.core.Cluster.connectAsync(Cluster.java:334)
	at com.datastax.driver.core.Cluster.connectAsync(Cluster.java:309)
	at com.datastax.driver.core.Cluster.connect(Cluster.java:251)
	at org.apache.cassandra.utils.NativeSSTableLoaderClient.init(NativeSSTableLoaderClient.java:73)
	at org.apache.cassandra.io.sstable.SSTableLoader.stream(SSTableLoader.java:159)
	at org.apache.cassandra.tools.BulkLoader.load(BulkLoader.java:80)
	... 1 more
```

Adding a `--port 9142` fixes the above problem. The code in this PR fixes it by always specifying `--port` when invoking sstableloader.
There is a similar construct below it for the storage port, which is conditional, but I see no reason to make the argument conditional, it's better to always specify it.



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1517) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1517
┆priority: Medium
