### PR TITLE
Allow overriding resolve_ip_addresses with an env variable

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -145,3 +145,17 @@ backup_grace_period_in_days = 10
 ; Enables the use of the management API to create snapshots. Falls back to using Jolokia if not enabled.
 ;use_mgmt_api = True
 ```
+
+### Environment Variable Overrides
+
+Some config settings can be overriden through environment variables prefixed with `MEDUSA_`:
+
+| Setting                | Env Variable                  |
+|------------------------|-------------------------------|
+| `cql_username`         | `MEDUSA_CQL_USERNAME`         |
+| `cql_password`         | `MEDUSA_CQL_PASSWORD`         |
+| `nodetool_username`    | `MEDUSA_NODETOOL_USERNAME`    |
+| `nodetool_password`    | `MEDUSA_NODETOOL_PASSWORD`    |
+| `sstableloader_tspw`   | `MEDUSA_SSTABLELOADER_TSPW`   |
+| `sstableloader_kspw`   | `MEDUSA_SSTABLELOADER_KSPW`   |
+| `resolve_ip_addresses` | `MEDUSA_RESOLVE_IP_ADDRESSES` |


### PR DESCRIPTION
Required by https://github.com/k8ssandra/k8ssandra-operator/pull/502

The standalone Medusa pod will not manage to resolve its own ip address the way we do for the Cassandra statefulset, requiring to disable hostname resolving specifically for it.
Since the configMap storing `medusa.ini` is shared by both the statefulset and the medusa pod, providing an override through an env variable is the most convenient way of doing this and matches how we handled other settings such as `cql_username`/`cql_password` for example.



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1550) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1550
┆priority: Medium
