### PR TITLE
Add MEDUSA_TMP_DIR env variable for setting the tmp directory in k8s mode

### DIFF
--- a/medusa/service/grpc/restore.py
+++ b/medusa/service/grpc/restore.py
@@ -87,7 +87,8 @@ if __name__ == '__main__':
     configure_console_logging(config.logging)
 
     backup_name = os.environ["BACKUP_NAME"]
-    tmp_dir = Path("/tmp")
+    tmp_dir = Path("/tmp") if "MEDUSA_TMP_DIR" not in os.environ else Path(os.environ["MEDUSA_TMP_DIR"])
+    print(f"Downloading backup {backup_name} to {tmp_dir}")
     keep_auth = False if in_place else True
     seeds = None
     verify = False


### PR DESCRIPTION
Fixes #492

This will allow setting a temp dir under `/var/lib/cassandra` in K8ssandra so that we have enough room to download the backups.
Currently, it is hardcoded to `/tmp` which is on ephemeral storage and cannot be overridden.



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1609) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1609
┆priority: Medium
