### PR TITLE
Expand documentation on concurrent transfers

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -90,7 +90,14 @@ max_backup_count = 0
 ; Used to throttle S3 backups/restores:
 transfer_max_bandwidth = 50MB/s
 
-; Max number of downloads/uploads. Not used by the GCS backend.
+; Regardless of the storage provider, determines the number of files to process in parallel when uploading or downloading.
+; Each group of concurrently processed files has to have all files processed before the next group starts
+; (so the groups are synchronous, example).
+; Then there is the storage-provider specific behaviour:
+; - For Google, it has no extra meaning. 
+; - For Azure, we pass it to the SDK library we use if the file is bigger than the multipart threshold (100MB in your case). 
+; - For S3, this controls the size of the executor we submit transfer tasks into. We do not propagate is to the 
+;   boto's concurrency parameter.
 concurrent_transfers = 1
 
 ; Size over which S3 uploads will be using the awscli with multi part uploads. Defaults to 100MB.

--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -95,7 +95,14 @@ max_backup_count = 0
 ; Used to throttle S3 backups/restores:
 transfer_max_bandwidth = 50MB/s
 
-; Max number of concurrent downloads/uploads.
+; Regardless of the storage provider, determines the number of files to process in parallel when uploading or downloading.
+; Each group of concurrently processed files has to have all files processed before the next group starts
+; (so the groups are synchronous, example).
+; Then there is the storage-provider specific behaviour:
+; - For Google, it has no extra meaning.
+; - For Azure, we pass it to the SDK library we use if the file is bigger than the multipart threshold (100MB in your case).
+; - For S3, this controls the size of the executor we submit transfer tasks into. We do not propagate is to the
+;   boto's concurrency parameter.
 concurrent_transfers = 1
 
 ; Size over which uploads will be using multi part uploads. Defaults to 20MB.


### PR DESCRIPTION
Replaces #585 .

Fixes #584.

I recently had a look at concurrent transfers because of [this issue](https://github.com/thelastpickle/cassandra-medusa/issues/734#issuecomment-2160491271). I've just taken the content from there and put it into the example ini files.