### PR TITLE
Disable dependency checks when running in Kubernetes

### DIFF
--- a/medusa/config.py
+++ b/medusa/config.py
@@ -31,7 +31,7 @@ StorageConfig = collections.namedtuple(
     ['bucket_name', 'key_file', 'prefix', 'fqdn', 'host_file_separator', 'storage_provider',
      'base_path', 'max_backup_age', 'max_backup_count', 'api_profile', 'transfer_max_bandwidth',
      'concurrent_transfers', 'multi_part_upload_threshold', 'host', 'region', 'port', 'secure', 'aws_cli_path',
-     'backup_grace_period_in_days', 'use_sudo_for_restore']
+     'backup_grace_period_in_days', 'use_sudo_for_restore', 'k8s_mode']
 )
 
 CassandraConfig = collections.namedtuple(
@@ -243,6 +243,8 @@ def parse_config(args, config_file):
     elif config['storage']['fqdn'] == socket.getfqdn():
         # The FQDN for the local node should comply with the hostname resolving rules.
         config.set('storage', 'fqdn', hostname_resolver.resolve_fqdn())
+
+    config.set('storage', 'k8s_mode', str(kubernetes_enabled))
 
     return config
 


### PR DESCRIPTION
Fixes a problem reported on Discord where the medusa container wouldn't start due to the Azure dependency check consistently blocking the grpc server startup.
Such checks can be disabled when running in kubernetes as we're confident the image contains all the necessary dependencies.

Fixes #508

┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1675) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1675
┆priority: Medium
