### PR TITLE
[Rebase] Add s3 canned ACL support

### DIFF
--- a/docs/aws_s3_setup.md
+++ b/docs/aws_s3_setup.md
@@ -51,6 +51,7 @@ Create an IAM Policy called `MedusaStorageStrategy`, with the following definiti
                 "s3:GetReplicationConfiguration",
                 "s3:ListMultipartUploadParts",
                 "s3:PutObject",
+                "s3:PutObjectAcl",
                 "s3:GetObject",
                 "s3:GetObjectTorrent",
                 "s3:PutObjectRetention",

--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -133,6 +133,9 @@ use_sudo_for_restore = True
 ; Read timeout in seconds for the storage provider.
 ;read_timeout = 60
 
+; Canned ACL for uploaded objects on S3. Defaults to private
+canned_acl = private
+
 [monitoring]
 ;monitoring_provider = <Provider used for sending metrics. Currently either of "ffwd" or "local">
 

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -31,7 +31,8 @@ StorageConfig = collections.namedtuple(
     ['bucket_name', 'key_file', 'prefix', 'fqdn', 'host_file_separator', 'storage_provider', 'storage_class',
      'base_path', 'max_backup_age', 'max_backup_count', 'api_profile', 'transfer_max_bandwidth',
      'concurrent_transfers', 'multi_part_upload_threshold', 'host', 'region', 'port', 'secure', 'ssl_verify',
-     'aws_cli_path', 'kms_id', 'backup_grace_period_in_days', 'use_sudo_for_restore', 'k8s_mode', 'read_timeout']
+     'aws_cli_path', 'kms_id', 'backup_grace_period_in_days', 'use_sudo_for_restore', 'k8s_mode', 'read_timeout',
+     'canned_acl']
 )
 
 CassandraConfig = collections.namedtuple(
@@ -117,7 +118,8 @@ def _build_default_config():
         'region': 'default',
         'backup_grace_period_in_days': 10,
         'use_sudo_for_restore': 'True',
-        'read_timeout': 60
+        'read_timeout': 60,
+        'canned_acl': 'private',
     }
 
     config['logging'] = {

--- a/tests/integration/features/integration_tests.feature
+++ b/tests/integration/features/integration_tests.feature
@@ -1151,6 +1151,7 @@ Feature: Integration tests
     Scenario Outline: Perform a differential backup with explicit storage class, then verify it
         Given I have a fresh ccm cluster "<client encryption>" running named "scenario32"
         Given I will use "<storage class>" as storage class in the storage
+        Given I will use "<canned ACL>" canned ACL when uploading objects
         Given I am using "<storage>" as storage provider in ccm cluster "<client encryption>" with gRPC server
         When I create the "test" table with secondary index in keyspace "medusa"
         When I load 100 rows in the "medusa.test" table
@@ -1158,29 +1159,29 @@ Feature: Integration tests
         When I perform a backup in "differential" mode of the node named "first_backup" with md5 checks "disabled"
         Then I can see the backup named "first_backup" when I list the backups
         Then I can verify the backup named "first_backup" with md5 checks "disabled" successfully
-        Then I can see 2 SSTables with "<storage class>" in the SSTable pool for the "test" table in keyspace "medusa"
+        Then I can see 2 SSTables with "<storage class>" and "<canned ACL>" in the SSTable pool for the "test" table in keyspace "medusa"
 
         @s3
         Examples: S3 storage
-        | storage           | client encryption         | storage class       |
-        | s3_us_west_oregon | without_client_encryption | STANDARD            |
-        | s3_us_west_oregon | without_client_encryption | REDUCED_REDUNDANCY  |
-        | s3_us_west_oregon | without_client_encryption | STANDARD_IA         |
-        | s3_us_west_oregon | without_client_encryption | ONEZONE_IA          |
-        | s3_us_west_oregon | without_client_encryption | INTELLIGENT_TIERING |
+        | storage           | client encryption         | storage class       | canned ACL        |
+        | s3_us_west_oregon | without_client_encryption | STANDARD            | bucket-owner-read	 |
+        | s3_us_west_oregon | without_client_encryption | REDUCED_REDUNDANCY  | bucket-owner-read |
+        | s3_us_west_oregon | without_client_encryption | STANDARD_IA         | bucket-owner-read |
+        | s3_us_west_oregon | without_client_encryption | ONEZONE_IA          | bucket-owner-read |
+        | s3_us_west_oregon | without_client_encryption | INTELLIGENT_TIERING | bucket-owner-read |
 
         @gcs
         Examples: Google Cloud Storage
-        | storage        | client encryption         | storage class |
-        | google_storage | without_client_encryption | STANDARD      |
+        | storage        | client encryption         | storage class | canned ACL |
+        | google_storage | without_client_encryption | STANDARD      | None       |
 # this is buggy for now, the library does not propagate the custom storage class headers
-#        | google_storage | without_client_encryption | NEARLINE      |
-#        | google_storage | without_client_encryption | COLDLINE      |
-#        | google_storage | without_client_encryption | ARCHIVE       |
+#        | google_storage | without_client_encryption | NEARLINE      | None       |
+#        | google_storage | without_client_encryption | COLDLINE      | None       |
+#        | google_storage | without_client_encryption | ARCHIVE       | None       |
 
         @azure
         Examples: Azure Blob Storage
-        | storage     | client encryption         | storage class |
-        | azure_blobs | without_client_encryption | HOT           |
-        | azure_blobs | without_client_encryption | COOL          |
-        | azure_blobs | without_client_encryption | COLD          |
+        | storage     | client encryption         | storage class | canned ACL |
+        | azure_blobs | without_client_encryption | HOT           | None       |
+        | azure_blobs | without_client_encryption | COOL          | None       |
+        | azure_blobs | without_client_encryption | COLD          | None       |

--- a/tests/storage/s3_storage_test.py
+++ b/tests/storage/s3_storage_test.py
@@ -197,7 +197,8 @@ class S3StorageTest(unittest.TestCase):
                 'region': 'default',
                 'storage_provider': 's3_compatible',
                 'key_file': credentials_file.name,
-                'concurrent_transfers': '1'
+                'concurrent_transfers': '1',
+                'canned_acl': 'public-read',
             })
 
             credentials = S3BaseStorage._consolidate_credentials(config)
