### PR TITLE
mgmt-api mTLS support

### DIFF
--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -162,6 +162,8 @@ use_sudo_for_restore = True
 
 ; Enables the use of the management API to create snapshots. Falls back to using Jolokia if not enabled.
 ;use_mgmt_api = True
-
+;ca_cert = mutual_auth_ca.pem
+;tls_cert = mutual_auth_client.crt
+;tls_key = mutual_auth_client.key
 
 

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -171,9 +171,9 @@ def _build_default_config():
         'enabled': 'False',
         'cassandra_url': 'None',
         'use_mgmt_api': 'False',
-        'ca_cert': 'None',
-        'tls_cert': 'None',
-        'tls_key': 'None'
+        'ca_cert': '',
+        'tls_cert': '',
+        'tls_key': ''
     }
     return config
 

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -78,7 +78,7 @@ GrpcConfig = collections.namedtuple(
 
 KubernetesConfig = collections.namedtuple(
     'KubernetesConfig',
-    ['enabled', 'cassandra_url', 'use_mgmt_api']
+    ['enabled', 'cassandra_url', 'use_mgmt_api', 'ca_cert', 'tls_cert', 'tls_key']
 )
 
 CONFIG_SECTIONS = {
@@ -170,7 +170,10 @@ def _build_default_config():
     config['kubernetes'] = {
         'enabled': 'False',
         'cassandra_url': 'None',
-        'use_mgmt_api': 'False'
+        'use_mgmt_api': 'False',
+        'ca_cert': 'None',
+        'tls_cert': 'None',
+        'tls_key': 'None'
     }
     return config
 

--- a/medusa/service/snapshot/management_api_snapshot_service.py
+++ b/medusa/service/snapshot/management_api_snapshot_service.py
@@ -23,7 +23,7 @@ class ManagementAPISnapshotService(AbstractSnapshotService):
     def __init__(self, config):
         self.config = config
         self.session = requests.Session()
-        if self.config.tls_cert:
+        if self.config.tls_cert is not None:
             self.session.verify = self.config.ca_cert
             self.session.cert = (self.config.tls_cert, self.config.tls_key)
 

--- a/medusa/service/snapshot/management_api_snapshot_service.py
+++ b/medusa/service/snapshot/management_api_snapshot_service.py
@@ -23,7 +23,7 @@ class ManagementAPISnapshotService(AbstractSnapshotService):
     def __init__(self, config):
         self.config = config
         self.session = requests.Session()
-        if self.config.tls_cert is not None:
+        if self.config.tls_cert is not None and len(self.config.tls_cert) > 0:
             self.session.verify = self.config.ca_cert
             self.session.cert = (self.config.tls_cert, self.config.tls_key)
 


### PR DESCRIPTION
* Add new config parameters: ca_cert, tls_cert and tls_key. 
* Use request…s persistant sessions on Medusa mgmt-api communication
* Set TLS properties if tls_cert config is set (support both TLS and mTLS setup)
