### PR TITLE
Tanana/add option for prepending nodetool

### DIFF
--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -22,6 +22,7 @@
 ; - `<cql_k8s_secrets_path>/username` containing username
 ; - `<cql_k8s_secrets_path>/password` containing password
 ;cql_k8s_secrets_path = <path to kubernetes secrets folder>
+;prefix_nodetool_command = <command to be run with && before nodetool>
 ;nodetool_username =  <my nodetool username>
 ;nodetool_password =  <my nodetool password>
 ;nodetool_password_file_path = <path to nodetool password file>

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -130,7 +130,6 @@ def _build_default_config():
 
     config['cassandra'] = {
         'config_file': medusa.cassandra_utils.CassandraConfigReader.DEFAULT_CASSANDRA_CONFIG,
-        'prefix_nodetool_command': None,
         'start_cmd': 'sudo service cassandra start',
         'stop_cmd': 'sudo service cassandra stop',
         'check_running': 'nodetool version',

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -37,7 +37,7 @@ StorageConfig = collections.namedtuple(
 CassandraConfig = collections.namedtuple(
     'CassandraConfig',
     ['prefix_nodetool_command', 'start_cmd', 'stop_cmd', 'config_file', 'cql_username', 'cql_password', 'check_running',
-      'is_ccm', 'sstableloader_bin', 'nodetool_username', 'nodetool_password', 'nodetool_password_file_path', 
+     'is_ccm', 'sstableloader_bin', 'nodetool_username', 'nodetool_password', 'nodetool_password_file_path',
      'nodetool_host', 'nodetool_executable', 'nodetool_port', 'certfile', 'usercert', 'userkey', 'sstableloader_ts',
      'sstableloader_tspw', 'sstableloader_ks', 'sstableloader_kspw', 'nodetool_ssl', 'resolve_ip_addresses', 'use_sudo',
      'nodetool_flags', 'cql_k8s_secrets_path', 'nodetool_k8s_secrets_path']

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -36,7 +36,7 @@ StorageConfig = collections.namedtuple(
 
 CassandraConfig = collections.namedtuple(
     'CassandraConfig',
-    ['start_cmd', 'stop_cmd', 'config_file', 'cql_username', 'cql_password', 'check_running', 'is_ccm',
+    ['prefix_nodetool_command','start_cmd', 'stop_cmd', 'config_file', 'cql_username', 'cql_password', 'check_running', 'is_ccm',
      'sstableloader_bin', 'nodetool_username', 'nodetool_password', 'nodetool_password_file_path', 'nodetool_host',
      'nodetool_executable', 'nodetool_port', 'certfile', 'usercert', 'userkey', 'sstableloader_ts',
      'sstableloader_tspw', 'sstableloader_ks', 'sstableloader_kspw', 'nodetool_ssl', 'resolve_ip_addresses', 'use_sudo',
@@ -130,6 +130,7 @@ def _build_default_config():
 
     config['cassandra'] = {
         'config_file': medusa.cassandra_utils.CassandraConfigReader.DEFAULT_CASSANDRA_CONFIG,
+        'prefix_nodetool_command': None,
         'start_cmd': 'sudo service cassandra start',
         'stop_cmd': 'sudo service cassandra stop',
         'check_running': 'nodetool version',

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -36,9 +36,9 @@ StorageConfig = collections.namedtuple(
 
 CassandraConfig = collections.namedtuple(
     'CassandraConfig',
-    ['prefix_nodetool_command','start_cmd', 'stop_cmd', 'config_file', 'cql_username', 'cql_password', 'check_running', 'is_ccm',
-     'sstableloader_bin', 'nodetool_username', 'nodetool_password', 'nodetool_password_file_path', 'nodetool_host',
-     'nodetool_executable', 'nodetool_port', 'certfile', 'usercert', 'userkey', 'sstableloader_ts',
+    ['prefix_nodetool_command', 'start_cmd', 'stop_cmd', 'config_file', 'cql_username', 'cql_password', 'check_running',
+      'is_ccm','sstableloader_bin', 'nodetool_username', 'nodetool_password', 'nodetool_password_file_path', 
+     'nodetool_host', 'nodetool_executable', 'nodetool_port', 'certfile', 'usercert', 'userkey', 'sstableloader_ts',
      'sstableloader_tspw', 'sstableloader_ks', 'sstableloader_kspw', 'nodetool_ssl', 'resolve_ip_addresses', 'use_sudo',
      'nodetool_flags', 'cql_k8s_secrets_path', 'nodetool_k8s_secrets_path']
 )

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -37,7 +37,7 @@ StorageConfig = collections.namedtuple(
 CassandraConfig = collections.namedtuple(
     'CassandraConfig',
     ['prefix_nodetool_command', 'start_cmd', 'stop_cmd', 'config_file', 'cql_username', 'cql_password', 'check_running',
-      'is_ccm','sstableloader_bin', 'nodetool_username', 'nodetool_password', 'nodetool_password_file_path', 
+      'is_ccm', 'sstableloader_bin', 'nodetool_username', 'nodetool_password', 'nodetool_password_file_path', 
      'nodetool_host', 'nodetool_executable', 'nodetool_port', 'certfile', 'usercert', 'userkey', 'sstableloader_ts',
      'sstableloader_tspw', 'sstableloader_ks', 'sstableloader_kspw', 'nodetool_ssl', 'resolve_ip_addresses', 'use_sudo',
      'nodetool_flags', 'cql_k8s_secrets_path', 'nodetool_k8s_secrets_path']

--- a/medusa/nodetool.py
+++ b/medusa/nodetool.py
@@ -20,6 +20,9 @@ class Nodetool(object):
         nodetool_executable = cassandra_config.nodetool_executable
         nodetool_flags = cassandra_config.nodetool_flags.split(" ") if cassandra_config.nodetool_flags else []
         self._nodetool = [nodetool_executable] + nodetool_flags
+        if cassandra_config.prefix_nodetool_command is not None:
+            curr_nodetool = self._nodetool
+            self._nodetool = cassandra_config.prefix_nodetool_command + "&&" + curr_nodetool
         if cassandra_config.nodetool_ssl == "true":
             self._nodetool += ['--ssl']
         if cassandra_config.nodetool_username is not None:

--- a/medusa/nodetool.py
+++ b/medusa/nodetool.py
@@ -23,7 +23,7 @@ class Nodetool(object):
         if cassandra_config.prefix_nodetool_command is not None:
             curr_nodetool = self._nodetool
             cmd_string = cassandra_config.prefix_nodetool_command + " &&"
-            cmd_array = cmd_string.split()
+            cmd_array = cmd_string.split(" ")
             cmd_array += curr_nodetool
             self._nodetool = cmd_array
         if cassandra_config.nodetool_ssl == "true":

--- a/medusa/nodetool.py
+++ b/medusa/nodetool.py
@@ -22,7 +22,10 @@ class Nodetool(object):
         self._nodetool = [nodetool_executable] + nodetool_flags
         if cassandra_config.prefix_nodetool_command is not None:
             curr_nodetool = self._nodetool
-            self._nodetool = cassandra_config.prefix_nodetool_command + "&&" + curr_nodetool
+            cmd_string = cassandra_config.prefix_nodetool_command + " &&"
+            cmd_array = cmd_string.split()
+            cmd_array += curr_nodetool
+            self._nodetool = cmd_array
         if cassandra_config.nodetool_ssl == "true":
             self._nodetool += ['--ssl']
         if cassandra_config.nodetool_username is not None:


### PR DESCRIPTION
Fairly straight forward change, if we get the variable in the config file, prepend it with && into the config. 
This will allow users with non standard cass configs to use the tool by sourcing a file before the run of pssh.