### PR TITLE
enable sourcing environment file within wrapper

### DIFF
--- a/bin/medusa-wrapper
+++ b/bin/medusa-wrapper
@@ -20,6 +20,9 @@ if test -f pid; then
     done
     exit $(cat status)
 fi
+if [ -f /etc/default/cassandra-medusa ]; then
+    . /etc/default/cassandra-medusa
+fi
 $@ >stdout 2>stderr &
 echo $! >pid
 wait $!

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -169,3 +169,9 @@ Some config settings can be overriden through environment variables prefixed wit
 | `sstableloader_tspw`        | `MEDUSA_SSTABLELOADER_TSPW`        |
 | `sstableloader_kspw`        | `MEDUSA_SSTABLELOADER_KSPW`        |
 | `resolve_ip_addresses`      | `MEDUSA_RESOLVE_IP_ADDRESSES`      |
+
+### Sourcing environment variables
+
+If you are using environment variables to override some settings, you can source a file containing the environment variables before running Medusa commands. For example, if you have a file named `/etc/default/cassandra-medusa` containing exported environment variables.
+
+These variables will also be available when running Medusa cluster commands, e.g. backup-cluster.

--- a/docs/minio_setup.md
+++ b/docs/minio_setup.md
@@ -29,4 +29,10 @@ secure = False
 ```
 
 Medusa should now be able to access the bucket and perform all required operations.
-*Note: MinIO and other self hosted S3 compatible storage systems can only be used in unsecured (non SSL) mode with Medusa due to limitations in Apache Libcloud. Cloud hosted S3 compatible backends (such as IBM) should be able/require to use secured access.*
+*Note: By default, MinIO and other self hosted S3 compatible storage systems can only be used in unsecured (non SSL) mode with Medusa due to limitations in Apache Libcloud. To enable SSL access to self hosted S3 compatible storage systems, you will need to set the environment variable `SSL_CERT_FILE` to the path of a valid certificate file containing trusted CA certificates of your S3 service. In order to get cluster wide commands working properly, you will need to set this in the `/etc/default/cassandra-medusa` file on all nodes running Medusa containing:*
+
+```bash
+export SSL_CERT_FILE=/path/to/certfile
+```
+
+*Cloud hosted S3 compatible backends (such as IBM) should be able/require to use secured access.*


### PR DESCRIPTION
When using medusa with an own-hosted S3 storage available via https an environment variable `SSL_CERT_FILE` needs to be set up. The backup-cluster subcommand, however, would fail, as the environment variables aren't sent via SSH. This patch allows the medusa-wrapper to source an environment file before calling the medusa backup on the local nodes.



┆Issue is synchronized with this [Jira Task](https://k8ssandra.atlassian.net/browse/K8SSAND-1839) by [Unito](https://www.unito.io)
┆friendlyId: K8SSAND-1839
┆priority: Medium
