### PR TITLE
Add gRPC config values to configure max send and max receive sizes

### DIFF
--- a/medusa/config.py
+++ b/medusa/config.py
@@ -73,7 +73,7 @@ LoggingConfig = collections.namedtuple(
 
 GrpcConfig = collections.namedtuple(
     'GrpcConfig',
-    ['enabled']
+    ['enabled', 'max_send_message_length', 'max_receive_message_length']
 )
 
 KubernetesConfig = collections.namedtuple(
@@ -161,6 +161,8 @@ def _build_default_config():
 
     config['grpc'] = {
         'enabled': 'False',
+        'max_send_message_length': '536870912',
+        'max_receive_message_length': '134217728',
     }
 
     config['kubernetes'] = {

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -52,7 +52,10 @@ class Server:
         self.config_file_path = config_file_path
         self.medusa_config = self.create_config()
         self.testing = testing
-        self.grpc_server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+        self.grpc_server = grpc.server(futures.ThreadPoolExecutor(max_workers=10), options = [
+            ('grpc.max_send_message_length', self.medusa_config.grpc.max_send_message_length),
+            ('grpc.max_receive_message_length', self.medusa_config.grpc.max_receive_message_length)
+        ])
         logging.info("GRPC server initialized")
 
     def shutdown(self, signum, frame):

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -52,7 +52,7 @@ class Server:
         self.config_file_path = config_file_path
         self.medusa_config = self.create_config()
         self.testing = testing
-        self.grpc_server = grpc.server(futures.ThreadPoolExecutor(max_workers=10), options = [
+        self.grpc_server = grpc.server(futures.ThreadPoolExecutor(max_workers=10), options=[
             ('grpc.max_send_message_length', self.medusa_config.grpc.max_send_message_length),
             ('grpc.max_receive_message_length', self.medusa_config.grpc.max_receive_message_length)
         ])


### PR DESCRIPTION
Sets the default values to 512MB for send and 128MB to recv (I don't see why Medusa would receive larger messages in the gRPC layer).

Fixes #673 