### PR TITLE
Use docker buildx for building multi arch images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             tox-py: py310
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os-version }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build Debian Package
       run: |
         version=$(cat VERSION)
@@ -168,7 +168,7 @@ jobs:
           - ${{ github.workspace }}/../data:/data
         options: --name=minio --health-cmd "curl http://localhost:9000/minio/health/live"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -291,28 +291,42 @@ jobs:
   
 
   publish-docker-master:
-    needs: [debian-build, build, integration-tests]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    strategy:
-      matrix:
-        storage-provider: ["", "-s3", "-azure", "-gcs"]
+#    needs: [debian-build, build, integration-tests]
+#    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - name: Publish Beta Docker Image
-      env:
-        DOCKER_USERNAME: ${{ secrets.K8SSANDRA_DOCKER_HUB_USERNAME }}
-        DOCKER_TOKEN: ${{ secrets.K8SSANDRA_DOCKER_HUB_PASSWORD }}
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: 'arm64,arm'
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.K8SSANDRA_DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.K8SSANDRA_DOCKER_HUB_PASSWORD }}
+    - name: Set git parsed values
+      id: vars
+      shell: bash
       run: |
-        docker login -u $DOCKER_USERNAME -p $DOCKER_TOKEN
-        echo "Publishing release $(git rev-parse --short HEAD)${{ matrix.storage-provider }} in Docker Hub"
+        echo "sha_short=$(git rev-parse --short=8 ${{ github.sha }})" >> $GITHUB_OUTPUT
+    - name: Build Medusa
+      run: |
+        echo "Publishing release $(git rev-parse --short HEAD) in Docker Hub"
         python setup.py build
-        # Push Docker image tagged with the short commit sha
-        docker build -t k8ssandra/medusa:$(git rev-parse --short HEAD)${{ matrix.storage-provider }} -f k8s/Dockerfile${{ matrix.storage-provider }} .
-        docker push k8ssandra/medusa:$(git rev-parse --short HEAD)${{ matrix.storage-provider }}
-        # Push Docker image tagged as "master"
-        docker tag k8ssandra/medusa:$(git rev-parse --short HEAD)${{ matrix.storage-provider }} k8ssandra/medusa:master${{ matrix.storage-provider }}
-        docker push k8ssandra/medusa:master${{ matrix.storage-provider }}
+    - name: Build image and push
+      id: docker_build
+      uses: docker/build-push-action@v4
+      with:
+        file: k8s/Dockerfile
+        context: .
+        push: false
+        tags: k8ssandra/medusa:${{ steps.vars.outputs.sha_short}},k8ssandra/medusa:master
+        platforms: linux/amd64,linux/arm64
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
     
   publish-debian:
     # We can only release if the build above succeeded first
@@ -327,7 +341,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os-version }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
@@ -358,23 +372,40 @@ jobs:
   publish-docker:
     needs: [publish-debian]
     if: github.event_name == 'release' && github.event.action == 'published'
-    strategy:
-      matrix:
-        storage-provider: ["", "-s3", "-azure", "-gcs"]
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - name: Publish Docker Image
-      env:
-        DOCKER_USERNAME: ${{ secrets.K8SSANDRA_DOCKER_HUB_USERNAME }}
-        DOCKER_TOKEN: ${{ secrets.K8SSANDRA_DOCKER_HUB_PASSWORD }}
+    - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: 'arm64,arm'
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.K8SSANDRA_DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.K8SSANDRA_DOCKER_HUB_PASSWORD }}
+    - name: Set git parsed values
+      id: vars
+      shell: bash
       run: |
-        version=$(cat VERSION)
-        docker login -u $DOCKER_USERNAME -p $DOCKER_TOKEN
-        echo "Publishing release ${version} in Docker Hub"
+        echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
+    - name: Build Medusa
+      run: |
+        echo "Publishing release ${{ steps.vars.outputs.version}} in Docker Hub"
         python setup.py build
-        docker build -t k8ssandra/medusa:${version}${{ matrix.storage-provider }} -f k8s/Dockerfile${{ matrix.storage-provider }} .
-        docker push k8ssandra/medusa:${version}${{ matrix.storage-provider }}
+    - name: Build image and push
+      id: docker_build
+      uses: docker/build-push-action@v4
+      with:
+        file: k8s/Dockerfile
+        context: .
+        push: false
+        tags: k8ssandra/medusa:${{ steps.vars.outputs.version}}
+        platforms: linux/amd64,linux/arm64
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache
 
   publish-pypi:
     # We can only release if the build above succeeded first
@@ -382,7 +413,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,7 +322,7 @@ jobs:
       with:
         file: k8s/Dockerfile
         context: .
-        push: false
+        push: true
         tags: k8ssandra/medusa:${{ steps.vars.outputs.sha_short}},k8ssandra/medusa:master
         platforms: linux/amd64,linux/arm64
         cache-from: type=local,src=/tmp/.buildx-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,8 +291,8 @@ jobs:
   
 
   publish-docker-master:
-#    needs: [debian-build, build, integration-tests]
-#    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: [debian-build, build, integration-tests]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Fixes #609 

This was tested in previous runs that had some comments in CI to build the images on PR pushes.
[This tag](https://hub.docker.com/layers/k8ssandra/medusa/be90ce5b/images/sha256-4464c8ac50048bb34035b53111887c44c3a936a0285ebc53183105d6ab398bf9?context=explore) can be used for testing the image.