### PR TITLE
Enable SSL without client verification

### DIFF
--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -16,6 +16,7 @@
 ;stop_cmd = /etc/init.d/cassandra stop
 ;start_cmd = /etc/init.d/cassandra start
 ;config_file = <path to cassandra.yaml. Defaults to /etc/cassandra/cassandra.yaml>
+;ssl = true
 ;cql_username = <username>
 ;cql_password = <password>
 ; When using the following setting there must be files in:

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -74,8 +74,8 @@ class CqlSessionProvider(object):
                                                   password=self._cassandra_config.cql_password)
             self._auth_provider = auth_provider
 
-        if ((self._cassandra_config.ssl is not None and evaluate_boolean(self._cassandra_config.ssl)) or 
-            self._cassandra_config.certfile is not None):
+        if ((self._cassandra_config.ssl is not None and evaluate_boolean(self._cassandra_config.ssl))
+                or self._cassandra_config.certfile is not None):
             ssl_context = SSLContext(PROTOCOL_TLSv1_2)
 
             if self._cassandra_config.certfile is not None:

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -74,8 +74,8 @@ class CqlSessionProvider(object):
                                                   password=self._cassandra_config.cql_password)
             self._auth_provider = auth_provider
 
-        if ( (self._cassandra_config.ssl is not None and evaluate_boolean(self._cassandra_config.ssl)) or 
-            self._cassandra_config.certfile is not None ):
+        if ((self._cassandra_config.ssl is not None and evaluate_boolean(self._cassandra_config.ssl)) or 
+            self._cassandra_config.certfile is not None):
             ssl_context = SSLContext(PROTOCOL_TLSv1_2)
 
             if self._cassandra_config.certfile is not None:

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -74,7 +74,8 @@ class CqlSessionProvider(object):
                                                   password=self._cassandra_config.cql_password)
             self._auth_provider = auth_provider
 
-        if evaluate_boolean(self._cassandra_config.ssl) or self._cassandra_config.certfile is not None:
+        if ( (self._cassandra_config.ssl is not None and evaluate_boolean(self._cassandra_config.ssl)) or 
+            self._cassandra_config.certfile is not None ):
             ssl_context = SSLContext(PROTOCOL_TLSv1_2)
 
             if self._cassandra_config.certfile is not None:

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -74,11 +74,10 @@ class CqlSessionProvider(object):
                                                   password=self._cassandra_config.cql_password)
             self._auth_provider = auth_provider
 
-
         if evaluate_boolean(self._cassandra_config.ssl) or self._cassandra_config.certfile is not None:
             ssl_context = SSLContext(PROTOCOL_TLSv1_2)
 
-            if self._cassandra_config.certfile is not None:                
+            if self._cassandra_config.certfile is not None:
                 ssl_context.load_verify_locations(self._cassandra_config.certfile)
                 ssl_context.verify_mode = CERT_REQUIRED
                 if self._cassandra_config.usercert is not None and self._cassandra_config.userkey is not None:

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -74,15 +74,18 @@ class CqlSessionProvider(object):
                                                   password=self._cassandra_config.cql_password)
             self._auth_provider = auth_provider
 
-        if self._cassandra_config.certfile is not None:
+
+        if medusa.utils.evaluate_boolean(self._cassandra_config.ssl) or self._cassandra_config.certfile is not None:
             ssl_context = SSLContext(PROTOCOL_TLSv1_2)
-            ssl_context.load_verify_locations(self._cassandra_config.certfile)
-            ssl_context.verify_mode = CERT_REQUIRED
-            if self._cassandra_config.usercert is not None and self._cassandra_config.userkey is not None:
-                ssl_context.load_cert_chain(
-                    certfile=self._cassandra_config.usercert,
-                    keyfile=self._cassandra_config.userkey)
-            self._ssl_context = ssl_context
+
+            if self._cassandra_config.certfile is not None:                
+                ssl_context.load_verify_locations(self._cassandra_config.certfile)
+                ssl_context.verify_mode = CERT_REQUIRED
+                if self._cassandra_config.usercert is not None and self._cassandra_config.userkey is not None:
+                    ssl_context.load_cert_chain(
+                        certfile=self._cassandra_config.usercert,
+                        keyfile=self._cassandra_config.userkey)
+                self._ssl_context = ssl_context
 
         load_balancing_policy = WhiteListRoundRobinPolicy(ip_addresses)
         self._execution_profiles = {

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -75,7 +75,7 @@ class CqlSessionProvider(object):
             self._auth_provider = auth_provider
 
 
-        if medusa.utils.evaluate_boolean(self._cassandra_config.ssl) or self._cassandra_config.certfile is not None:
+        if evaluate_boolean(self._cassandra_config.ssl) or self._cassandra_config.certfile is not None:
             ssl_context = SSLContext(PROTOCOL_TLSv1_2)
 
             if self._cassandra_config.certfile is not None:                

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -138,7 +138,7 @@ def _build_default_config():
         'resolve_ip_addresses': 'True',
         'use_sudo': 'True',
         'nodetool_executable': 'nodetool',
-        'nodetool_flags': '-Dcom.sun.jndi.rmiURLParsing=legacy', 
+        'nodetool_flags': '-Dcom.sun.jndi.rmiURLParsing=legacy',
         'ssl': 'False'
     }
 

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -36,7 +36,7 @@ StorageConfig = collections.namedtuple(
 
 CassandraConfig = collections.namedtuple(
     'CassandraConfig',
-    ['start_cmd', 'stop_cmd', 'config_file', 'cql_username', 'cql_password', 'check_running', 'is_ccm',
+    ['start_cmd', 'stop_cmd', 'config_file', 'ssl', 'cql_username', 'cql_password', 'check_running', 'is_ccm',
      'sstableloader_bin', 'nodetool_username', 'nodetool_password', 'nodetool_password_file_path', 'nodetool_host',
      'nodetool_executable', 'nodetool_port', 'certfile', 'usercert', 'userkey', 'sstableloader_ts',
      'sstableloader_tspw', 'sstableloader_ks', 'sstableloader_kspw', 'nodetool_ssl', 'resolve_ip_addresses', 'use_sudo',
@@ -138,7 +138,8 @@ def _build_default_config():
         'resolve_ip_addresses': 'True',
         'use_sudo': 'True',
         'nodetool_executable': 'nodetool',
-        'nodetool_flags': '-Dcom.sun.jndi.rmiURLParsing=legacy'
+        'nodetool_flags': '-Dcom.sun.jndi.rmiURLParsing=legacy', 
+        'ssl': 'False'
     }
 
     config['ssh'] = {

--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -44,7 +44,8 @@ class CassandraUtilsTest(unittest.TestCase):
             'host_file_separator': ','
         }
         config['cassandra'] = {
-            'resolve_ip_addresses': 'False'
+            'resolve_ip_addresses': 'False',
+            'ssl': 'False'
         }
         config["grpc"] = {
             "enabled": "0"


### PR DESCRIPTION
## Support SSL connection when client verification is not required. 

### Description
This PR is to support SSL connection without cert files required. This is needed when "require_client_auth" is disabled in Cassandra configurations. 

### Status

- done, ready for review


Closes #563 and #543 
