### PR TITLE
upload empty files with az cli command

### DIFF
--- a/medusa/storage/azure_blobs_storage/concurrent.py
+++ b/medusa/storage/azure_blobs_storage/concurrent.py
@@ -110,7 +110,9 @@ def __upload_file(storage, connection, src, dest, bucket, multi_part_upload_thre
     )
     full_object_name = str("{}/{}".format(dest, obj_name))
 
-    if file_size >= multi_part_upload_threshold:
+    # if file is empty, uploading with libcloud azure storage driver (_upload_single_part) will fail with 403 error
+    # thus, we need to use az cli command (_upload_multi_part) to upload empty files
+    if file_size == 0 or file_size >= multi_part_upload_threshold:
         # Files larger than the configured threshold should be uploaded as multi part
         logging.debug("Uploading {} as multi part".format(full_object_name))
         obj = _upload_multi_part(storage, connection, src, bucket, full_object_name)


### PR DESCRIPTION
SSTable-Attached Secondary Index (SASI) files (SI_*.db) could be empty. Medusa uses azure storage driver from libcloud to upload small files and az cli command to upload large files. However, libcloud fails to upload empty files with 403 error. Thus, we could use az cli command to upload empty files.

┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1825) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1825
┆priority: Medium
