### PR TITLE
Support s3 address style config

### DIFF
--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -128,6 +128,11 @@ use_sudo_for_restore = True
 ; Enabling this is not yet supported - we don't have a good way to configure paths to custom certificates.
 ; ssl_verify = False
 
+; addressing style of s3
+; S3 supports two different ways to address a bucket, Virtual Host Style and Path Style.
+; you can choose from auto/path/virtual
+;s3_addressing_style = auto
+
 ;aws_cli_path = <Location of the aws cli binary if not in PATH>
 
 ; Read timeout in seconds for the storage provider.

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -28,10 +28,13 @@ from medusa.network.hostname_resolver import HostnameResolver
 
 StorageConfig = collections.namedtuple(
     'StorageConfig',
-    ['bucket_name', 'key_file', 'prefix', 'fqdn', 'host_file_separator', 'storage_provider', 'storage_class',
-     'base_path', 'max_backup_age', 'max_backup_count', 'api_profile', 'transfer_max_bandwidth',
-     'concurrent_transfers', 'multi_part_upload_threshold', 'host', 'region', 'port', 'secure', 'ssl_verify',
-     'aws_cli_path', 'kms_id', 'backup_grace_period_in_days', 'use_sudo_for_restore', 'k8s_mode', 'read_timeout']
+    [
+        'bucket_name', 'key_file', 'prefix', 'fqdn', 'host_file_separator', 'storage_provider', 'storage_class',
+        'base_path', 'max_backup_age', 'max_backup_count', 'api_profile', 'transfer_max_bandwidth',
+        'concurrent_transfers', 'multi_part_upload_threshold', 'host', 'region', 'port', 'secure', 'ssl_verify',
+        'aws_cli_path', 'kms_id', 'backup_grace_period_in_days', 'use_sudo_for_restore', 'k8s_mode', 'read_timeout',
+        's3_addressing_style'
+    ]
 )
 
 CassandraConfig = collections.namedtuple(
@@ -117,7 +120,8 @@ def _build_default_config():
         'region': 'default',
         'backup_grace_period_in_days': 10,
         'use_sudo_for_restore': 'True',
-        'read_timeout': 60
+        'read_timeout': 60,
+        's3_addressing_style': 'auto',
     }
 
     config['logging'] = {

--- a/medusa/storage/s3_base_storage.py
+++ b/medusa/storage/s3_base_storage.py
@@ -138,6 +138,7 @@ class S3BaseStorage(AbstractStorage):
             tcp_keepalive=True,
             max_pool_connections=max_pool_size,
             read_timeout=int(self.config.read_timeout),
+            s3={'addressing_style': self.config.s3_addressing_style},
         )
         if self.credentials.access_key_id is not None:
             self.s3_client = boto3.client(


### PR DESCRIPTION
Tencent cloud cos now only support virtual addressing style in new created buckets.

This pr add a config opt to pass `s3={"addressing_style": xx}` args to boto core Config class.

fix https://github.com/thelastpickle/cassandra-medusa/issues/605

ref: [boto3 doc](https://boto3.amazonaws.com/v1/documentation/api/1.9.42/guide/s3.html#changing-the-addressing-style)
ref: [域名合规问题-对象存储-腾讯云](https://cloud.tencent.com/document/faq/436/102489) (sorry i can't find english version of the addressing_style doc)