@@ -220,7 +221,8 @@ class S3StorageTest(unittest.TestCase):
                     'ssl_verify': 'False',
                     'host': None,
                     'port': None,
-                    'concurrent_transfers': '1'
+                    'concurrent_transfers': '1',
+                    'canned_acl': 'public-read',
                 })
                 s3_storage = S3BaseStorage(config)
                 # there are no extra connection args when connecting to regular S3
@@ -244,7 +246,8 @@ class S3StorageTest(unittest.TestCase):
                     'ssl_verify': 'False',
                     'host': None,
                     'port': None,
-                    'concurrent_transfers': '1'
+                    'concurrent_transfers': '1',
+                    'canned_acl': 'public-read',
                 })
                 s3_storage = S3BaseStorage(config)
                 # again, no extra connection args when connecting to regular S3
@@ -269,7 +272,8 @@ class S3StorageTest(unittest.TestCase):
                     'ssl_verify': 'False',
                     'host': 's3.example.com',
                     'port': '443',
-                    'concurrent_transfers': '1'
+                    'concurrent_transfers': '1',
+                    'canned_acl': 'public-read',
                 })
                 s3_storage = S3BaseStorage(config)
                 self.assertEqual(
@@ -292,7 +296,8 @@ class S3StorageTest(unittest.TestCase):
                     'ssl_verify': 'False',
                     'host': 's3.example.com',
                     'port': '8080',
-                    'concurrent_transfers': '1'
+                    'concurrent_transfers': '1',
+                    'canned_acl': 'public-read',
                 })
                 s3_storage = S3BaseStorage(config)
                 self.assertEqual(
@@ -314,7 +319,8 @@ class S3StorageTest(unittest.TestCase):
                 'ssl_verify': 'False',
                 'host': 's3.example.com',
                 'port': '8080',
-                'concurrent_transfers': '1'
+                'concurrent_transfers': '1',
+                'canned_acl': 'public-read',
             })
             s3_storage = S3BaseStorage(config)
             connection_args = s3_storage._make_connection_arguments(config)
@@ -334,7 +340,8 @@ class S3StorageTest(unittest.TestCase):
                 'ssl_verify': 'True',
                 'host': 's3.example.com',
                 'port': '8080',
-                'concurrent_transfers': '1'
+                'concurrent_transfers': '1',
+                'canned_acl': 'public-read',
             })
             s3_storage = S3BaseStorage(config)
             connection_args = s3_storage._make_connection_arguments(config)
@@ -375,7 +382,8 @@ class S3StorageTest(unittest.TestCase):
                 'ssl_verify': 'False',
                 'host': None,
                 'port': None,
-                'concurrent_transfers': '1'
+                'concurrent_transfers': '1',
+                'canned_acl': 'public-read',
             })
 
             # Replace the open function with the mock


### PR DESCRIPTION
This PR is a rebase of #189 on top of the current main. 
The storage implementation has changed a lot since 189 was opened, so I had to rework things a bit.
I've tried adding ITs for the ACLs, but it's not easy. To begin with, we'd need a ACL-enabled bucket, which I'm hesitant to create.

Superseeds #189.
We don't have an issue.