### PR TITLE
[Storage] Adjust chunk sizes based on file_size

### DIFF
--- a/medusa/storage/abstract_storage.py
+++ b/medusa/storage/abstract_storage.py
@@ -32,6 +32,9 @@ MULTIPART_PART_SIZE_IN_MB = 8
 MULTIPART_BLOCK_SIZE_BYTES = 65536
 MULTIPART_BLOCKS_PER_MB = 16
 
+DEFAULT_MULTIPART_PART_SIZE = 5 * 1024 * 1024   # 5 MB
+DEFAULT_MULTIPART_PARTS_COUNT = 9500            # 47.5 GB
+
 
 AbstractBlob = collections.namedtuple('AbstractBlob', ['name', 'size', 'hash', 'last_modified'])
 
@@ -42,11 +45,21 @@ class AbstractStorage(abc.ABC):
         self.config = config
         self.driver = self.connect_storage()
         self.bucket = self.driver.get_container(container_name=config.bucket_name)
+        self.MULTIPART_PART_SIZE = DEFAULT_MULTIPART_PART_SIZE
+        self.MULTIPART_PARTS_COUNT = DEFAULT_MULTIPART_PARTS_COUNT
 
     @abc.abstractmethod
     def connect_storage(self):
         # Override for each child class
         pass
+
+    def set_multipart_thresholds(
+            self,
+            part_size=DEFAULT_MULTIPART_PART_SIZE,
+            max_parts_count=DEFAULT_MULTIPART_PARTS_COUNT
+    ):
+        self.MULTIPART_PART_SIZE = part_size
+        self.MULTIPART_PARTS_COUNT = max_parts_count
 
     @retry(stop_max_attempt_number=7, wait_exponential_multiplier=10000, wait_exponential_max=120000)
     def list_objects(self, path=None):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ flake8==3.7.9
 nose==1.3.7
 coverage>=5.5
 pytest-cov
+humanfriendly

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -968,3 +968,29 @@ Feature: Integration tests
         Examples: Local storage
         | storage           | client encryption |
         | local      |  with_client_encryption |     
+
+
+    @26
+    Scenario Outline: Initialise a storage, do a multipart upload and verify it happened correctly
+        Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>"
+        Given I configure the storage to allow max "5" parts per multipart upload
+        When I upload a "20 MiB" file named "file1.db" to path "multipart-test"
+        Then I can see the upload happened in "4" parts of size "5.000MiB" each
+        And I can see the file "multipart-test/file1.db" exists in the storage
+        And I can download the file "multipart-test/file1.db" of size "20 Mib" from the storage
+        When I upload a "40 MiB" file named "file2.db" to path "multipart-test"
+        Then I can see the upload happened in "5" parts of size "8.000MiB" each
+        And I can see the file "multipart-test/file2.db" exists in the storage
+        And I can download the file "multipart-test/file2.db" of size "40 Mib" from the storage
+        Then I clean up the multipart files in the storage
+
+
+        @s3
+        Examples: S3 storage
+        | storage           | client encryption         |
+        | s3_us_west_oregon | without_client_encryption |
+
+        @minio
+        Examples: MinIO storage
+        | storage           | client encryption         |
+        | minio             | without_client_encryption |

--- a/tests/storage/s3_storage_test.py
+++ b/tests/storage/s3_storage_test.py
@@ -22,7 +22,7 @@ from unittest.mock import patch, MagicMock
 
 from libcloud.storage.providers import get_driver
 
-from medusa.storage.s3_base_storage import S3BaseStorage
+from medusa.storage.s3_base_storage import S3BaseStorage, DEFAULT_MULTIPART_PARTS_COUNT
 
 
 class AttributeDict(dict):
@@ -36,8 +36,74 @@ class S3StorageTest(unittest.TestCase):
     def test_legacy_provider_region_replacement(self):
         assert get_driver("s3_us_west_oregon").region_name == "us-west-2"
 
