### PR TITLE
Support (S3, GCP, Azure) storage classes

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -52,6 +52,14 @@ storage_provider = <Storage system used for backups>
 ; storage_provider should be either of "local", "google_storage" or "s3"
 region = <Region hosting the storage>
 
+storage_class = <Storage Class Name used to store backups>
+; AWS S3 Storage classes: STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | GLACIER | DEEP_ARCHIVE | GLACIER_IR
+; GCP Storage classes: STANDARD | NEARLINE | COLDLINE | ARCHIVE
+; AZURE Storage classes: ARCHIVE | COLD | COOL | HOT
+; https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html
+; https://cloud.google.com/storage/docs/storage-classes
+; https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview
+
 ; Name of the bucket used for storing backups
 bucket_name = cassandra_backups
 

--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -63,7 +63,7 @@ storage_provider = <Storage system used for backups>
 storage_class = <Storage Class Name used to store backups>
 ; AWS S3 Storage classes: STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | GLACIER | DEEP_ARCHIVE | GLACIER_IR
 ; GCP Storage classes: STANDARD | NEARLINE | COLDLINE | ARCHIVE
-; AZURE Storage classes: Cool | Hot | Archive
+; AZURE Storage classes: ARCHIVE | COLD | COOL | HOT
 ; https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html
 ; https://cloud.google.com/storage/docs/storage-classes
 ; https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview

--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -60,6 +60,14 @@ storage_provider = <Storage system used for backups>
 ; storage_provider should be either of "local", "google_storage", "azure_blobs" or the s3_* values from
 ; https://github.com/apache/libcloud/blob/trunk/libcloud/storage/types.py
 
