### PR TITLE
fix purge confusion when nodes have the same name prefix

### DIFF
--- a/medusa/storage/__init__.py
+++ b/medusa/storage/__init__.py
@@ -174,7 +174,7 @@ class Storage(object):
             return list(map(get_blob_name, all_backup_blobs))
 
         def get_blobs_for_fqdn(blobs, fqdn):
-            return list(filter(lambda b: fqdn in b, blobs))
+            return list(filter(lambda b: f'_{fqdn}.' in b, blobs))
 
         if backup_index_blobs is None:
             backup_index_blobs = self.list_backup_index_blobs()

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -930,3 +930,20 @@ Feature: Integration tests
         Examples: Local storage
         | storage                    | client encryption |
         | local_backup_gc_grace      |  with_client_encryption |
+    
+    @24
+    Scenario Outline: Run purge with nodes sharing the same prefix as fqdn
+        Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>"
+        When node "127.0.0.10" fakes a complete backup named "backup1" on "2019-04-15 12:12:00"
+        And node "127.0.0.101" fakes a complete backup named "backup1" on "2019-04-15 12:14:00"
+        And node "127.0.0.102" fakes a complete backup named "backup1" on "2019-04-15 12:14:00"
+        And node "127.0.0.10" fakes a complete backup named "backup2" on "2019-04-01 12:14:00"
+        And node "127.0.0.101" fakes a complete backup named "backup2" on "2019-04-01 12:14:00"
+        And node "127.0.0.102" fakes a complete backup named "backup2" on "2019-04-01 12:14:00"
+        Then listing backups for node "127.0.0.10" returns 2 backups
+        
+
+        @local
+        Examples: Local storage
+        | storage           | client encryption |
+        | local      |  with_client_encryption |

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -1010,6 +1010,14 @@ def _the_latest_cluster_backup_is(context, expected_backup_name):
     assert expected_backup_name == backup.name
 
 
+@then(r'listing backups for node "{fqdn}" returns {nb_backups} backups')
+def _listing_backups_for_node_returns(context, fqdn, nb_backups):
+    storage = Storage(config=context.medusa_config.storage)
+    backup_index = storage.list_backup_index_blobs()
+    backups = list(storage.list_node_backups(fqdn=fqdn, backup_index_blobs=backup_index))
+    assert int(nb_backups) == len(backups)
+
+
 @then(r"there is no latest complete backup")
 def _there_is_no_latest_complete_backup(context):
     storage = Storage(config=context.medusa_config.storage)

--- a/tests/storage_test_with_prefix.py
+++ b/tests/storage_test_with_prefix.py
@@ -323,6 +323,50 @@ class RestoreNodeTest(unittest.TestCase):
             self.storage.get_timestamp_from_blob_name('index/bi/third_backup/finished_localhost_1574343029.timestamp')
         )
 
+    def test_parse_backup_index_common_prefix(self):
+        file_content = "content of the test file"
+        # SSTables for node1 and backup1
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.10/backup1/data/ks1/sstable1.db".format(self.storage.prefix_path), file_content)
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.10/backup1/data/ks1/sstable2.db".format(self.storage.prefix_path), file_content)
+        # Metadata for node1 and backup1
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.10/backup1/meta/tokenmap.json".format(self.storage.prefix_path), file_content)
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.10/backup1/meta/manifest.json".format(self.storage.prefix_path), file_content)
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.10/backup1/meta/schema.cql".format(self.storage.prefix_path), file_content)
+        # SSTables for node2 and backup1
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.101/backup1/data/ks1/sstable1.db".format(self.storage.prefix_path), file_content)
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.101/backup1/data/ks1/sstable2.db".format(self.storage.prefix_path), file_content)
+        # Metadata for node2 and backup1
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.101/backup1/meta/tokenmap.json".format(self.storage.prefix_path), file_content)
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.101/backup1/meta/manifest.json".format(self.storage.prefix_path), file_content)
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.101/backup1/meta/schema.cql".format(self.storage.prefix_path), file_content)
+        # SSTables for node1 and backup2
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.101/backup2/data/ks1/sstable1.db".format(self.storage.prefix_path), file_content)
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.101/backup2/data/ks1/sstable2.db".format(self.storage.prefix_path), file_content)
+        # Metadata for node1 and backup2
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.10/backup2/meta/tokenmap.json".format(self.storage.prefix_path), file_content)
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.10/backup2/meta/manifest.json".format(self.storage.prefix_path), file_content)
+        self.storage.storage_driver.upload_blob_from_string(
+            "{}127.0.0.10/backup2/meta/schema.cql".format(self.storage.prefix_path), file_content)
+        build_indices(self.config, False)
+        path = '{}index/backup_index'.format(self.storage.prefix_path)
+        backup_index = self.storage.storage_driver.list_objects(path)
+        backups = self.storage.list_node_backups(fqdn="127.0.0.10", backup_index_blobs=backup_index)
+        self.assertEquals(2, len(list(backups)))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #485 

The code was so far using a lazy "in" check to select blobs for a specific fqdn. That resulted in "10.0.0.101" blobs being selected when the required fqdn was "10.0.0.10" for example.
This PR fixes this by being more restrictive and given that files are named with the fqdn in last position, checking for the presence of `_{fqdn}.` instead avoids mixing blobs from fqdns/ip addresses with the same prefix.



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1601) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1601
┆priority: Medium
