### PR TITLE
Make gRPC service report backups as FAILED if lose their callback future

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,17 +251,17 @@ jobs:
         if [ "${{ matrix.it-backend }}" == "s3" ]
         then
           # AWS S3 Storage tests
-          ./run_integration_tests.sh -v --s3 --no-local --cassandra-version=${{ matrix.cassandra-version }}
+          ./run_integration_tests.sh -vv --s3 --no-local --cassandra-version=${{ matrix.cassandra-version }}
         elif [ "${{ matrix.it-backend }}" == "gcs" ]
         then
           # Google Cloud Storage tests
           echo '${{ secrets.MEDUSA_GCS_CREDENTIALS }}' > ~/medusa_credentials.json
-          ./run_integration_tests.sh -v --gcs --no-local --cassandra-version=${{ matrix.cassandra-version }}
+          ./run_integration_tests.sh -vv --gcs --no-local --cassandra-version=${{ matrix.cassandra-version }}
         elif [ "${{ matrix.it-backend }}" == "ibm" ]
         then
           # IBM Cloud Object Storage tests
           printf "%s" '${{ secrets.MEDUSA_IBM_CREDENTIALS }}' > ~/.aws/ibm_credentials
-          ./run_integration_tests.sh -v --ibm --no-local --cassandra-version=${{ matrix.cassandra-version }}
+          ./run_integration_tests.sh -vv --ibm --no-local --cassandra-version=${{ matrix.cassandra-version }}
         elif [ "${{ matrix.it-backend }}" == "minio" ]
         then
           # MinIO Object Storage tests
@@ -272,20 +272,20 @@ jobs:
           ./mc alias set minio http://127.0.0.1:9000 minio_key minio_secret
           ./mc mb minio/medusa-dev
           cp ./tests/resources/minio/minio_credentials ~/.aws/minio_credentials
-          ./run_integration_tests.sh -v --minio --no-local --cassandra-version=${{ matrix.cassandra-version }} 
+          ./run_integration_tests.sh -vv --minio --no-local --cassandra-version=${{ matrix.cassandra-version }} 
         elif [ "${{ matrix.it-backend }}" == "azure" ]
         then
           # Azure Blob Storage tests
           printf "%s" '${{ secrets.MEDUSA_AZURE_CREDENTIALS }}' > ~/medusa_azure_credentials.json
-          ./run_integration_tests.sh -v --azure --no-local --cassandra-version=${{ matrix.cassandra-version }} 
+          ./run_integration_tests.sh -vv --azure --no-local --cassandra-version=${{ matrix.cassandra-version }} 
         elif [ "${{ matrix.it-backend }}" == "azure-hierarchical" ]
         then
           # Azure Blob Storage with hierarchical namespace tests
           printf "%s" '${{ secrets.MEDUSA_AZURE_HIERARCHICAL_CREDENTIALS }}' > ~/medusa_azure_credentials.json
-          ./run_integration_tests.sh -v --azure --no-local --cassandra-version=${{ matrix.cassandra-version }} 
+          ./run_integration_tests.sh -vv --azure --no-local --cassandra-version=${{ matrix.cassandra-version }} 
         else
         # Local storage tests
-          ./run_integration_tests.sh -v --cassandra-version=${{ matrix.cassandra-version }}
+          ./run_integration_tests.sh -vv --cassandra-version=${{ matrix.cassandra-version }}
         fi
 
         # Move and convert the coverage analysis file to XML

--- a/tests/backup_man_test.py
+++ b/tests/backup_man_test.py
@@ -58,7 +58,8 @@ class BackupManTest(unittest.TestCase):
     def test_register_backup_sync_mode(self):
         BackupMan.register_backup("test_backup_id", is_async=False)
         self.assertEqual(BackupMan.STATUS_UNKNOWN, BackupMan.get_backup_status("test_backup_id"))
-        self.assertEqual(None, BackupMan.get_backup_future("test_backup_id"))
+        with self.assertRaises(RuntimeError):
+            BackupMan.get_backup_future("test_backup_id")
 
         BackupMan.update_backup_status("test_backup_id", BackupMan.STATUS_SUCCESS)
         self.assertEqual(BackupMan.STATUS_SUCCESS, BackupMan.get_backup_status("test_backup_id"))
@@ -66,6 +67,7 @@ class BackupManTest(unittest.TestCase):
     def test_register_backup_async_mode(self):
         backup_id = "test_backup_id"
         mock_future = Mock(concurrent.futures.Future)
+        mock_future.done = lambda: False
         BackupMan.register_backup(backup_id, is_async=True)
         BackupMan.set_backup_future(backup_id, mock_future)
         stored_future = BackupMan.get_backup_future(backup_id)
@@ -76,6 +78,7 @@ class BackupManTest(unittest.TestCase):
 
         backup_id_2 = "test_backup_id_2"
         mock_future_2 = Mock(concurrent.futures.Future)