+storage_class = <Storage Class Name used to store backups>
+; AWS S3 Storage classes: STANDARD | REDUCED_REDUNDANCY | STANDARD_IA | ONEZONE_IA | INTELLIGENT_TIERING | GLACIER | DEEP_ARCHIVE | GLACIER_IR
+; GCP Storage classes: STANDARD | NEARLINE | COLDLINE | ARCHIVE
+; AZURE Storage classes: Cool | Hot | Archive
+; https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html
+; https://cloud.google.com/storage/docs/storage-classes
+; https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview
+
 ; Name of the bucket used for storing backups
 bucket_name = cassandra_backups
 

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -28,7 +28,7 @@ from medusa.network.hostname_resolver import HostnameResolver
 
 StorageConfig = collections.namedtuple(
     'StorageConfig',
-    ['bucket_name', 'key_file', 'prefix', 'fqdn', 'host_file_separator', 'storage_provider', 'storage_class', 
+    ['bucket_name', 'key_file', 'prefix', 'fqdn', 'host_file_separator', 'storage_provider', 'storage_class',
      'base_path', 'max_backup_age', 'max_backup_count', 'api_profile', 'transfer_max_bandwidth',
      'concurrent_transfers', 'multi_part_upload_threshold', 'host', 'region', 'port', 'secure', 'ssl_verify',
      'aws_cli_path', 'kms_id', 'backup_grace_period_in_days', 'use_sudo_for_restore', 'k8s_mode']

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -28,7 +28,7 @@ from medusa.network.hostname_resolver import HostnameResolver
 
 StorageConfig = collections.namedtuple(
     'StorageConfig',
-    ['bucket_name', 'key_file', 'prefix', 'fqdn', 'host_file_separator', 'storage_provider',
+    ['bucket_name', 'key_file', 'prefix', 'fqdn', 'host_file_separator', 'storage_provider', 'storage_class', 
      'base_path', 'max_backup_age', 'max_backup_count', 'api_profile', 'transfer_max_bandwidth',
      'concurrent_transfers', 'multi_part_upload_threshold', 'host', 'region', 'port', 'secure', 'ssl_verify',
      'aws_cli_path', 'kms_id', 'backup_grace_period_in_days', 'use_sudo_for_restore', 'k8s_mode']

--- a/medusa/storage/abstract_storage.py
+++ b/medusa/storage/abstract_storage.py
@@ -441,6 +441,12 @@ class AbstractStorage(abc.ABC):
         """
         return {}
 
+    def get_storage_class(self):
+        if self.config.storage_class is not None:
+            return self.config.storage_class.upper()
+        else:
+            return None
+
     @staticmethod
     def human_readable_size(size, decimal_places=3):
         for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:

--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -115,6 +115,7 @@ class AzureStorage(AbstractStorage):
             name=object_key,
             data=data,
             overwrite=True,
+            standard_blob_tier=self.get_storage_class(),
         )
         blob_properties = await blob_client.get_blob_properties()
         return AbstractBlob(
@@ -189,6 +190,7 @@ class AzureStorage(AbstractStorage):
                 data=data,
                 overwrite=True,
                 max_concurrency=16,
+                standard_blob_tier=self.get_storage_class(),
             )
         blob_properties = await blob_client.get_blob_properties()
         mo = ManifestObject(

--- a/medusa/storage/google_storage.py
+++ b/medusa/storage/google_storage.py
@@ -124,8 +124,7 @@ class GoogleStorage(AbstractStorage):
         )
 
         storage_class = self.storage.get_storage_class(),
-        ex_header = { "storageClass": storage_class }
-    
+        ex_header = {"storageClass": storage_class}
         resp = await self.gcs_storage.upload(
             bucket=self.bucket_name,
             object_name=object_key,
@@ -200,8 +199,7 @@ class GoogleStorage(AbstractStorage):
             )
 
             storage_class = self.get_storage_class(),
-            ex_header = { "storageClass": storage_class }
-
+            ex_header = {"storageClass": storage_class}
             resp = await self.gcs_storage.copy(
                 bucket=self.bucket_name,
                 object_name=f'{src}'.replace(f'gs://{self.bucket_name}/', ''),

--- a/medusa/storage/google_storage.py
+++ b/medusa/storage/google_storage.py
@@ -122,12 +122,17 @@ class GoogleStorage(AbstractStorage):
                 self.config.bucket_name, object_key
             )
         )
+
+        storage_class = self.storage.get_storage_class(),
+        ex_header = { "storageClass": storage_class }
+    
         resp = await self.gcs_storage.upload(
             bucket=self.bucket_name,
             object_name=object_key,
             file_data=data,
             force_resumable_upload=True,
             timeout=-1,
+            headers=ex_header,
         )
         return AbstractBlob(resp['name'], int(resp['size']), resp['md5Hash'], resp['timeCreated'])
 
@@ -193,12 +198,17 @@ class GoogleStorage(AbstractStorage):
                     src, self.config.bucket_name, object_key
                 )
             )
+
+            storage_class = self.get_storage_class(),
+            ex_header = { "storageClass": storage_class }
+
             resp = await self.gcs_storage.copy(
                 bucket=self.bucket_name,
                 object_name=f'{src}'.replace(f'gs://{self.bucket_name}/', ''),
                 destination_bucket=self.bucket_name,
                 new_name=object_key,
                 timeout=-1,
+                headers=ex_header,
             )
             resp = resp['resource']
         else:

--- a/medusa/storage/s3_base_storage.py
+++ b/medusa/storage/s3_base_storage.py
@@ -263,7 +263,9 @@ class S3BaseStorage(AbstractStorage):
             kms_args['ServerSideEncryption'] = 'aws:kms'
             kms_args['SSEKMSKeyId'] = self.kms_id
 
-        kms_args['StorageClass'] = self.get_storage_class()
+        storage_class = self.get_storage_class()
+        if storage_class is not None:
+            kms_args['StorageClass'] = storage_class
 
         logging.debug(
             '[S3 Storage] Uploading object from stream -> s3://{}/{}'.format(
@@ -354,7 +356,9 @@ class S3BaseStorage(AbstractStorage):
             kms_args['ServerSideEncryption'] = 'aws:kms'
             kms_args['SSEKMSKeyId'] = self.kms_id
 
-        kms_args['StorageClass'] = self.get_storage_class()
+        storage_class = self.get_storage_class()
+        if storage_class is not None:
+            kms_args['StorageClass'] = storage_class
 
         file_size = os.stat(src).st_size
         logging.debug(

--- a/medusa/storage/s3_base_storage.py
+++ b/medusa/storage/s3_base_storage.py
@@ -263,6 +263,8 @@ class S3BaseStorage(AbstractStorage):
             kms_args['ServerSideEncryption'] = 'aws:kms'
             kms_args['SSEKMSKeyId'] = self.kms_id
 
+        kms_args['StorageClass'] = self.get_storage_class()
+
         logging.debug(
             '[S3 Storage] Uploading object from stream -> s3://{}/{}'.format(
                 self.bucket_name, object_key
@@ -351,6 +353,8 @@ class S3BaseStorage(AbstractStorage):
         if self.kms_id is not None:
             kms_args['ServerSideEncryption'] = 'aws:kms'
             kms_args['SSEKMSKeyId'] = self.kms_id
+
+        kms_args['StorageClass'] = self.get_storage_class()
 
         file_size = os.stat(src).st_size
         logging.debug(

--- a/tests/resources/config/medusa-azure_blobs.ini
+++ b/tests/resources/config/medusa-azure_blobs.ini
@@ -8,6 +8,7 @@ host_file_separator = ","
 bucket_name = medusa-integration-tests
 key_file = ~/medusa_azure_credentials.json
 storage_provider = azure_blobs
+storage_class = Cool
 fqdn = 127.0.0.1
 base_path = /tmp
 prefix = storage_prefix

--- a/tests/resources/config/medusa-google_storage.ini
+++ b/tests/resources/config/medusa-google_storage.ini
@@ -9,6 +9,7 @@ host_file_separator = ","
 bucket_name = medusa-it
 key_file = ~/medusa_credentials.json
 storage_provider = google_storage
+storage_class = STANDARD
 fqdn = 127.0.0.1
 base_path = /tmp
 prefix = storage_prefix

--- a/tests/resources/config/medusa-s3_us_west_oregon.ini
+++ b/tests/resources/config/medusa-s3_us_west_oregon.ini
@@ -8,6 +8,7 @@ host_file_separator = ","
 bucket_name = medusa-it-gha
 key_file = ~/.aws/medusa_credentials
 storage_provider = s3_us_west_oregon
+storage_class = STANDARD
 fqdn = 127.0.0.1
 prefix = storage_prefix
 multi_part_upload_threshold = 1024


### PR DESCRIPTION
Medusa does not support specifying the storage class name when uploading backups to S3/GCP/Azure.
This is very important for many customers as it can help to reduce the storage cost.

Closes #568 
