### PR TITLE
Incorrect example message about concurrent_transfers with GCS was fixed

### DIFF
--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -83,7 +83,7 @@ max_backup_count = 0
 ; Used to throttle S3 backups/restores:
 transfer_max_bandwidth = 50MB/s
 
-; Max number of downloads/uploads. Not used by the GCS backend.
+; Max number of downloads/uploads. GCS backend will use it as `gsutil -m` with `GSUtil:parallel_process_count` options.
 concurrent_transfers = 1
 
 ; Size over which S3 uploads will be using the awscli with multi part uploads. Defaults to 100MB.


### PR DESCRIPTION
#584 