### PR TITLE
Make grpc's AsynBackup trully Async

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -31,7 +31,7 @@ ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 RUN python3 -m pip install -U pip && pip3 install --ignore-installed --user poetry
 
 # Build medusa itself so we can add the executables in the final image
-RUN cd /build && poetry install
+RUN cd /build && poetry build && poetry install
 
 # Could be python:slim, but we have a .sh entrypoint
 FROM ubuntu:22.04
@@ -52,7 +52,8 @@ WORKDIR /home/cassandra
 
 ENV DEBUG_VERSION 1
 ENV DEBUG_SLEEP 0
-ENV PATH=/home/cassandra/.local/bin:/home/cassandra/google-cloud-sdk/bin:$PATH
+ENV PATH=/home/cassandra/.local/bin:/home/cassandra/google-cloud-sdk/bin:/home/cassandra/bin:$PATH
+ENV PYTHONPATH=/home/cassandra
 
 COPY --from=base --chown=cassandra:cassandra /root/.local /home/cassandra/.local
 
@@ -60,6 +61,9 @@ COPY --from=base --chown=cassandra:cassandra /build/.venv /home/cassandra/.venv
 COPY --from=base --chown=cassandra:cassandra /build/pyproject.toml /home/cassandra/pyproject.toml
 COPY --chown=cassandra:cassandra medusa /home/cassandra/medusa
 COPY --chown=cassandra:cassandra k8s/docker-entrypoint.sh /home/cassandra
+
+RUN mkdir -p /home/cassandra/bin
+COPY --chown=cassandra:cassandra k8s/medusa.sh /home/cassandra/bin/medusa
 
 # Avoid Click locale errors when running medusa directly
 ENV LC_ALL=C.UTF-8

--- a/k8s/medusa.sh
+++ b/k8s/medusa.sh
@@ -1,0 +1,5 @@
+#!/home/cassandra/.venv/bin/python
+import sys
+from medusa.medusacli import cli
+if __name__ == '__main__':
+    sys.exit(cli())

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -926,6 +926,7 @@ Feature: Integration tests
         When I load 100 rows in the "medusa.test" table
         When I run a "ccm node1 nodetool -- -Dcom.sun.jndi.rmiURLParsing=legacy flush" command
         When I perform an async backup over gRPC in "differential" mode of the node named "grpc_backup_23"
+        Then I wait for the async backup "grpc_backup_23" to finish
         Then the backup index exists
         Then I verify over gRPC that the backup "grpc_backup_23" exists and is of type "differential"
         Then I can see the backup index entry for "grpc_backup_23"
@@ -1038,6 +1039,7 @@ Feature: Integration tests
         When I run a "ccm node1 nodetool -- -Dcom.sun.jndi.rmiURLParsing=legacy flush" command
         When I run a "ccm node2 nodetool -- -Dcom.sun.jndi.rmiURLParsing=legacy flush" command
         When I perform an async backup over gRPC in "differential" mode of the node named "grpc_backup_28"
+        Then I wait for the async backup "grpc_backup_28" to finish
         Then the backup index exists
         Then I verify over gRPC that the backup "grpc_backup_28" exists and is of type "differential"
         # The backup status is not actually a SUCCESS because the node2 has not been backed up.
@@ -1066,12 +1068,14 @@ Feature: Integration tests
         When I run a DSE "nodetool flush" command
         Then I can make a search query against the "medusa"."test" table
         When I perform an async backup over gRPC in "differential" mode of the node named "backup29-1"
+        Then I wait for the async backup "backup29-1" to finish
         Then the backup index exists
         Then I can see the backup named "backup29-1" when I list the backups
         And the backup "backup29-1" has server_type "dse" in its metadata
         Then I verify over gRPC that the backup "backup29-1" exists and is of type "differential"
         Then I verify over gRPC that the backup "backup29-1" has expected status SUCCESS
         When I perform an async backup over gRPC in "differential" mode of the node named "backup29-2"
+        Then I wait for the async backup "backup29-2" to finish
         Then the backup index exists
         Then I can see the backup named "backup29-2" when I list the backups
         And the backup "backup29-2" has server_type "dse" in its metadata


### PR DESCRIPTION
Fixes https://github.com/k8ssandra/k8ssandra-operator/issues/1183
Fixes https://github.com/k8ssandra/k8ssandra-operator/issues/1231
Fixes https://github.com/thelastpickle/cassandra-medusa/issues/721

The GRPC's AsyncBackup endpoint was not async. It was blocking until the backup finished. This PR fixes that, and then adjusts the ITs so that they work with the new async implementation. 
I've also touched the logging during ITs so that we don't have thousands of lines about Cassandra not being yet available.
I've also touched how we build the Medusa container image for k8s; it now has the Medusa entry point on the system path again.

Aside from the ITs, I've tested this by:
- manually hitting the (Async)Backup endpoints with Bloom RPC
- loading a Medusa image built off this branch into a k8s cluster with k8ssandra-operator and creating a backup
- observing that the backups happen in parallel
- observing that the MedusaBackupJob gets its status updated after a node finishes (or fails) instead of waiting till all the nodes are done.