### PR TITLE
Adding support to build images for multiple architectures

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,6 +1,6 @@
 ARG ARCH="amd64"
 
-FROM --platform=linux/${ARCH} ubuntu:22.04 as base
+FROM --platform=linux/${ARCH} ubuntu:22.04 AS base
 
 RUN mkdir /install
 WORKDIR /install

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:22.04 as base
+ARG ARCH="amd64"
+
+FROM --platform=linux/${ARCH} ubuntu:22.04 as base
 
 RUN mkdir /install
 WORKDIR /install
@@ -34,7 +36,7 @@ RUN python3 -m pip install -U pip && pip3 install --ignore-installed --user poet
 RUN cd /build && poetry build && poetry install
 
 # Could be python:slim, but we have a .sh entrypoint
-FROM ubuntu:22.04
+FROM --platform=linux/${ARCH} ubuntu:22.04
 
 ## add user
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 --create-home cassandra
@@ -43,9 +45,10 @@ RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 --creat
 RUN apt-get update && apt-get install -y python3 python3-setuptools wget \
     && rm -rf /var/lib/apt/lists/*
 
+# Download the correct grpc_health_probe binary based on architecture
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.25 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
+wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${ARCH} && \
+chmod +x /bin/grpc_health_probe
 
 USER cassandra
 WORKDIR /home/cassandra
@@ -56,7 +59,6 @@ ENV PATH=/home/cassandra/.local/bin:/home/cassandra/google-cloud-sdk/bin:/home/c
 ENV PYTHONPATH=/home/cassandra
 
 COPY --from=base --chown=cassandra:cassandra /root/.local /home/cassandra/.local
-
 COPY --from=base --chown=cassandra:cassandra /build/.venv /home/cassandra/.venv
 COPY --from=base --chown=cassandra:cassandra /build/pyproject.toml /home/cassandra/pyproject.toml
 COPY --chown=cassandra:cassandra medusa /home/cassandra/medusa

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,6 +1,6 @@
-ARG ARCH="amd64"
+ARG TARGETARCH="amd64"
 
-FROM --platform=linux/${ARCH} ubuntu:22.04 AS base
+FROM --platform=linux/${TARGETARCH} ubuntu:22.04 AS base
 
 RUN mkdir /install
 WORKDIR /install
@@ -36,7 +36,7 @@ RUN python3 -m pip install -U pip && pip3 install --ignore-installed --user poet
 RUN cd /build && poetry build && poetry install
 
 # Could be python:slim, but we have a .sh entrypoint
-FROM --platform=linux/${ARCH} ubuntu:22.04
+FROM --platform=linux/${TARGETARCH} ubuntu:22.04
 
 ## add user
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 --create-home cassandra
@@ -47,7 +47,7 @@ RUN apt-get update && apt-get install -y python3 python3-setuptools wget \
 
 # Download the correct grpc_health_probe binary based on architecture
 RUN GRPC_HEALTH_PROBE_VERSION=v0.4.25 && \
-wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${ARCH} && \
+wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-${TARGETARCH} && \
 chmod +x /bin/grpc_health_probe
 
 USER cassandra

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,6 +1,10 @@
+# Declare architecture variable globally
 ARG TARGETARCH="amd64"
 
 FROM --platform=linux/${TARGETARCH} ubuntu:22.04 AS base
+
+# Reuse the architecture argument
+ARG TARGETARCH
 
 RUN mkdir /install
 WORKDIR /install
@@ -37,6 +41,9 @@ RUN cd /build && poetry build && poetry install
 
 # Could be python:slim, but we have a .sh entrypoint
 FROM --platform=linux/${TARGETARCH} ubuntu:22.04
+
+# Reuse the architecture argument
+ARG TARGETARCH
 
 ## add user
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 --create-home cassandra

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,9 +1,5 @@
-# Declare architecture variable globally
-ARG TARGETARCH="amd64"
-
 FROM --platform=linux/${TARGETARCH} ubuntu:22.04 AS base
 
-# Reuse the architecture argument
 ARG TARGETARCH
 
 RUN mkdir /install

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -82,10 +82,14 @@ The image can be used for backups or for restores. The `docker-entrypoint.sh` sc
 ## Building the Image
 If you made any changes to `medusa.proto`, then you first need to run the protobuf compiler as described above.
 
-Run the following from the project root:
+To build for a specific architecture, run the following from the project root:
 
 ```
 $ poetry install && poetry build
-
-$ docker build -t <tag name> -f k8s/Dockerfile .
+$ docker buildx build --platform linux/amd64 -t <tag name> -f k8s/Dockerfile .
+```
+Or, to build for both AMD64 and ARM64 architectures at the same time, run:
+```
+$ poetry install && poetry build
+$ docker buildx build --platform linux/amd64,linux/arm64 -t <tag name> -f k8s/Dockerfile .
 ```


### PR DESCRIPTION
Adding support for creating images for multiple architectures using docker buildx, this will also fix the issue with the grpc-health-probe binary referenced here:

Fixes #759