+        mock_future_2.done = lambda: False
         BackupMan.register_backup(backup_id_2, is_async=True)
         BackupMan.set_backup_future(backup_id_2, mock_future_2)
 
@@ -91,7 +94,9 @@ class BackupManTest(unittest.TestCase):
         # Self-healing of detected duplicate, clean and reset w/ new expected
         backup_id_1 = "test_backup_id"
         mock_future_1 = Mock(concurrent.futures.Future)
+        mock_future_1.done = lambda: False
         mock_future_2 = Mock(concurrent.futures.Future)
+        mock_future_2.done = lambda: False
         BackupMan.register_backup(backup_id_1, is_async=True)
         BackupMan.set_backup_future(backup_id_1, mock_future_1)
         self.assertEqual(BackupMan.get_backup_future(backup_id_1), mock_future_1)

--- a/tests/backup_node_test.py
+++ b/tests/backup_node_test.py
@@ -72,6 +72,7 @@ class BackupNodeTest(unittest.TestCase):
                                             backup_name_arg=test_backup_name, stagger_time=None,
                                             enable_md5_checks_flag=False, mode="differential")
             mock_future_instance = MagicMock()
+            mock_future_instance.done = lambda: False
             mock_callback = MagicMock()
             mock_future_instance.result.return_value = {"foo": "bar"}
             backup_future.add_done_callback(mock_callback)

--- a/tests/service/grpc/server_test.py
+++ b/tests/service/grpc/server_test.py
@@ -110,6 +110,7 @@ class ServerTest(unittest.TestCase):
             "node1": {"tokens": [-1094266504216117253], "is_up": True, "rack": "r1", "dc": "dc1"},
             "node2": {"tokens": [1094266504216117253], "is_up": True, "rack": "r1", "dc": "dc1"}
         }
+        BackupMan.remove_backup('backup1')
         BackupMan.register_backup('backup1', True)
         BackupMan.update_backup_status('backup1', BackupMan.STATUS_IN_PROGRESS)
 


### PR DESCRIPTION
Fixes https://github.com/k8ssandra/k8ssandra-operator/issues/1312.

This PR alters how the BackupMan reports a status of the backup.
Previously, it'd just look at the storage, and report the state of the backup as IN_PROGRESS if the backup has started (~wrote something into the storage). It'd not care if the backup is _actually_ ongoing.

With this change, it will also check if there is an active future waiting for the backup to finish. The future's presence indicates a healthy state, which in turn means the backup has a high chance of happening.

However, waiting for the future to complete and run the associated callback is not a requirement for the backup to complete.  When I tried to cover this in the integration steps, I was able to restart the gRPC server, but I was unable to kill the actual process that does the backup. So the new server (with new BackupMan) came back and saw the backup as complete.

The benefit of this change is more visible in the world of k8ssandra-operator, where a pod might restart mid-backup. Killing a pod. during a backup, would lead to the following situation:
```
kubectl get MedusaBackupJob,MedusaBackup -n k8ssandra-operator

NAME                                           STARTED   FINISHED
medusabackupjob.medusa.k8ssandra.io/backup-1   12m       11m
medusabackupjob.medusa.k8ssandra.io/backup-2   7m38s     7m23s
medusabackupjob.medusa.k8ssandra.io/backup-3   51s

NAME                                        STARTED   FINISHED   NODES   FILES   SIZE        COMPLETED   STATUS
medusabackup.medusa.k8ssandra.io/backup-1   12m       11m        1       184     143.53 KB   1           SUCCESS
medusabackup.medusa.k8ssandra.io/backup-2   7m38s     7m23s      1       296     227.16 KB   1           SUCCESS
```
The `backup-3` would never finish, it'd continue to be reported as `IN_PROGRESS`. This is because the `MedusaBackupJob` would always feature:
```
status:
  inProgress:
    - firstcluster-dc1-default-sts-0
  startTime: '2024-06-19T14:05:18Z'
```

Deploying a Medusa container built off this branch actually heals the situation:

```
Every 1.0s: kubectl get MedusaBackupJob,MedusaBackup -n k8ssandra-operator                                                                                                                       

NAME                                           STARTED   FINISHED
medusabackupjob.medusa.k8ssandra.io/backup-1   15m       15m
medusabackupjob.medusa.k8ssandra.io/backup-2   10m       10m
medusabackupjob.medusa.k8ssandra.io/backup-3   4m9s      17s

NAME                                        STARTED   FINISHED   NODES   FILES   SIZE        COMPLETED   STATUS
medusabackup.medusa.k8ssandra.io/backup-1   15m       15m        1       184     143.53 KB   1           SUCCESS
medusabackup.medusa.k8ssandra.io/backup-2   10m       10m        1       296     227.16 KB   1           SUCCESS
medusabackup.medusa.k8ssandra.io/backup-3   4m9s      17s        1               0.00 B                  FAILED
```

Because:
```
status:
  failed:
    - firstcluster-dc1-default-sts-0
  finishTime: '2024-06-19T14:09:10Z'
  startTime: '2024-06-19T14:05:18Z'
  ```