### PR TITLE
Add bin/medusa-wrapper to package's installed scripts

### DIFF
--- a/medusa/scripts/medusa-wrapper.sh
+++ b/medusa/scripts/medusa-wrapper.sh
@@ -1,3 +1,5 @@
+#! /bin/sh
+
 # Copyright 2019 Spotify AB. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#! /bin/sh
 if test -f pid; then
     # We can't wait for things that aren't our children. Loop and sleep. :-(
     while ! test -f status; do
@@ -26,5 +27,6 @@ fi
 $@ >stdout 2>stderr &
 echo $! >pid
 wait $!
-echo $? >status
+STATUS=$?
+echo ${STATUS} >status
 exit $(cat status)

--- a/medusa/scripts/medusa_wrapper.py
+++ b/medusa/scripts/medusa_wrapper.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import subprocess
+import sys
+import os
+
+
+def main():
+    # Adjust the path to where your actual shell script is located
+    script_dir = os.path.join(os.path.dirname(__file__))
+    script_path = os.path.join(script_dir, 'medusa-wrapper.sh')
+    args = sys.argv[1:]
+    command = [script_path] + args
+    p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    if stderr:
+        print(stderr, file=sys.stderr)
+    if stdout:
+        print(stdout, file=sys.stdout)
+    rc = p.returncode
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,7 @@ packages = [
     { include = "medusa" }
 ]
 include = [
-    { path = "medusa-example.ini" },
-    { path = "bin/medsua-wrapper" }
+    { path = "medusa-example.ini" }
 ]
 
 [project]
@@ -44,6 +43,7 @@ requires-python = ">=3.8,<=3.11"
 
 [tool.poetry.scripts]
 medusa = { reference = "medusa.medusacli:cli", type = "console" }
+medusa-wrapper = { reference = "medusa.scripts.medusa_wrapper:main", type = "console" }
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
Fixes https://github.com/thelastpickle/cassandra-medusa/issues/735.

Tested on a blank EC2 Ubuntu 22.04 instance by running:

```
sudo apt-get update
sudo apt-get install -y python3-pip
pip install git+https://github.com/thelastpickle/cassandra-medusa.git@radovan/fix-wrapper
logout
(log back in)
$ medusa-wrapper
$
```

This installs Medusa to `/home/ubuntu/.local/lib/python3.10/site-packages/medusa`. The wrapper script is in there too now, because poetry does not have a way to bundle it in otherwies.

One other thing I spotted is that the `medusa-example.ini` file lands in `/home/ubuntu/.local/lib/python3.10/site-packages/medusa-example.ini`, which is perhaps not the nicest.