### PR TITLE
Make remote command shell act as a login shell

### DIFF
--- a/medusa/orchestration.py
+++ b/medusa/orchestration.py
@@ -65,7 +65,7 @@ class Orchestration(object):
                                 cert_file=cert_file)
             logging.debug('Batch #{i}: Running "{command}" on nodes {hosts} parallelism of {pool_size}'
                           .format(i=i, command=command, hosts=parallel_hosts, pool_size=len(parallel_hosts)))
-            output = client.run_command(command, host_args=hosts_variables,
+            output = client.run_command(command, host_args=hosts_variables, shell='$SHELL -cl',
                                         sudo=medusa.utils.evaluate_boolean(self.config.cassandra.use_sudo))
             client.join(output)
 


### PR DESCRIPTION
This commit adds a parameter to the run_command() method call. The value differs from the pssh's default '$SHELL -c' by adding '-l' to make the shell act as a login shell.

This results in loading .bash_profile or .profile, depending on which shell it is and other circumstances.

The reason to load a profile file is to set up environment, for example PATH.

This is especially handy in environments where Python virtual envs are used. There, to use one, the user has to activate the env by sourcing a file.