### PR TITLE
Concurrent calls of set_upload_bandwidth cause duplication in ".aws/config"

### DIFF
--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -177,6 +177,8 @@ def handle_backup(config, backup_name_arg, stagger_time, enable_md5_checks_flag,
         logging.debug("Starting backup preparations with Mode: {}".format(mode))
         storage = Storage(config=config.storage)
         cassandra = Cassandra(config)
+        
+        storage.storage_driver.prepare_upload()
 
         differential_mode = False
         if mode == "differential":

--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -177,7 +177,7 @@ def handle_backup(config, backup_name_arg, stagger_time, enable_md5_checks_flag,
         logging.debug("Starting backup preparations with Mode: {}".format(mode))
         storage = Storage(config=config.storage)
         cassandra = Cassandra(config)
-        
+
         storage.storage_driver.prepare_upload()
 
         differential_mode = False

--- a/medusa/storage/abstract_storage.py
+++ b/medusa/storage/abstract_storage.py
@@ -255,6 +255,10 @@ class AbstractStorage(abc.ABC):
         # Override for each child class
         pass
 
+    def prepare_upload(self):
+        # Override for each child class
+        pass
+
     def additional_upload_headers(self):
         """
         Additional HTTP headers to be passed to libcloud during upload operations. To be overriden by

--- a/medusa/storage/s3_base_storage.py
+++ b/medusa/storage/s3_base_storage.py
@@ -200,16 +200,17 @@ class S3BaseStorage(AbstractStorage):
 
         return sizes_match and hashes_match
 
-    def set_upload_bandwidth(self):
-        subprocess.check_call(
-            [
-                "aws",
-                "configure",
-                "set",
-                "default.s3.max_bandwidth",
-                self.config.transfer_max_bandwidth,
-            ]
-        )
+    def prepare_upload(self):
+        if self.config.transfer_max_bandwidth is not None:
+            subprocess.check_call(
+                [
+                    "aws",
+                    "configure",
+                    "set",
+                    "default.s3.max_bandwidth",
+                    self.config.transfer_max_bandwidth,
+                ]
+            )
 
     def prepare_download(self):
         # Unthrottle downloads to speed up restores

--- a/medusa/storage/s3_storage.py
+++ b/medusa/storage/s3_storage.py
@@ -36,7 +36,4 @@ class S3Storage(S3BaseStorage):
             region=self.session.get_config_variable('region'),
         )
 
-        if self.config.transfer_max_bandwidth is not None:
-            self.set_upload_bandwidth()
-
         return driver


### PR DESCRIPTION
Hi,

We have faced duplication parameters in the ".aws/config" file because "set_upload_bandwidth" is being called in parallel by multiple threads.

> cassandra@cass-01: ~$ more .aws/config
> [default]
> s3 =
> max_bandwidth = 250MB/s
> [default]
> s3 =
> max_bandwidth = 250MB/s

I have contacted AWS support team, and they said that "aws configure set default.s3.max_bandwidth 250Mb/s" is not thread-safe and It doesn't support multiple calls of this command at the same time.

This command should be executed once in medusa at start-up. No need to execute it by each thread.

I have fixed this in the medusa source code by renaming "set_upload_bandwidth" to "prepare_upload" and executing it only once in the "handle_backup" method. Similar to the "preapre_download" method.