### PR TITLE
Re-upload files if they are missing in storage

### DIFF
--- a/medusa/storage/abstract_storage.py
+++ b/medusa/storage/abstract_storage.py
@@ -21,6 +21,7 @@ import datetime
 import hashlib
 import io
 import logging
+import pathlib
 import typing as t
 
 from pathlib import Path
@@ -401,15 +402,15 @@ class AbstractStorage(abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def file_matches_cache(src, cached_item, threshold=None, enable_md5_checks=False):
+    def file_matches_storage(src: pathlib.Path, cached_item: ManifestObject, threshold=None, enable_md5_checks=False):
         """
-        Compares a local file with its entry in the cache of backed up items. This happens when doing an actual backup.
+        Compares a local file with its version in the storage backend. This happens when doing an actual backup.
 
         This method is expected to take care of actually computing the local hash, but leave the actual comparing to
         _compare_blob_with_manifest().
 
-        :param src: typically, local file that comes as a string/path
-        :param cached_item: usually a reference to a item in the storage, mostly a dict. Likely a manifest object
+        :param src: typically, local file that comes as a Path
+        :param cached_item: a reference to the storage, should be via a manifest object
         :param threshold: files bigger than this are digested by chunks
         :param enable_md5_checks: boolean flag to enable md5 file generation and comparison to the md5
                 found in the manifest (only applicable to some cloud storage implementations that compare md5 hashes)

--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -20,6 +20,7 @@ import io
 import json
 import logging
 import os
+import pathlib
 import typing as t
 
 from azure.core.credentials import AzureNamedKeyCredential
@@ -233,12 +234,12 @@ class AzureStorage(AbstractStorage):
         )
 
     @staticmethod
-    def file_matches_cache(src, cached_item, threshold=None, enable_md5_checks=False):
+    def file_matches_storage(src: pathlib.Path, cached_item: ManifestObject, threshold=None, enable_md5_checks=False):
         return AzureStorage.compare_with_manifest(
             actual_size=src.stat().st_size,
-            size_in_manifest=cached_item['size'],
+            size_in_manifest=cached_item.size,
             actual_hash=AbstractStorage.generate_md5_hash(src) if enable_md5_checks else None,
-            hash_in_manifest=cached_item['MD5'],
+            hash_in_manifest=cached_item.MD5,
         )
 
     @staticmethod

--- a/medusa/storage/google_storage.py
+++ b/medusa/storage/google_storage.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pathlib
 
 import aiohttp
 import base64
@@ -254,12 +255,12 @@ class GoogleStorage(AbstractStorage):
         )
 
     @staticmethod
-    def file_matches_cache(src, cached_item, threshold=None, enable_md5_checks=False):
+    def file_matches_storage(src: pathlib.Path, cached_item: ManifestObject, threshold=None, enable_md5_checks=False):
         return GoogleStorage.compare_with_manifest(
             actual_size=src.stat().st_size,
-            size_in_manifest=cached_item['size'],
+            size_in_manifest=cached_item.size,
             actual_hash=AbstractStorage.generate_md5_hash(src) if enable_md5_checks else None,
-            hash_in_manifest=cached_item['MD5']
+            hash_in_manifest=cached_item.MD5
         )
 
     @staticmethod

--- a/medusa/storage/local_storage.py
+++ b/medusa/storage/local_storage.py
@@ -18,6 +18,7 @@ import hashlib
 import io
 import logging
 import os
+import pathlib
 import typing as t
 from pathlib import Path
 
@@ -186,10 +187,10 @@ class LocalStorage(AbstractStorage):
         )
 
     @staticmethod
-    def file_matches_cache(src, cached_item, threshold=None, enable_md5_checks=False):
+    def file_matches_storage(src: pathlib.Path, cached_item: ManifestObject, threshold=None, enable_md5_checks=False):
         return LocalStorage.compare_with_manifest(
             actual_size=src.stat().st_size,
-            size_in_manifest=cached_item['size']
+            size_in_manifest=cached_item.size
         )
 
     @staticmethod

--- a/medusa/storage/s3_base_storage.py
+++ b/medusa/storage/s3_base_storage.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 import asyncio
 import base64
+import pathlib
+
 import boto3
 import botocore.session
 import concurrent.futures
@@ -426,7 +428,7 @@ class S3BaseStorage(AbstractStorage):
         )
 
     @staticmethod
-    def file_matches_cache(src, cached_item, threshold=None, enable_md5_checks=False):
+    def file_matches_storage(src: pathlib.Path, cached_item: ManifestObject, threshold=None, enable_md5_checks=False):
 
         threshold = int(threshold) if threshold else -1
 
@@ -440,9 +442,9 @@ class S3BaseStorage(AbstractStorage):
 
         return S3BaseStorage.compare_with_manifest(
             actual_size=src.stat().st_size,
-            size_in_manifest=cached_item['size'],
+            size_in_manifest=cached_item.size,
             actual_hash=md5_hash,
-            hash_in_manifest=cached_item['MD5'],
+            hash_in_manifest=cached_item.MD5,
             threshold=threshold
         )
 

--- a/medusa/storage/s3_rgw.py
+++ b/medusa/storage/s3_rgw.py
@@ -12,7 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pathlib
 
+from medusa.storage.abstract_storage import ManifestObject
 from medusa.storage.s3_base_storage import S3BaseStorage
 from medusa.storage.s3_storage import S3Storage
 
@@ -28,9 +30,9 @@ class S3RGWStorage(S3BaseStorage):
         return S3Storage.blob_matches_manifest(blob, object_in_manifest, enable_md5_checks)
 
     @staticmethod
-    def file_matches_cache(src, cached_item, threshold=None, enable_md5_checks=False):
+    def file_matches_storage(src: pathlib.Path, cached_item: ManifestObject, threshold=None, enable_md5_checks=False):
         # for S3RGW, we never set threshold so the S3's multipart never happens
-        return S3Storage.file_matches_cache(src, cached_item, None, enable_md5_checks)
+        return S3Storage.file_matches_storage(src, cached_item, None, enable_md5_checks)
 
     @staticmethod
     def compare_with_manifest(actual_size, size_in_manifest, actual_hash=None, hash_in_manifest=None, threshold=None):

--- a/packaging/docker-build/Dockerfile
+++ b/packaging/docker-build/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update \
 RUN pip3 install --upgrade pip
 
 RUN cd /tmp && \
-    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.2.2-1.4_all.deb && \
+    wget http://mirrors.kernel.org/ubuntu/pool/universe/d/dh-virtualenv/dh-virtualenv_1.2.2-1.4build1_all.deb && \
     gdebi -n dh-virtualenv*.deb && \
     rm dh-virtualenv_*.deb
         

--- a/tests/backup_test.py
+++ b/tests/backup_test.py
@@ -16,6 +16,7 @@
 import pathlib
 import unittest
 
+from medusa.storage.abstract_storage import ManifestObject
 from medusa.storage.google_storage import GoogleStorage
 from medusa.storage.s3_storage import S3Storage
 
@@ -26,31 +27,27 @@ class RestoreNodeTest(unittest.TestCase):
         super().__init__(*args, **kwargs)
 
     def test_single_part_s3_file(self):
-        cached_item = {'MD5': '620c203520494bb92811fddc6d88cd65',
-                       'size': 113651}
+        cached_item = ManifestObject('path', 113651, '620c203520494bb92811fddc6d88cd65')
         src = pathlib.Path(__file__).parent / "resources/s3/md-10-big-CompressionInfo.db"
-        assert S3Storage.file_matches_cache(src, cached_item, 100 * 1024 * 1024, True)
+        assert S3Storage.file_matches_storage(src, cached_item, 100 * 1024 * 1024, True)
 
     def test_multi_part_s3_file(self):
         # Multi part hashes have a special structure, with the number of chunks at the end
-        cached_item = {'MD5': 'e4344d1ea2b32372db7f7e1c81d154b9-1',
-                       'size': 113651}
+        cached_item = ManifestObject('path', 113651, 'e4344d1ea2b32372db7f7e1c81d154b9-1')
         src = pathlib.Path(__file__).parent / "resources/s3/md-10-big-CompressionInfo.db"
-        assert S3Storage.file_matches_cache(src, cached_item, 100, True)
+        assert S3Storage.file_matches_storage(src, cached_item, 100, True)
 
     def test_multi_part_s3_file_fail(self):
         # File size is below the multi part threshold, a single part hash will be computed
-        cached_item = {'MD5': 'e4344d1ea2b32372db7f7e1c81d154b9-1',
-                       'size': 113651}
+        cached_item = ManifestObject('path', 113651, 'e4344d1ea2b32372db7f7e1c81d154b9-1')
         src = pathlib.Path(__file__).parent / "resources/s3/md-10-big-CompressionInfo.db"
-        assert not S3Storage.file_matches_cache(src, cached_item, 100 * 1024 * 1024, True)
+        assert not S3Storage.file_matches_storage(src, cached_item, 100 * 1024 * 1024, True)
 
     def test_gcs_file(self):
         # GCS hashes are b64 encoded
-        cached_item = {'MD5': '2c6QmQGESWilicKJiNY1NQ==',
-                       'size': 148906}
+        cached_item = ManifestObject('path', 148906, '2c6QmQGESWilicKJiNY1NQ==')
         src = pathlib.Path(__file__).parent / "resources/gcs/lb-21-big-Index.db"
-        assert GoogleStorage.file_matches_cache(src, cached_item, True)
+        assert GoogleStorage.file_matches_storage(src, cached_item, True)
 
 
 if __name__ == '__main__':

--- a/tests/storage_test.py
+++ b/tests/storage_test.py
@@ -17,20 +17,28 @@ import base64
 import configparser
 import hashlib
 import os
+import pathlib
 import shutil
 import tempfile
 import unittest
 
 from datetime import datetime
 from random import randrange
+from unittest.mock import patch
 
 import medusa.storage.abstract_storage
 
 from medusa.storage import NodeBackup, ClusterBackup
-from medusa.storage.abstract_storage import AbstractStorage, AbstractBlob
+from medusa.storage.abstract_storage import AbstractStorage, AbstractBlob, ManifestObject
 from medusa.config import MedusaConfig, StorageConfig, _namedtuple_from_dict, CassandraConfig
 from medusa.index import build_indices
 from medusa.storage import Storage
+
+
+class AttributeDict(dict):
+    __slots__ = ()
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
 
 
 class StorageTest(unittest.TestCase):
@@ -353,6 +361,92 @@ class StorageTest(unittest.TestCase):
         self.assertEqual(
             1574343029,
             self.storage.get_timestamp_from_blob_name('index/bi/third_backup/finished_localhost_1574343029.timestamp')
+        )
+
+    def test_list_files_per_table_with_prefix(self):
+
+        def fake_blob(s):
+            return AbstractBlob(s, 0, '0', datetime.now())
+
+        def fake_mo(s):
+            return ManifestObject(s, 0, '0')
+
+        config = AttributeDict({
+            'bucket_name': 'test-bucket',
+            'base_path': 'test-path',
+            'prefix': 'test-prefix',
+            'fqdn': 'test-fqdn',
+            'k8s_mode': False,
+            'storage_provider': 'local'
+        })
+        s = Storage(config=config)
+        listed_files = [
+            fake_blob('test-prefix/test-fqdn/data/test-keyspace/test-table-1/test-file-1.db'),
+            fake_blob('test-prefix/test-fqdn/data/test-keyspace/test-table-2/test-file-2.db'),
+            fake_blob('test-prefix/test-fqdn/data/test-keyspace/test-table-1/.index/test-file-1.db'),
+            fake_blob('test-prefix/test-fqdn/data/test-keyspace-2/test-table-2/test-file-1.db'),
+            fake_blob('test-prefix/test-fqdn/data/dse/metadata/nodes/local'),
+            # not having prefix actually doesn't matter because we parse from the end
+            fake_blob('test-fqdn/data/test-keyspace-3/test-table-1/test-file-1.db'),
+            fake_blob('test-fqdn/data/test-keyspace-3/test-table-2/test-file-2.db'),
+
+        ]
+        expected_grouping = {
+            'test-keyspace': {
+                'test-table-1': {
+                    'test-file-1.db': fake_mo('test-prefix/test-fqdn/data/test-keyspace/test-table-1/test-file-1.db')
+                },
+                'test-table-1..index': {
+                    'test-file-1.db':
+                        fake_mo('test-prefix/test-fqdn/data/test-keyspace/test-table-1/.index/test-file-1.db')
+                },
+                'test-table-2': {
+                    'test-file-2.db': fake_mo('test-prefix/test-fqdn/data/test-keyspace/test-table-2/test-file-2.db')
+                },
+            },
+            'test-keyspace-2': {
+                'test-table-2': {
+                    'test-file-1.db': fake_mo('test-prefix/test-fqdn/data/test-keyspace-2/test-table-2/test-file-1.db')
+                }
+            },
+            'dse': {
+                'metadata.nodes': {
+                    'local': fake_mo('test-prefix/test-fqdn/data/dse/metadata/nodes/local')
+                }
+            },
+            'test-keyspace-3': {
+                'test-table-1': {
+                    'test-file-1.db': fake_mo('test-fqdn/data/test-keyspace-3/test-table-1/test-file-1.db')
+                },
+                'test-table-2': {
+                    'test-file-2.db': fake_mo('test-fqdn/data/test-keyspace-3/test-table-2/test-file-2.db')
+                }
+            },
+
+        }
+        with patch('medusa.storage.local_storage.LocalStorage._list_blobs', return_value=listed_files):
+            self.assertEqual(expected_grouping, s.list_files_per_table())
+
+    def test_saniitize_keyspace_and_table_name(self):
+        p = pathlib.Path('/some/path/keyspace/table-cfid/snapshots/snapshot-name/nb-5-big-CompressionInfo.db')
+        self.assertEqual(
+            ('keyspace', 'table-cfid'),
+            self.storage.sanitize_keyspace_and_table_name(p)
+        )
+        p = pathlib.Path('/path/keyspace/table-cfid/snapshots/snapshot-name/.index_name/nb-5-big-CompressionInfo.db')
+        self.assertEqual(
+            ('keyspace', 'table-cfid..index_name'),
+            self.storage.sanitize_keyspace_and_table_name(p)
+        )
+        p = pathlib.Path('other/path/prefix/fqdn/data/keyspace/table-cfid/nb-5-big-Data.db')
+        self.assertEqual(
+            ('keyspace', 'table-cfid'),
+            self.storage.sanitize_keyspace_and_table_name(p)
+        )
+        p = pathlib.Path('other/path/prefix/fqdn/data/keyspace/table-cfid/.index_name/nb-5-big-Data.db')
+        self.assertEqual(
+            ('keyspace', 'table-cfid..index_name'),
+            self.storage.sanitize_keyspace_and_table_name(p)
         )
 
 


### PR DESCRIPTION
Fixes #709
Fixes #368 

In short, the way we do this is to list all files in storage, in the data folder for the given prefix and node,  _after_ doing a snapshot but _before_ we start backing up individual tables. We we then group the listed files into a dict->dict->set keyed by keyspace->table, so that we can look up any given file efficiently. 

Tested manually on a node with ~11k LCS SSTables. Did not observe a particular increase in (differential) backup duration.  There probably is an increased memory consumption, but I'm struggling a bit to quantify how much.