### PR TITLE
improve ipv6 compatibility (fixes #560)

### DIFF
--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -37,6 +37,7 @@ from retrying import retry
 
 from medusa.host_man import HostMan
 from medusa.network.hostname_resolver import HostnameResolver
+from medusa.network.hostname_resolver import resolve_name
 from medusa.nodetool import Nodetool
 from medusa.service.snapshot import SnapshotService
 from medusa.utils import null_if_empty, evaluate_boolean
@@ -157,7 +158,7 @@ class CqlSession(object):
 
     def placement(self):
         logging.debug('Checking placement using dc and rack...')
-        listen_address = socket.gethostbyname(self.cluster.contact_points[0])
+        listen_address = resolve_name(self.cluster.contact_points[0])
         token_map = self.cluster.metadata.token_map
 
         for host in token_map.token_to_host_owner.values():
@@ -254,7 +255,7 @@ class CassandraConfigReader(object):
         if 'listen_address' in self._config and self._config['listen_address']:
             return self._config['listen_address']
 
-        return socket.gethostbyname(socket.getfqdn())
+        return resolve_name(socket.getfqdn())
 
     @property
     def storage_port(self):

--- a/medusa/network/hostname_resolver.py
+++ b/medusa/network/hostname_resolver.py
@@ -20,6 +20,16 @@ import logging
 import socket
 
 
+def resolve_name(name):
+    try:
+        return socket.gethostbyname(name)
+    except Exception as e:
+        try:
+            return socket.getaddrinfo(name, None)[0][4][0]
+        except Exception:
+            raise e
+
+
 class HostnameResolver:
     def __init__(self, resolve_addresses, k8s_mode):
         self.resolve_addresses = resolve_addresses
@@ -27,7 +37,7 @@ class HostnameResolver:
 
     def resolve_fqdn(self, ip_address=''):
         logging.info(f"Resolving ip address {ip_address}")
-        ip_address_to_resolve = ip_address if ip_address != '' else socket.gethostbyname(socket.getfqdn())
+        ip_address_to_resolve = ip_address if ip_address != '' else resolve_name(socket.getfqdn())
         logging.info(f"ip address to resolve {ip_address_to_resolve}")
         if str(self.resolve_addresses) == "False":
             logging.debug("Not resolving {} as requested".format(ip_address_to_resolve))


### PR DESCRIPTION
Fix to work better in ipv6 only environment (k8ssandra cluster) (fixes #560)

This change tries to call socket.getaddrinfo after socket.gethostbyname fails.
socket.gethostbyname always fails in case there is no ipv4 address(but there can be ipv6 address).

socket.gethostbyname is called first to make sure behavior does not change for dual stack cases.