### PR TITLE
Fix GetBackupStatus endpoint on a fresh gRPC server

### DIFF
--- a/medusa/backup_manager.py
+++ b/medusa/backup_manager.py
@@ -109,7 +109,7 @@ class BackupMan:
                 BackupMan()
 
             if backup_name in BackupMan.__instance.__backups:
-                logging.warning("Registered backup name {} found existing, replacing with new".format(backup_name))
+                logging.debug("Registered backup name {} found existing, replacing with new".format(backup_name))
                 if not BackupMan.__clean(backup_name):
                     logging.error("Registered backup name {} cleanup failed prior to re-register.".format(backup_name))
 
@@ -177,8 +177,10 @@ class BackupMan:
             with lock:
                 if backup_name in BackupMan.__instance.__backups:
                     old_status = BackupMan.__instance.__backups[backup_name][BackupMan.__IDX_STATUS]
-                    logging.info("Updated from existing status: {} to new status: {} "
-                                 "for backup id: {} ".format(old_status, status, backup_name))
+                    logging.debug(
+                        "Updated from existing status: {} to new status: {} for backup id: {} "
+                        .format(old_status, status, backup_name)
+                    )
                     BackupMan.__instance.__backups[backup_name][BackupMan.__IDX_STATUS] = status
                 else:
                     raise RuntimeError('Unable to update backup status for backup id: {} '

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -189,6 +189,13 @@ class MedusaService(medusa_pb2_grpc.MedusaServicer):
                     response.finishTime = datetime.fromtimestamp(backup.finished).strftime(TIMESTAMP_FORMAT)
                 else:
                     response.finishTime = ""
+                BackupMan.register_backup(request.backupName, is_async=False)
+                status = BackupMan.STATUS_UNKNOWN
+                if backup.started:
+                    status = BackupMan.STATUS_IN_PROGRESS
+                if backup.finished:
+                    status = BackupMan.STATUS_SUCCESS
+                BackupMan.update_backup_status(request.backupName, status)
                 # record the status
                 record_status_in_response(response, request.backupName)
         except KeyError:

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -1097,3 +1097,22 @@ Feature: Integration tests
     Examples: S3 storage
     | storage           | client encryption         |
     | s3_us_west_oregon | without_client_encryption |
+
+    @31
+    Scenario Outline: Perform a backup, then forget about it, then get its status over gRPC
+        Given I have a fresh ccm cluster with jolokia "<client encryption>" running named "scenario31"
+        Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>" with gRPC server
+        Then the gRPC server is up
+        When I create the "test" table in keyspace "medusa"
+        When I load 100 rows in the "medusa.test" table
+        When I run a "ccm node1 nodetool -- -Dcom.sun.jndi.rmiURLParsing=legacy flush" command
+        When I perform a backup in "differential" mode of the node named "first_backup" with md5 checks "enabled"
+        Then the backup index exists
+        When I forget about all backups
+        Then I verify over gRPC that the backup "first_backup" has status "SUCCESS"
+        Then I shutdown the gRPC server
+
+        @local
+        Examples: Local storage
+        | storage           | client encryption |
+        | local      |  with_client_encryption |

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -427,6 +427,12 @@ def i_am_using_storage_provider_with_grpc_server(context, storage_provider, clie
     time.sleep(3)
 
 
+@when(r'I forget about all backups')
+def i_forget_backups(context):
+    # makes the gRPC server look like we've just started it
+    BackupMan.remove_all_backups()
+
+
 @given(r'I am using "{storage_provider}" as storage provider in ccm cluster "{client_encryption}" with mgmt api')
 def i_am_using_storage_provider_with_grpc_server_and_mgmt_api(context, storage_provider, client_encryption):
     config = parse_medusa_config(
@@ -730,6 +736,12 @@ def _i_perform_grpc_backup_of_node_named_backupname_fails(context, backup_mode, 
     except Exception:
         # This exception is required to be raised to validate the step
         pass
+
+
+@then(r'I verify over gRPC that the backup "{backup_name}" has status "{backup_status}"')
+def _i_verify_over_grpc_that_backup_has_status(context, backup_name, backup_status):
+    status = asyncio.get_event_loop().run_until_complete(context.grpc_client.get_backup_status(name=backup_name))
+    assert status == medusa_pb2.StatusType.SUCCESS
 
 
 @then(r'I verify over gRPC that the backup "{backup_name}" exists and is of type "{backup_type}"')

--- a/tests/service/grpc/server_test.py
+++ b/tests/service/grpc/server_test.py
@@ -211,8 +211,8 @@ class ServerTest(unittest.TestCase):
             context = Mock(spec=ServicerContext)
             backup_status = service.BackupStatus(request, context)
 
-            # we get the response as IN_PROGRESS
-            self.assertEqual(medusa_pb2.StatusType.IN_PROGRESS, backup_status.status)
+            # we get the response as SUCCESS because the finish time is set (~not None)
+            self.assertEqual(medusa_pb2.StatusType.SUCCESS, backup_status.status)
             # the finish time is already set
             # I'm not sure this is because of faking the backup
             start_time = int(datetime.strptime(backup_status.startTime, '%Y-%m-%d %H:%M:%S').timestamp())


### PR DESCRIPTION
Fixes #515 .

There was a bug in the `GetBackupStatus` endpoint. If it got hit on a fresh server (such that that particular python process never seen the creation of the requested backup), then it would not be able to report the status of the backup, and complain something along the lines of:
```
        File "/.../cassandra-medusa/medusa/backup_manager.py", line 73, in get_backup_status
          if backup_name not in BackupMan.__instance.__backups:
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      AttributeError: 'NoneType' object has no attribute '_BackupMan__backups'
```

This PR fixes that by (re)registering the backup once we list it during answering the `GetBackupStatus` request.

Edit: The debian build is failing because [this](https://github.com/thelastpickle/cassandra-medusa/pull/716/files#diff-9852e2a81ec69c8ecf9eb81d6a86c23d12a7e13a794a7f6aa4e73c692e2bff72L61) is not merged yet.