### PR TITLE
[docker] update images to 20.04

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as base
+FROM ubuntu:20.04 as base
 
 RUN mkdir /install
 WORKDIR /install
@@ -15,14 +15,11 @@ RUN apt-get update \
         python3-all \
         python3-all-dev \
         python3-dev \
-        python-dev \
-        python-pip \
         python3-pip \
         python3-setuptools \
         python3-venv \
         build-essential \
         devscripts \
-        dh-virtualenv \
         equivs \
         wget \
         apt-transport-https \
@@ -48,7 +45,7 @@ RUN pip3 install --ignore-installed --user -r /build/requirements-azure.txt \
 RUN pip3 install --ignore-installed --user /build
 
 # Could be python:slim, but we have a .sh entrypoint
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ## add user
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 --create-home cassandra

--- a/k8s/Dockerfile-azure
+++ b/k8s/Dockerfile-azure
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as base
+FROM ubuntu:20.04 as base
 
 RUN mkdir /install
 WORKDIR /install
@@ -15,14 +15,11 @@ RUN apt-get update \
         python3-all \
         python3-all-dev \
         python3-dev \
-        python-dev \
-        python-pip \
         python3-pip \
         python3-setuptools \
         python3-venv \
         build-essential \
         devscripts \
-        dh-virtualenv \
         equivs \
         wget \
         apt-transport-https \
@@ -45,7 +42,7 @@ RUN pip3 install --ignore-installed --user -r /build/requirements-azure.txt \
 RUN pip3 install --ignore-installed --user /build
 
 # Could be python:slim, but we have a .sh entrypoint
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ## add user
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 --create-home cassandra

--- a/k8s/Dockerfile-gcs
+++ b/k8s/Dockerfile-gcs
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as base
+FROM ubuntu:20.04 as base
 
 RUN mkdir /install
 WORKDIR /install
@@ -15,14 +15,11 @@ RUN apt-get update \
         python3-all \
         python3-all-dev \
         python3-dev \
-        python-dev \
-        python-pip \
         python3-pip \
         python3-setuptools \
         python3-venv \
         build-essential \
         devscripts \
-        dh-virtualenv \
         equivs \
         wget \
         apt-transport-https \
@@ -41,7 +38,7 @@ RUN python3 -m pip install -U pip && pip3 install --ignore-installed --user \
 RUN pip3 install --ignore-installed --user /build
 
 # Could be python:slim, but we have a .sh entrypoint
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ## add user
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 --create-home cassandra

--- a/k8s/Dockerfile-s3
+++ b/k8s/Dockerfile-s3
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 as base
+FROM ubuntu:20.04 as base
 
 RUN mkdir /install
 WORKDIR /install
@@ -15,14 +15,11 @@ RUN apt-get update \
         python3-all \
         python3-all-dev \
         python3-dev \
-        python-dev \
-        python-pip \
         python3-pip \
         python3-setuptools \
         python3-venv \
         build-essential \
         devscripts \
-        dh-virtualenv \
         equivs \
         wget \
         apt-transport-https \
@@ -44,7 +41,7 @@ RUN pip3 install --ignore-installed --user -r /build/requirements-s3.txt
 RUN pip3 install --ignore-installed --user /build
 
 # Could be python:slim, but we have a .sh entrypoint
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ## add user
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 --create-home cassandra


### PR DESCRIPTION
This PR bumps Ubuntu version from 18.04 (`bionic`, EOL Apr. 2023) to 20.04 (`focal`, EOL Apr 2025).

This is a relatively small change, just had to remove a couple packages which are not available any more and do not seem required for the images to work.

* `dh-virtualenv` is related to Debian package building so not mandatory on an image running Cassandra and/or Medusa
* `python-dev`/`python-pip` do not seem to be required to either build or run Medusa, looks like everything uses Python3 here.

Switching to `22.04` (`jammy`, EOL Apr 2027) yields a lot more required changes.
 
See [ubuntu releases](https://wiki.ubuntu.com/Releases) for details.