### PR TITLE
Correct clean_path execution in restore_node_sstableloader function.

### DIFF
--- a/medusa/restore_node.py
+++ b/medusa/restore_node.py
@@ -181,10 +181,10 @@ def restore_node_sstableloader(config, temp_dir, backup_name, in_place, keep_aut
                              cassandra.native_port)
         logging.info('Finished loading backup from {}'.format(fqdn))
 
-    # Clean the restored data from local temporary folder
-    if download_dir:
+        # Clean the restored data from local temporary folder
         use_sudo = medusa.utils.evaluate_boolean(config.cassandra.use_sudo)
         clean_path(download_dir, use_sudo, keep_folder=False)
+
     return node_backup
 
 


### PR DESCRIPTION
Correcting a bug where `restore_node_sstableloader` is not cleaning up multiple restore directories.

Note: Looking through the `tests/restore_node.py`, I am not seeing any tests around the `restore_node_sstableloader` function and it looks like the file system tests are mocked out.

However, this fix has been tested in both our PreProduction and Production environments successfully.