### PR TITLE
Fix k8s restore no backup (v0.15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,10 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         include:
           - python-version: 3.7
             tox-py: py37
-          - python-version: 3.6
-            tox-py: py36
           - python-version: 3.8
             tox-py: py38
           - python-version: 3.9
@@ -105,8 +103,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          #python-version: [3.6]
-          python-version: [3.6, "3.10"]
+          python-version: [3.7, "3.10"]
           it-backend: [local, s3, gcs, minio, azure, azure-hierarchical]
           # IBM not included by default due to lite plan quota being easily exceeded
           #it-backend: [local, s3, gcs, minio, ibm, azure]
@@ -498,10 +495,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install dependencies
       run: |
         python -m venv venv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,8 +329,6 @@ jobs:
           context: .
           tags: k8ssandra/medusa:${{ env.short_sha }}
           platforms: linux/amd64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
       - uses: actions/checkout@v3
         with:
           repository: k8ssandra/k8ssandra-operator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,19 +319,24 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - uses: actions/checkout@v3
+        with:
+          path: cassandra-medusa
       - uses: actions/checkout@v3
         with:
           repository: k8ssandra/k8ssandra-operator
           ref: add-medusa-non-regression-test
-          path: ./k8ssandra-operator
+          path: k8ssandra-operator
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: '1.20'
           cache: true
+          cache-dependency-path: "**/*.sum"
       - name: Install Kind
+        working-directory: k8ssandra-operator
         run: go get sigs.k8s.io/kind
       - name: Build Medusa
+        working-directory: cassandra-medusa
         run: |
           echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           python setup.py build
@@ -339,10 +344,11 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v4
         with:
-          file: k8s/Dockerfile
-          context: .
+          file: cassandra-medusa/k8s/Dockerfile
+          context: ./cassandra-medusa
           tags: k8ssandra/medusa:${{ env.short_sha }}
           platforms: linux/amd64
+          load: true
       - name: Setup kind cluster
         working-directory: k8ssandra-operator
         run: |
@@ -358,11 +364,12 @@ jobs:
           args="$args -medusaImageTag ${{ env.short_sha }}"
           make E2E_TEST="$e2e_test" TEST_ARGS="$args" e2e-test
       - name: Setup tmate session
+        if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
         timeout-minutes: 15
       - name: Get artefact upload directory
-        if: ${{ failure() }}
         working-directory: k8ssandra-operator
+        if: ${{ failure() }}
         run: |
           uploaddir_name=$(echo ${{ matrix.e2e_test }}| sed 's/\//__/g')
           echo 'setting uploaddir_name to' $uploaddir_name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,57 +104,54 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          python-version: [3.7]
-          it-backend: [local]
-          #python-version: [3.7, "3.10"]
-          #it-backend: [local, s3, gcs, minio, azure, azure-hierarchical]
+          python-version: [3.7, "3.10"]
+          it-backend: [local, s3, gcs, minio, azure, azure-hierarchical]
           # IBM not included by default due to lite plan quota being easily exceeded
           #it-backend: [local, s3, gcs, minio, ibm, azure]
-          #cassandra-version: [2.2.19, 3.11.11, 4.0.0, 'github:apache/trunk']
-          cassandra-version: [3.11.11]
+          cassandra-version: [2.2.19, 3.11.11, 4.0.0, 'github:apache/trunk']
           include:
-            #- cassandra-version: 2.2.19
-            #  experimental: false
+            - cassandra-version: 2.2.19
+              experimental: false
             - cassandra-version: 3.11.11
               experimental: false
-            #- cassandra-version: 4.0.0
-            #  experimental: false
-            #- cassandra-version: 'github:apache/trunk'
-            #  experimental: true
-          #exclude:
-          #  # excludes unnecessary combinations
-          #  - it-backend: s3
-          #    cassandra-version: 2.2.19
-          #  - it-backend: s3
-          #    cassandra-version: 'github:apache/trunk'
-          #  - it-backend: s3
-          #    python-version: "3.10"
-          #  - it-backend: gcs
-          #    cassandra-version: 2.2.19
-          #  - it-backend: gcs
-          #    cassandra-version: 'github:apache/trunk'
-          #  - it-backend: gcs
-          #    python-version: "3.10"
-          #  - it-backend: minio
-          #    cassandra-version: 2.2.19
-          #  - it-backend: minio
-          #    cassandra-version: 'github:apache/trunk'
-          #  - it-backend: minio
-          #    python-version: "3.10"
-          #  - it-backend: azure
-          #    cassandra-version: 2.2.19
-          #  - it-backend: azure
-          #    cassandra-version: 'github:apache/trunk'
-          #  - it-backend: azure
-          #    python-version: "3.10"
-          #  - it-backend: azure-hierarchical
-          #    cassandra-version: 2.2.19
-          #  - it-backend: azure-hierarchical
-          #    cassandra-version: 3.11.11
-          #  - it-backend: azure-hierarchical
-          #    cassandra-version: 'github:apache/trunk'
-          #  - it-backend: azure-hierarchical
-          #    python-version: "3.10"
+            - cassandra-version: 4.0.0
+              experimental: false
+            - cassandra-version: 'github:apache/trunk'
+              experimental: true
+          exclude:
+            # excludes unnecessary combinations
+            - it-backend: s3
+              cassandra-version: 2.2.19
+            - it-backend: s3
+              cassandra-version: 'github:apache/trunk'
+            - it-backend: s3
+              python-version: "3.10"
+            - it-backend: gcs
+              cassandra-version: 2.2.19
+            - it-backend: gcs
+              cassandra-version: 'github:apache/trunk'
+            - it-backend: gcs
+              python-version: "3.10"
+            - it-backend: minio
+              cassandra-version: 2.2.19
+            - it-backend: minio
+              cassandra-version: 'github:apache/trunk'
+            - it-backend: minio
+              python-version: "3.10"
+            - it-backend: azure
+              cassandra-version: 2.2.19
+            - it-backend: azure
+              cassandra-version: 'github:apache/trunk'
+            - it-backend: azure
+              python-version: "3.10"
+            - it-backend: azure-hierarchical
+              cassandra-version: 2.2.19
+            - it-backend: azure-hierarchical
+              cassandra-version: 3.11.11
+            - it-backend: azure-hierarchical
+              cassandra-version: 'github:apache/trunk'
+            - it-backend: azure-hierarchical
+              python-version: "3.10"
 
     runs-on: ubuntu-20.04
     services:
@@ -297,7 +294,6 @@ jobs:
       matrix:
         e2e_test:
           - CreateSingleMedusaJob
-          - UpgradeOperatorImage
       fail-fast: false
     name: ${{ matrix.e2e_test }}
     env:
@@ -329,6 +325,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: k8ssandra/k8ssandra-operator
+          # Modify this line to use a different branch when making changes to the operator affecting Medusa
+          # Change to main once the operator changes are merged
           ref: add-medusa-non-regression-test
           path: k8ssandra-operator
       - name: Set up Go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,10 @@ jobs:
       - name: Install Kind
         working-directory: k8ssandra-operator
         run: go get sigs.k8s.io/kind
+      - name: Install kustomize
+        uses: imranismail/setup-kustomize@v2
+        with:
+          kustomize-version: 4.x
       - name: Build Medusa
         working-directory: cassandra-medusa
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,14 +350,13 @@ jobs:
         with:
           file: cassandra-medusa/k8s/Dockerfile
           context: ./cassandra-medusa
-          tags: k8ssandra/medusa:${{ env.short_sha }}
+          tags: k8ssandra/medusa:${{ env.short_sha }}-tmp
           platforms: linux/amd64
-          load: true
+          push: true
       - name: Setup kind cluster
         working-directory: k8ssandra-operator
         run: |
           make single-create
-          kind load docker-image --name k8ssandra-0 k8ssandra/medusa:${{ env.short_sha }}
       - name: Run e2e test ( ${{ matrix.e2e_test }} )
         working-directory: k8ssandra-operator
         run: |
@@ -365,7 +364,7 @@ jobs:
           args="-kubeconfigFile '${{ env.KUBECONFIG_FILE }}'"
           args="$args -controlPlane '${{ env.CONTROL_PLANE }}'"
           args="$args -dataPlanes '${{ env.DATA_PLANES }}'"
-          args="$args -medusaImageTag ${{ env.short_sha }}"
+          args="$args -medusaImageTag ${{ env.short_sha }}-tmp"
           make E2E_TEST="$e2e_test" TEST_ARGS="$args" e2e-test
       - name: Setup tmate session
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,7 +316,21 @@ jobs:
         run: |
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/dotnet
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: k8ssandra/k8ssandra-operator
+          ref: add-medusa-non-regression-test
+          path: ./k8ssandra-operator
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+          cache: true
+      - name: Install Kind
+        run: go get sigs.k8s.io/kind
       - name: Build Medusa
         run: |
           echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
@@ -329,20 +343,6 @@ jobs:
           context: .
           tags: k8ssandra/medusa:${{ env.short_sha }}
           platforms: linux/amd64
-      - uses: actions/checkout@v3
-        with:
-          repository: k8ssandra/k8ssandra-operator
-          ref: add-medusa-non-regression-test
-          path: k8ssandra-operator
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version-file: 'go.mod'
-          cache: true
-      - name: Install Kind
-        run: go get sigs.k8s.io/kind
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
       - name: Setup kind cluster
         working-directory: k8ssandra-operator
         run: |
@@ -357,6 +357,9 @@ jobs:
           args="$args -dataPlanes '${{ env.DATA_PLANES }}'"
           args="$args -medusaImageTag ${{ env.short_sha }}"
           make E2E_TEST="$e2e_test" TEST_ARGS="$args" e2e-test
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        timeout-minutes: 15
       - name: Get artefact upload directory
         if: ${{ failure() }}
         working-directory: k8ssandra-operator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,9 +289,93 @@ jobs:
     - uses: codecov/codecov-action@v1
       name: Report code coverage
   
+  k8ssandra-e2e-tests:
+    needs: [build, integration-tests]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        e2e_test:
+          - CreateSingleMedusaJob
+          - UpgradeOperatorImage
+      fail-fast: false
+    name: ${{ matrix.e2e_test }}
+    env:
+      CGO_ENABLED: 0
+      KUBECONFIG_FILE: "./build/kind-kubeconfig"
+      CONTROL_PLANE: kind-k8ssandra-0
+      DATA_PLANES: kind-k8ssandra-0
+    steps:
+      - name: Raise open files limit
+        run: |
+          echo fs.file-max=1000000 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+          echo fs.inotify.max_user_instances=1280 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+          echo fs.inotify.max_user_watches=655360 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+          ulimit -a
+      - name: Free diskspace by removing unused packages
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+      - uses: actions/checkout@v3
+      - name: Build Medusa
+        run: |
+          echo "Publishing release $(git rev-parse --short HEAD) in Docker Hub"
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          python setup.py build
+      - name: Build image and push
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          file: k8s/Dockerfile
+          context: .
+          push: true
+          tags: k8ssandra/medusa:${{ env.short_sha }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+      - uses: actions/checkout@v3
+        with:
+          repository: k8ssandra/k8ssandra-operator
+          ref: add-medusa-non-regression-test
+          path: k8ssandra-operator
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - name: Install Kind
+        run: go get sigs.k8s.io/kind
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Setup kind cluster
+        working-directory: k8ssandra-operator
+        run: |
+          make single-create
+          kind load docker-image --name k8ssandra-0 k8ssandra/medusa:${{ env.short_sha }}
+      - name: Run e2e test ( ${{ matrix.e2e_test }} )
+        working-directory: k8ssandra-operator
+        run: |
+          e2e_test="TestOperator/${{ matrix.e2e_test }}"
+          args="-kubeconfigFile '${{ env.KUBECONFIG_FILE }}'"
+          args="$args -controlPlane '${{ env.CONTROL_PLANE }}'"
+          args="$args -dataPlanes '${{ env.DATA_PLANES }}'"
+          args="$args -medusaImageTag ${{ env.short_sha }}"
+          make E2E_TEST="$e2e_test" TEST_ARGS="$args" e2e-test
+      - name: Get artefact upload directory
+        if: ${{ failure() }}
+        working-directory: k8ssandra-operator
+        run: |
+          uploaddir_name=$(echo ${{ matrix.e2e_test }}| sed 's/\//__/g')
+          echo 'setting uploaddir_name to' $uploaddir_name
+          echo "uploaddir_name=$uploaddir_name" >> $GITHUB_ENV
+      - name: Archive k8s logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: k8s-logs-${{ env.uploaddir_name }}
+          path: ./k8ssandra-operator/build/test
 
   publish-docker-master:
-    needs: [debian-build, build, integration-tests]
+    needs: [debian-build, build, integration-tests, k8ssandra-e2e-tests]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-20.04
     steps:
@@ -330,7 +414,7 @@ jobs:
     
   publish-debian:
     # We can only release if the build above succeeded first
-    needs: [debian-build, build, integration-tests]
+    needs: [debian-build, build, integration-tests, k8ssandra-e2e-tests]
     if: github.event_name == 'release' && github.event.action == 'published'
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,17 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        #python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7]
         include:
           - python-version: 3.7
             tox-py: py37
-          - python-version: 3.8
-            tox-py: py38
-          - python-version: 3.9
-            tox-py: py39
-          - python-version: "3.10"
-            tox-py: py310
+          #- python-version: 3.8
+          #  tox-py: py38
+          #- python-version: 3.9
+          #  tox-py: py39
+          #- python-version: "3.10"
+          #  tox-py: py310
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -290,7 +291,7 @@ jobs:
       name: Report code coverage
   
   k8ssandra-e2e-tests:
-    needs: [build, integration-tests]
+    needs: [build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -318,18 +319,16 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build Medusa
         run: |
-          echo "Publishing release $(git rev-parse --short HEAD) in Docker Hub"
           echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           python setup.py build
-      - name: Build image and push
+      - name: Build Medusa image
         id: docker_build
         uses: docker/build-push-action@v4
         with:
           file: k8s/Dockerfile
           context: .
-          push: true
           tags: k8ssandra/medusa:${{ env.short_sha }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,54 +103,57 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          python-version: [3.7, "3.10"]
-          it-backend: [local, s3, gcs, minio, azure, azure-hierarchical]
+          python-version: [3.7]
+          it-backend: [local]
+          #python-version: [3.7, "3.10"]
+          #it-backend: [local, s3, gcs, minio, azure, azure-hierarchical]
           # IBM not included by default due to lite plan quota being easily exceeded
           #it-backend: [local, s3, gcs, minio, ibm, azure]
-          cassandra-version: [2.2.19, 3.11.11, 4.0.0, 'github:apache/trunk']
+          #cassandra-version: [2.2.19, 3.11.11, 4.0.0, 'github:apache/trunk']
+          cassandra-version: [3.11.11]
           include:
-            - cassandra-version: 2.2.19
-              experimental: false
+            #- cassandra-version: 2.2.19
+            #  experimental: false
             - cassandra-version: 3.11.11
               experimental: false
-            - cassandra-version: 4.0.0
-              experimental: false
-            - cassandra-version: 'github:apache/trunk'
-              experimental: true
-          exclude:
-            # excludes unnecessary combinations
-            - it-backend: s3
-              cassandra-version: 2.2.19
-            - it-backend: s3
-              cassandra-version: 'github:apache/trunk'
-            - it-backend: s3
-              python-version: "3.10"
-            - it-backend: gcs
-              cassandra-version: 2.2.19
-            - it-backend: gcs
-              cassandra-version: 'github:apache/trunk'
-            - it-backend: gcs
-              python-version: "3.10"
-            - it-backend: minio
-              cassandra-version: 2.2.19
-            - it-backend: minio
-              cassandra-version: 'github:apache/trunk'
-            - it-backend: minio
-              python-version: "3.10"
-            - it-backend: azure
-              cassandra-version: 2.2.19
-            - it-backend: azure
-              cassandra-version: 'github:apache/trunk'
-            - it-backend: azure
-              python-version: "3.10"
-            - it-backend: azure-hierarchical
-              cassandra-version: 2.2.19
-            - it-backend: azure-hierarchical
-              cassandra-version: 3.11.11
-            - it-backend: azure-hierarchical
-              cassandra-version: 'github:apache/trunk'
-            - it-backend: azure-hierarchical
-              python-version: "3.10"
+            #- cassandra-version: 4.0.0
+            #  experimental: false
+            #- cassandra-version: 'github:apache/trunk'
+            #  experimental: true
+          #exclude:
+          #  # excludes unnecessary combinations
+          #  - it-backend: s3
+          #    cassandra-version: 2.2.19
+          #  - it-backend: s3
+          #    cassandra-version: 'github:apache/trunk'
+          #  - it-backend: s3
+          #    python-version: "3.10"
+          #  - it-backend: gcs
+          #    cassandra-version: 2.2.19
+          #  - it-backend: gcs
+          #    cassandra-version: 'github:apache/trunk'
+          #  - it-backend: gcs
+          #    python-version: "3.10"
+          #  - it-backend: minio
+          #    cassandra-version: 2.2.19
+          #  - it-backend: minio
+          #    cassandra-version: 'github:apache/trunk'
+          #  - it-backend: minio
+          #    python-version: "3.10"
+          #  - it-backend: azure
+          #    cassandra-version: 2.2.19
+          #  - it-backend: azure
+          #    cassandra-version: 'github:apache/trunk'
+          #  - it-backend: azure
+          #    python-version: "3.10"
+          #  - it-backend: azure-hierarchical
+          #    cassandra-version: 2.2.19
+          #  - it-backend: azure-hierarchical
+          #    cassandra-version: 3.11.11
+          #  - it-backend: azure-hierarchical
+          #    cassandra-version: 'github:apache/trunk'
+          #  - it-backend: azure-hierarchical
+          #    python-version: "3.10"
 
     runs-on: ubuntu-20.04
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,11 @@ jobs:
           sudo rm -rf /usr/share/dotnet
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.K8SSANDRA_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.K8SSANDRA_DOCKER_HUB_PASSWORD }}
       - uses: actions/checkout@v3
         with:
           path: cassandra-medusa

--- a/medusa/service/grpc/restore.py
+++ b/medusa/service/grpc/restore.py
@@ -71,8 +71,9 @@ def apply_mapping_env():
                 os.environ["POD_IP"] = mapping["host_map"][os.environ["POD_NAME"]]["source"][0]
                 print(f"Restoring from {os.environ['POD_IP']}")
             else:
-                return False, f"POD_NAME {os.environ['POD_NAME']} not found in mapping"
-    return in_place, None
+                print(f"POD_NAME {os.environ['POD_NAME']} not found in mapping")
+                return None
+    return in_place
 
 
 def restore_backup(in_place, config):
@@ -108,13 +109,11 @@ if __name__ == '__main__':
         logging.error("Usage: {} <config_file_path> <restore_key>".format(sys.argv[0]))
         sys.exit(1)
 
-    (in_place, error_message) = apply_mapping_env()
-    if error_message:
-        print(error_message)
-        sys.exit(1)
+    in_place = apply_mapping_env()
+    # If in_place is None, it means that there's no corresponding backup and we can skip the restore phase.
+    if in_place is not None:
+        config = create_config(config_file_path)
+        configure_console_logging(config.logging)
 
-    config = create_config(config_file_path)
-    configure_console_logging(config.logging)
-
-    output_message = restore_backup(in_place, config)
-    logging.info(output_message)
+        output_message = restore_backup(in_place, config)
+        logging.info(output_message)

--- a/medusa/service/grpc/restore.py
+++ b/medusa/service/grpc/restore.py
@@ -87,7 +87,7 @@ def restore_backup(in_place, config):
     tables = {}
     use_sstableloader = False
 
-    cluster_backups = list(medusa.listing.get_backups(config, True))
+    cluster_backups = list(medusa.listing.get_backups(config, False))
     logging.info(f"Found {len(cluster_backups)} backups in the cluster")
     # Checking if the backup exists for the node we're restoring.
     # Skipping restore if it doesn't exist.

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -969,21 +969,23 @@ Feature: Integration tests
         | storage           | client encryption |
         | local      |  with_client_encryption |  
 
-    @26
-    Scenario Outline: Test purge of decommissioned nodes
-        Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>"
-        When node "127.0.0.2" fakes a complete backup named "backup1" on "2019-04-15 12:12:00"
-        Then I can see the backup named "backup1" when I list the backups
-        When I create the "test" table in keyspace "medusa"
-        When I perform a backup in "differential" mode of the node named "backup2" with md5 checks "disabled"
-        Then checking the list of decommissioned nodes returns "127.0.0.2"
-        When I run a purge on decommissioned nodes
-        Then I cannot see the backup named "backup1" when I list the backups
-        Then I can see the backup named "backup2" when I list the backups
-
-        
-
-        @local
-        Examples: Local storage
-        | storage           | client encryption |
-        | local      |  with_client_encryption |
+    # TODO: some steps weren't implemented. Disabling the test until all steps are.
+    #@26
+    #Scenario Outline: Test purge of decommissioned nodes
+    #Given I have a fresh ccm cluster "<client encryption>" running named "scenario26"
+    #    Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>"
+    #    When node "127.0.0.2" fakes a complete backup named "backup1" on "2019-04-15 12:12:00"
+    #    Then I can see the backup named "backup1" when I list the backups
+    #    When I create the "test" table in keyspace "medusa"
+    #    When I perform a backup in "differential" mode of the node named "backup2" with md5 checks "disabled"
+    #    Then checking the list of decommissioned nodes returns "127.0.0.2"
+    #    When I run a purge on decommissioned nodes
+    #    Then I cannot see the backup named "backup1" when I list the backups
+    #    Then I can see the backup named "backup2" when I list the backups
+    #
+    #    
+    #
+    #    @local
+    #    Examples: Local storage
+    #    | storage           | client encryption |
+    #    | local      |  with_client_encryption |

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -967,4 +967,23 @@ Feature: Integration tests
 	@local
         Examples: Local storage
         | storage           | client encryption |
-        | local      |  with_client_encryption |     
+        | local      |  with_client_encryption |  
+
+    @26
+    Scenario Outline: Test purge of decommissioned nodes
+        Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>"
+        When node "127.0.0.2" fakes a complete backup named "backup1" on "2019-04-15 12:12:00"
+        Then I can see the backup named "backup1" when I list the backups
+        When I create the "test" table in keyspace "medusa"
+        When I perform a backup in "differential" mode of the node named "backup2" with md5 checks "disabled"
+        Then checking the list of decommissioned nodes returns "127.0.0.2"
+        When I run a purge on decommissioned nodes
+        Then I cannot see the backup named "backup1" when I list the backups
+        Then I can see the backup named "backup2" when I list the backups
+
+        
+
+        @local
+        Examples: Local storage
+        | storage           | client encryption |
+        | local      |  with_client_encryption |

--- a/tests/service/grpc/restore_test.py
+++ b/tests/service/grpc/restore_test.py
@@ -34,10 +34,9 @@ class ServiceRestoreTest(unittest.TestCase):
             + '"test-dc1-sts-0": {"source": ["test-dc1-sts-0"], "seed": false},' \
             + '"test-dc1-sts-1": {"source": ["test-dc1-sts-1"], "seed": false},' \
             + '"test-dc1-sts-2": {"source": "prod-dc1-sts-2", "seed": false}}}'
-        (in_place, error_message) = apply_mapping_env()
+        in_place = apply_mapping_env()
 
         assert in_place is True
-        assert error_message is None
         assert "POD_IP" not in os.environ.keys()
 
     def test_restore_remote(self):
@@ -46,10 +45,9 @@ class ServiceRestoreTest(unittest.TestCase):
             + '"test-dc1-sts-0": {"source": ["prod-dc1-sts-3"], "seed": false},' \
             + '"test-dc1-sts-1": {"source": ["prod-dc1-sts-1"], "seed": false},' \
             + '"test-dc1-sts-2": {"source": "prod-dc1-sts-2", "seed": false}}}'
-        (in_place, error_message) = apply_mapping_env()
+        in_place = apply_mapping_env()
 
         assert in_place is False
-        assert error_message is None
         assert "POD_IP" in os.environ.keys()
         assert os.environ['POD_IP'] == 'prod-dc1-sts-3'
 
@@ -59,10 +57,9 @@ class ServiceRestoreTest(unittest.TestCase):
             + '"test-dc1-sts-3": {"source": ["prod-dc1-sts-3"], "seed": false},' \
             + '"test-dc1-sts-1": {"source": ["prod-dc1-sts-1"], "seed": false},' \
             + '"test-dc1-sts-2": {"source": "prod-dc1-sts-2", "seed": false}}}'
-        (in_place, error_message) = apply_mapping_env()
+        in_place = apply_mapping_env()
 
-        assert in_place is False
-        assert error_message is not None
+        assert in_place is None
         assert "POD_IP" not in os.environ.keys()
 
     def test_success_restore_backup(self):

--- a/tests/service/grpc/restore_test.py
+++ b/tests/service/grpc/restore_test.py
@@ -89,7 +89,7 @@ class ServiceRestoreTest(unittest.TestCase):
 
                 # Assertions
                 assert result == expected_output
-                mock_get_backups.assert_called_once_with(config, True)
+                mock_get_backups.assert_called_once_with(config, False)
                 mock_restore_node.assert_called_once_with(config, PosixPath('/tmp'),
                                                           'test_backup', True, False, None, False, {}, {}, False)
 
@@ -118,7 +118,7 @@ class ServiceRestoreTest(unittest.TestCase):
                 result = restore_backup(in_place, config)
 
                 assert result == expected_output
-                mock_get_backups.assert_called_once_with(config, True)
+                mock_get_backups.assert_called_once_with(config, False)
                 mock_restore_node.assert_not_called()
 
 


### PR DESCRIPTION
Fixes restore.py (used in the medusa-restore init container of k8ssandra-operator) which fails if a backup cannot be found.
This actually happens when scaling up a cluster after a restore, and is expected so it shouldn't exit with failure but gracefully.

It also invokes relevant e2e tests in k8ssandra-operator so we can make sure the restore.py script still works with it and add non regression checks.
