### PR TITLE
[Storage] Pass KMS headers when uploading blobs

### DIFF
--- a/medusa/storage/abstract_storage.py
+++ b/medusa/storage/abstract_storage.py
@@ -36,6 +36,9 @@ MULTIPART_BLOCKS_PER_MB = 16
 AbstractBlob = collections.namedtuple('AbstractBlob', ['name', 'size', 'hash', 'last_modified'])
 
 
+AbstractBlobMetadata = collections.namedtuple('AbstractBlobMetadata', ['name', 'sse_enabled', 'sse_key_id'])
+
+
 class AbstractStorage(abc.ABC):
 
     def __init__(self, config):
@@ -156,6 +159,14 @@ class AbstractStorage(abc.ABC):
     def delete_objects(self, objects):
         for o in objects:
             self.delete_object(o)
+
+    @retry(stop_max_attempt_number=5, wait_fixed=5000)
+    def get_blob_metadata(self, blob_key: str):
+        return AbstractBlobMetadata(blob_key, False, None)
+
+    @retry(stop_max_attempt_number=5, wait_fixed=5000)
+    def get_blobs_metadata(self, blob_keys):
+        return [AbstractBlobMetadata(blob_key, False, None) for blob_key in blob_keys]
 
     def check_dependencies(self):
         """

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -29,9 +29,11 @@ Feature: Integration tests
         When I run a "ccm node1 nodetool -- -Dcom.sun.jndi.rmiURLParsing=legacy flush" command
         When I perform a backup in "full" mode of the node named "first_backup" with md5 checks "disabled"
         Then I can see the backup named "first_backup" when I list the backups
+        And all files of "medusa.test" in "first_backup" were uploaded with KMS key as configured in "<storage>"
         Then I can download the backup named "first_backup" for all tables
         Then I can download the backup named "first_backup" for "medusa.test"
         And I can fetch the tokenmap of the backup named "first_backup"
+        And the schema of the backup named "first_backup" was uploaded with KMS key according to "<storage>"
         Then I can see the backup status for "first_backup" when I run the status command
         Then backup named "first_backup" has 32 files in the manifest for the "test" table in keyspace "medusa"
         Then the backup index exists


### PR DESCRIPTION
I'm still not happy that we pass in the headers differently for upload blob from file vs upload blob from a stream.

I'm also not happy with how eloquent the ITs are, but it's probably still better than hardcoding blob paths.

Fixes #612.