### PR TITLE
Dockerfile not working when compiling Medusa on Debian 11 (Buster)

### DIFF
--- a/packaging/docker-build/Dockerfile
+++ b/packaging/docker-build/Dockerfile
@@ -33,6 +33,8 @@ RUN apt-get update && \
 # install dependencies
 RUN apt-get update \
     && apt-get install -y \
+        libffi-dev \   
+        libssl-dev \  
         debhelper \
         gdebi-core \
         gcc \


### PR DESCRIPTION
When compiling last version of medusa Deb file I faced the following error:


```
 => ERROR [10/11] RUN pip3 install gevent                                                                                                                                                                                                7.7s
------
 > [10/11] RUN pip3 install gevent:
#13 0.800 Collecting gevent
#13 1.340   Downloading https://files.pythonhosted.org/packages/c8/18/631398e45c109987f2d8e57f3adda161cc5ff2bd8738ca830c3a2dd41a85/gevent-21.12.0.tar.gz (6.2MB)
#13 2.862   Installing build dependencies: started
#13 7.493   Installing build dependencies: finished with status 'error'
#13 7.493   Complete output from command /usr/bin/python3 -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-fzbhbess --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- "setuptools >= 40.8.0" wheel "Cython >= 3.0a9" "cffi >= 1.12.3 ; platform_python_implementation == 'CPython'" "greenlet >= 0.4.17, < 2.0 ; platform_python_implementation == 'CPython'":
#13 7.493   Collecting setuptools>=40.8.0
#13 7.493     Downloading https://files.pythonhosted.org/packages/e9/1c/ec080fde54ab30a738c92f794eab7f5d2f354f2b619ee95b2efe353e0766/setuptools-62.3.2-py3-none-any.whl (1.2MB)
#13 7.493   Collecting wheel
#13 7.493     Downloading https://files.pythonhosted.org/packages/27/d6/003e593296a85fd6ed616ed962795b2f87709c3eee2bca4f6d0fe55c6d00/wheel-0.37.1-py2.py3-none-any.whl
#13 7.493   Collecting Cython>=3.0a9
#13 7.493     Downloading https://files.pythonhosted.org/packages/c4/7c/293f5e9311664af5f54ca46dcb2118fc1b4e551eec161f74c050f17cd991/Cython-3.0.0a10-py2.py3-none-any.whl (1.1MB)
#13 7.493   Collecting cffi>=1.12.3
#13 7.493     Downloading https://files.pythonhosted.org/packages/00/9e/92de7e1217ccc3d5f352ba21e52398372525765b2e0c4530e6eb2ba9282a/cffi-1.15.0.tar.gz (484kB)
#13 7.493   Collecting greenlet<2.0,>=0.4.17
#13 7.493   Collecting pycparser (from cffi>=1.12.3)
#13 7.493     Downloading https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl (118kB)
#13 7.493   Building wheels for collected packages: cffi
#13 7.493     Running setup.py bdist_wheel for cffi: started
#13 7.493     Running setup.py bdist_wheel for cffi: finished with status 'error'
#13 7.493     Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-g7sqlkpe/cffi/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/pip-wheel-_oz46zhi --python-tag cp37:
#13 7.493     running bdist_wheel
#13 7.493     running build
#13 7.493     running build_py
#13 7.493     creating build
#13 7.493     creating build/lib.linux-aarch64-3.7
#13 7.493     creating build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/vengine_gen.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/pkgconfig.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/cffi_opcode.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/ffiplatform.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/api.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/vengine_cpy.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/error.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/__init__.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/model.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/recompiler.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/cparser.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/verifier.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/backend_ctypes.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/lock.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/commontypes.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/setuptools_ext.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/_cffi_include.h -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/parse_c_type.h -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/_embedding.h -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     copying cffi/_cffi_errors.h -> build/lib.linux-aarch64-3.7/cffi
#13 7.493     running build_ext
#13 7.493     building '_cffi_backend' extension
#13 7.493     creating build/temp.linux-aarch64-3.7
#13 7.493     creating build/temp.linux-aarch64-3.7/c
#13 7.493     aarch64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/python3.7m -c c/_cffi_backend.c -o build/temp.linux-aarch64-3.7/c/_cffi_backend.o
#13 7.493     c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
#13 7.493      #include <ffi.h>
#13 7.493               ^~~~~~~
#13 7.493     compilation terminated.
#13 7.493     error: command 'aarch64-linux-gnu-gcc' failed with exit status 1
#13 7.493
#13 7.493     ----------------------------------------
#13 7.493     Failed building wheel for cffi
#13 7.493     Running setup.py clean for cffi
#13 7.493   Failed to build cffi
#13 7.493   Installing collected packages: setuptools, wheel, Cython, pycparser, cffi, greenlet
#13 7.493     Running setup.py install for cffi: started
#13 7.493       Running setup.py install for cffi: finished with status 'error'
#13 7.493       Complete output from command /usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-g7sqlkpe/cffi/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-olo0qodg/install-record.txt --single-version-externally-managed --prefix /tmp/pip-build-env-fzbhbess --compile:
#13 7.493       running install
#13 7.493       running build
#13 7.493       running build_py
#13 7.493       creating build
#13 7.493       creating build/lib.linux-aarch64-3.7
#13 7.493       creating build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/vengine_gen.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/pkgconfig.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/cffi_opcode.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/ffiplatform.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/api.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/vengine_cpy.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/error.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/__init__.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/model.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/recompiler.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/cparser.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/verifier.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/backend_ctypes.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/lock.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/commontypes.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/setuptools_ext.py -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/_cffi_include.h -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/parse_c_type.h -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/_embedding.h -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       copying cffi/_cffi_errors.h -> build/lib.linux-aarch64-3.7/cffi
#13 7.493       running build_ext
#13 7.493       building '_cffi_backend' extension
#13 7.493       creating build/temp.linux-aarch64-3.7
#13 7.493       creating build/temp.linux-aarch64-3.7/c
#13 7.493       aarch64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/python3.7m -c c/_cffi_backend.c -o build/temp.linux-aarch64-3.7/c/_cffi_backend.o
#13 7.493       c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
#13 7.493        #include <ffi.h>
#13 7.493                 ^~~~~~~
#13 7.493       compilation terminated.
#13 7.493       error: command 'aarch64-linux-gnu-gcc' failed with exit status 1
#13 7.493
#13 7.493       ----------------------------------------
#13 7.493   Command "/usr/bin/python3 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-g7sqlkpe/cffi/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" install --record /tmp/pip-record-olo0qodg/install-record.txt --single-version-externally-managed --prefix /tmp/pip-build-env-fzbhbess --compile" failed with error code 1 in /tmp/pip-install-g7sqlkpe/cffi/
#13 7.493
#13 7.493   ----------------------------------------
#13 7.539 Command "/usr/bin/python3 -m pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-fzbhbess --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- "setuptools >= 40.8.0" wheel "Cython >= 3.0a9" "cffi >= 1.12.3 ; platform_python_implementation == 'CPython'" "greenlet >= 0.4.17, < 2.0 ; platform_python_implementation == 'CPython'"" failed with error code 1 in None
------
executor failed running [/bin/sh -c pip3 install gevent]: exit code: 1
ERROR: Service 'cassandra-medusa-builder-buster' failed to build : Build failed
```

