### PR TITLE
Support partially backup

### DIFF
--- a/docs/Performing-backups.md
+++ b/docs/Performing-backups.md
@@ -30,6 +30,8 @@ Options:
                                   Number of concurrent synchronous (blocking)
                                   ssh sessions started by pssh
 
+  --exclude TEXT                  Regex to exclude <keyspace>.<table>
+  --include TEXT                  Regex to include <keyspace>.<table>
   --help                          Show this message and exit.
 ```
 
@@ -73,6 +75,8 @@ Options:
                               size, which is used by default)
 
   --mode [full|differential]
+  --exclude TEXT              Regex to exclude <keyspace>.<table>
+  --include TEXT              Regex to include <keyspace>.<table>
   --help                      Show this message and exit.
 ```
 
@@ -87,6 +91,8 @@ In order to perform an **full** backup, add the `--mode=full` argument to your c
 ```
 $ medusa backup --backup-name=<name of the backup> --mode=full
 ```
+
+You can pass regex to `--include` or `--exclude` to do partially backup. The regex will be passed to fqtn(keyspace.table-xxxx) to check if it should skip this ks or table.
 
 When executed like this Medusa will:
 


### PR DESCRIPTION
support exclude/include fqtn by regex on cli.

for example: backup fqtn like: `test_ks.test_table-dd6ec5d02f9d11ef8b8f13b0bf265570` can be exclude or include with regex `test_ks\.test_table.+`

fix https://github.com/thelastpickle/cassandra-medusa/issues/116