### PR TITLE
Updated the check for the cluster restore to use the `use_sudo_for_restore` config instead of `use_sudo`

### DIFF
--- a/medusa/restore_cluster.py
+++ b/medusa/restore_cluster.py
@@ -429,7 +429,7 @@ class RestoreJob(object):
                   '{in_place} {keep_auth} %s {verify} --backup-name {backup} --temp-dir {temp_dir} ' \
                   '{use_sstableloader} {keyspaces} {tables}' \
             .format(work=self.work_dir,
-                    sudo='sudo' if medusa.utils.evaluate_boolean(self.config.cassandra.use_sudo) else '',
+                    sudo='sudo' if medusa.utils.evaluate_boolean(self.config.storage.use_sudo_for_restore) else '',
                     config=f'--config-file {self.config.file_path}' if self.config.file_path else '',
                     in_place=in_place_option,
                     keep_auth=keep_auth_option,


### PR DESCRIPTION
closes [#729](https://github.com/thelastpickle/cassandra-medusa/issues/729)

Updated the check for the cluster restore to use the `use_sudo_for_restore` config instead of `use_sudo`