### PR TITLE
Fix reported time in seconds in metrics when backup are >24h

### DIFF
--- a/medusa/backup_cluster.py
+++ b/medusa/backup_cluster.py
@@ -68,9 +68,9 @@ def orchestrate(config, backup_name_arg, seed_target, stagger, enable_md5_checks
 
         logging.debug('Emitting metrics')
 
-        logging.info('Backup duration: {}'.format(backup_duration.seconds))
+        logging.info('Backup duration: {}'.format(backup_duration.total_seconds()))
         tags = ['medusa-cluster-backup', 'cluster-backup-duration', backup_name]
-        monitoring.send(tags, backup_duration.seconds)
+        monitoring.send(tags, backup_duration.total_seconds())
 
         tags = ['medusa-cluster-backup', 'cluster-backup-error', backup_name]
         monitoring.send(tags, 0)

--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -334,7 +334,7 @@ def update_monitoring(actual_backup_duration, backup_name, monitoring, node_back
     logging.debug('Emitting metrics')
 
     tags = ['medusa-node-backup', 'backup-duration', backup_name]
-    monitoring.send(tags, actual_backup_duration.seconds)
+    monitoring.send(tags, actual_backup_duration.total_seconds())
 
     tags = ['medusa-node-backup', 'backup-size', backup_name]
     monitoring.send(tags, node_backup.size())

--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -76,9 +76,9 @@ def orchestrate(config, backup_name, seed_target, temp_dir, host_list, keep_auth
 
         logging.debug('Emitting metrics')
 
-        logging.info('Restore duration: {}'.format(restore_duration.seconds))
+        logging.info('Restore duration: {}'.format(restore_duration.total_seconds()))
         tags = ['medusa-cluster-restore', 'restore-duration', backup_name]
-        monitoring.send(tags, restore_duration.seconds)
+        monitoring.send(tags, restore_duration.total_seconds())
 
         tags = ['medusa-cluster-restore', 'restore-error', backup_name]
         monitoring.send(tags, 0)


### PR DESCRIPTION
- When backup duration is >24h, the .seconds conversion only convert the second of the day, not the full duration.
- This fix #606