To fix this problem i have added the following libraries libffi-dev, ibssl-dev to Dockerfile and problem was fixed successfully 

```
Building cassandra-medusa-builder-buster
[+] Building 144.3s (16/16) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 2.16kB                                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                        0.0s
 => => transferring context: 34B                                                                                                                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/debian:buster                                                                                                                                                                         1.3s
 => [ 1/11] FROM docker.io/library/debian:buster@sha256:405f48fbb359190809bd91aac79c3f6c346c1e79878c839351c6a817db5e9fc4                                                                                                                 0.0s
 => [internal] load build context                                                                                                                                                                                                        0.0s
 => => transferring context: 136B                                                                                                                                                                                                        0.0s
 => CACHED [ 2/11] RUN ln -snf /usr/share/zoneinfo/Europe/Paris /etc/localtime && echo Europe/Paris > /etc/timezone                                                                                                                      0.0s
 => CACHED [ 3/11] RUN mkdir -p /usr/src/app                                                                                                                                                                                             0.0s
 => CACHED [ 4/11] WORKDIR /usr/src/app                                                                                                                                                                                                  0.0s
 => CACHED [ 5/11] RUN echo "Acquire::http::Pipeline-Depth 0;" >> /etc/apt/apt.conf                                                                                                                                                      0.0s
 => CACHED [ 6/11] RUN apt-get update &&     apt-get install -y software-properties-common                                                                                                                                               0.0s
 => [ 7/11] RUN apt-get update     && apt-get install -y         libffi-dev         libssl-dev         debhelper         gdebi-core         gcc         dh-python         python3-all         python3-all-dev         python3-dev       62.2s
 => [ 8/11] RUN cd /tmp &&     wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.0-1_all.deb &&     gdebi -n dh-virtualenv*.deb &&     rm dh-virtualenv_*.deb                                          5.0s
 => [ 9/11] RUN pip3 install greenlet                                                                                                                                                                                                    2.0s
 => [10/11] RUN pip3 install gevent                                                                                                                                                                                                     70.4s
 => [11/11] COPY packaging/docker-build/docker-entrypoint.sh /usr/src/app                                                                                                                                                                0.0s
 => exporting to image                                                                                                                                                                                                                   3.3s
 => => exporting layers                                                                                                                                                                                                                  3.2s
 => => writing image sha256:03568c540343993c18bea7c13f6e46bf37feabddb3cf79261808e75dabb60fb1                                                                                                                                             0.0s
 => => naming to docker.io/library/docker-build_cassandra-medusa-builder-buster
```



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1525) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1525
┆priority: Medium
