### PR TITLE
Make a tempfile while backup is running

### DIFF
--- a/medusa/backup_manager.py
+++ b/medusa/backup_manager.py
@@ -193,7 +193,7 @@ class BackupMan:
     def __clean(backup_name):
         try:
             backup_future = BackupMan.__instance.__backups[backup_name][0]
-            logging.debug("Cancelling backup` id: {}".format(backup_name))
+            logging.debug("Cancelling backup id: {}".format(backup_name))
             if backup_future is not None and asyncio.isfuture(backup_future):
                 backup_future.cancel("Removal of backup requested. Cancelling backup Name: {} with "
                                      "done state: {}".format(backup_name, backup_future.done()))

--- a/medusa/utils.py
+++ b/medusa/utils.py
@@ -15,7 +15,29 @@
 
 import logging
 import sys
+import pathlib
 import traceback
+
+
+class MedusaTempFile(object):
+
+    _tempfile_path = '/tmp/medusa_backup_in_progress'
+
+    def __init__(self):
+        pass
+
+    def create(self):
+        self._tempfile = open(self._tempfile_path, 'wb')
+
+    def delete(self):
+        self._tempfile.close()
+        pathlib.Path(self._tempfile_path).unlink()
+
+    def exists(self):
+        return pathlib.Path(self._tempfile_path).exists()
+
+    def get_path(self):
+        return self._tempfile_path
 
 
 def evaluate_boolean(value):

--- a/medusa/utils.py
+++ b/medusa/utils.py
@@ -17,12 +17,13 @@ import logging
 import sys
 import pathlib
 import traceback
+import tempfile
 
 
 class MedusaTempFile(object):
 
     _tempfile = None
-    _tempfile_path = '/tmp/medusa_backup_in_progress'
+    _tempfile_path = f'{tempfile.gettempdir()}/medusa_backup_in_progress'
 
     def __init__(self):
         pass

--- a/medusa/utils.py
+++ b/medusa/utils.py
@@ -44,7 +44,13 @@ class MedusaTempFile(object):
 
     def exists(self):
         if self._tempfile is not None:
-            return pathlib.Path(self._tempfile_path).exists()
+            try:
+                return pathlib.Path(self._tempfile_path).exists()
+            except Exception:
+                logging.warning(
+                    f'Could not check for running backup marker {self._tempfile_path}. Assuming a backup is not running'
+                )
+                return False
         else:
             return False
 

--- a/medusa/utils.py
+++ b/medusa/utils.py
@@ -21,20 +21,31 @@ import traceback
 
 class MedusaTempFile(object):
 
+    _tempfile = None
     _tempfile_path = '/tmp/medusa_backup_in_progress'
 
     def __init__(self):
         pass
 
     def create(self):
-        self._tempfile = open(self._tempfile_path, 'wb')
+        try:
+            self._tempfile = open(self._tempfile_path, 'wb')
+        except Exception:
+            logging.warning(f'Could not create running backup marker at {self._tempfile_path}')
 
     def delete(self):
-        self._tempfile.close()
-        pathlib.Path(self._tempfile_path).unlink()
+        try:
+            if self._tempfile is not None:
+                self._tempfile.close()
+                pathlib.Path(self._tempfile_path).unlink()
+        except Exception:
+            pass
 
     def exists(self):
-        return pathlib.Path(self._tempfile_path).exists()
+        if self._tempfile is not None:
+            return pathlib.Path(self._tempfile_path).exists()
+        else:
+            return False
 
     def get_path(self):
         return self._tempfile_path

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -926,7 +926,9 @@ Feature: Integration tests
         When I load 100 rows in the "medusa.test" table
         When I run a "ccm node1 nodetool -- -Dcom.sun.jndi.rmiURLParsing=legacy flush" command
         When I perform an async backup over gRPC in "differential" mode of the node named "grpc_backup_23"
+        Then I can tell a backup "is" in progress
         Then I wait for the async backup "grpc_backup_23" to finish
+        Then I can tell a backup "is not" in progress
         Then the backup index exists
         Then I verify over gRPC that the backup "grpc_backup_23" exists and is of type "differential"
         Then I can see the backup index entry for "grpc_backup_23"

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -71,6 +71,8 @@ from medusa.config import _namedtuple_from_dict
 from medusa.monitoring import LocalMonitoring
 from medusa.service.grpc import medusa_pb2
 from medusa.storage import Storage
+from medusa.utils import MedusaTempFile
+
 
 storage_prefix = "{}-{}".format(datetime.datetime.now().isoformat(), str(uuid.uuid4()))
 os.chdir("..")
@@ -1665,6 +1667,15 @@ def _backup_has_server_type_and_release_version(context, backup_name, server_typ
         node_backup = storage.get_node_backup(fqdn=context.medusa_config.storage.fqdn, name=backup_name)
         assert server_type == node_backup.server_type
         # not asserting for release_version because it's hard to get the Cassandra's one
+
+
+@then(u'I can tell a backup "{is_in_progress}" in progress')
+def _backup_is_or_is_not_in_progress(context, is_in_progress):
+    marker_file_path = MedusaTempFile().get_path()
+    if 'is' == is_in_progress:
+        assert Path(marker_file_path).exists()
+    if 'is not' == is_in_progress:
+        assert not Path(marker_file_path).exists()
 
 
 def connect_cassandra(is_client_encryption_enable, tls_version=PROTOCOL_TLS):


### PR DESCRIPTION
Fixes https://github.com/k8ssandra/k8ssandra-operator/issues/1256
Fixes https://github.com/k8ssandra/k8ssandra-operator/issues/1255

This PR adds the feature of reloading Medusa's configuration when running within the k8ssandra-operator.

The implementation has two parts:
* Medusa will touch a file in `/tmp` to indicate a backup is running. This is easily detectable from a shell w/o invoking anything special (another Medusa instance included).
* The entry point of the Docker image we use in k8ssandra-operator will start Medusa and then proceed to watch the `medusa.ini` file for changes by recalculating its digest every 5 seconds. If the digest changes, it'll check for running backups. If there are none, it'll kill the Medusa's gRPC process and exit, thus killing the entire container.

The k8ssandra-operator will then restart the container, which will bring in the updated config.

(The debian build is failing for a known reason that gets fixed in another PR).