-    def test_credentials_from_metadata(self):
+    def test_calculate_part_sizes(self):
+        size_5mb = 5 * 1024 * 1024
+        size_32gb = 32 * 1024 * 1024 * 1024
+        part_size, part_count = S3BaseStorage.calculate_part_size(size_32gb)
+        self.assertEqual(size_5mb, part_size)
+        # 6554 x 5mb
+        self.assertEqual(6554, part_count)
 
+    def test_calculate_part_sizes_big_file(self):
+        size_512gb = 512 * 1024 * 1024 * 1024
+        part_size, part_count = S3BaseStorage.calculate_part_size(size_512gb)
+        # part size goes way up if we want to fit to 9500 chunks
+        self.assertEqual(57_869_034, part_size)
+        self.assertEqual(DEFAULT_MULTIPART_PARTS_COUNT, part_count)
+
+    def test_calculate_part_sizes_file_at_threshold(self):
+        size_5mb = 5 * 1024 * 1024
+        exact_size = DEFAULT_MULTIPART_PARTS_COUNT * size_5mb
+
+        part_size, part_count = S3BaseStorage.calculate_part_size(exact_size)
+        self.assertEqual(size_5mb, part_size)
+        self.assertEqual(DEFAULT_MULTIPART_PARTS_COUNT, part_count)
+
+        part_size, part_count = S3BaseStorage.calculate_part_size(exact_size + 1)
+        self.assertEqual(5_242_881, part_size)      # 5mb + 1b
+        self.assertEqual(DEFAULT_MULTIPART_PARTS_COUNT, part_count)
+
+        # there's 9500 parts, so increasing each by just 1b is enough to accommodate 1023 more bytes
+        part_size, part_count = S3BaseStorage.calculate_part_size(exact_size + 1023)
+        self.assertEqual(5_242_881, part_size)      # 5mb + 1b
+        self.assertEqual(DEFAULT_MULTIPART_PARTS_COUNT, part_count)
+
+        # with 1kb more, we already need bigger pats
+        part_size, part_count = S3BaseStorage.calculate_part_size(exact_size + 1024 * 1023)
+        self.assertEqual(5_242_991, part_size)
+        self.assertEqual(DEFAULT_MULTIPART_PARTS_COUNT, part_count)
+
+    def test_calculate_part_sizes_leading_to_too_big_parts(self):
+        size_5mb = 5 * 1024 * 1024
+        size_20gb = 20 * 1024 * 1024 * 1024
+        size_5gb = 5 * 1024 * 1024 * 1024
+        size_2point5gb = 2.5 * 1024 * 1024 * 1024
+
+        # baseline, with a free parts count
+        part_size, part_count = S3BaseStorage.calculate_part_size(size_20gb)
+        self.assertEqual(size_5mb, part_size)
+        self.assertEqual(4096, part_count)
+
+        # baseline, with only 8 parts, we should get 2.5 gb parts
+        part_size, part_count = S3BaseStorage.calculate_part_size(size_20gb, max_parts_count=8)
+        self.assertEqual(size_2point5gb, part_size)
+        self.assertEqual(8, part_count)
+
+        # baseline, with only 4 parts, we should get 5 gb parts, which exactly matches
+        part_size, part_count = S3BaseStorage.calculate_part_size(size_20gb, max_parts_count=4)
+        self.assertEqual(size_5gb, part_size)
+        self.assertEqual(4, part_count)
+
+        # a bit bigger and we're screwed
+        self.assertRaises(ValueError, S3BaseStorage.calculate_part_size, size_20gb + 1, max_parts_count=4)
+
+    def test_reproduce_IT_behaviour(self):
+        size_40mb = 40 * 1024 * 1024
+        part_size, parts_count = S3BaseStorage.calculate_part_size(size_40mb, max_parts_count=5)
+        self.assertEqual(8_388_608, part_size)
+        self.assertEqual(5, parts_count)
+
+    def test_credentials_from_metadata(self):
         with patch('botocore.httpsession.URLLib3Session', return_value=_make_instance_metadata_mock()):
             # make an empty temp file to pass as an unconfigured key_file
             with tempfile.NamedTemporaryFile() as empty_file:


### PR DESCRIPTION
There is a cap on number of chunks per multipart-upload (10k of them). For large files, we need to use bigger chunks to fit within this limit.

Fixes #614.