### PR TITLE
Fix backup man future registration and BackupStatus computation of the node backup state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,12 @@ jobs:
         then
             echo "Updating debian changelog..."
             cd packaging/docker-build
-            docker-compose build release && docker-compose run release
+            docker compose build release && docker compose run release
             cd ../..
         fi
         cd packaging/docker-build
-        docker-compose build "cassandra-medusa-builder-${{ matrix.suite }}" \
-            && docker-compose run "cassandra-medusa-builder-${{ matrix.suite }}"
+        docker compose build "cassandra-medusa-builder-${{ matrix.suite }}" \
+            && docker compose run "cassandra-medusa-builder-${{ matrix.suite }}"
         
         cd ../../packages
         if [ -f "cassandra-medusa_${version}-0~${{ matrix.suite }}0_amd64.deb" ]; then
@@ -439,16 +439,16 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-        sudo chmod +x /usr/local/bin/docker-compose
-        sudo ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+        sudo curl -L "https://github.com/docker/compose/releases/download/1.25.0/docker compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker compose
+        sudo chmod +x /usr/local/bin/docker compose
+        sudo ln -s /usr/local/bin/docker compose /usr/bin/docker compose
     - name: Build Debian
       run: |
         version=$(cat VERSION)
         echo "VERSION=$version" >> $GITHUB_ENV
         cd packaging/docker-build
-        docker-compose build "cassandra-medusa-builder-${{ matrix.suite }}" \
-            && docker-compose run "cassandra-medusa-builder-${{ matrix.suite }}"
+        docker compose build "cassandra-medusa-builder-${{ matrix.suite }}" \
+            && docker compose run "cassandra-medusa-builder-${{ matrix.suite }}"
         
     - name: Push Debian to Cloudsmith
       id: push-deb

--- a/medusa/backup_manager.py
+++ b/medusa/backup_manager.py
@@ -108,12 +108,13 @@ class BackupMan:
             if not BackupMan.__instance:
                 BackupMan()
 
-            if backup_name in BackupMan.__instance.__backups:
+            if backup_name in BackupMan.__instance.__backups.keys():
                 if overwrite_existing:
                     if not BackupMan.__clean(backup_name):
                         logging.error(f"Registered backup name {backup_name} cleanup failed prior to re-register.")
-
-            BackupMan.__instance.__backups[backup_name] = [None, BackupMan.STATUS_UNKNOWN, is_async]
+                    BackupMan.__instance.__backups[backup_name] = [None, BackupMan.STATUS_UNKNOWN, is_async]
+            else:
+                BackupMan.__instance.__backups[backup_name] = [None, BackupMan.STATUS_UNKNOWN, is_async]
             logging.info("Registered backup id {}".format(backup_name))
 
     # Caller can decide how long to wait for a result using the registered backup future returned.

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -192,11 +192,24 @@ class MedusaService(medusa_pb2_grpc.MedusaServicer):
                 BackupMan.register_backup(request.backupName, is_async=False, overwrite_existing=False)
                 status = BackupMan.STATUS_UNKNOWN
                 future = BackupMan.get_backup_future(request.backupName)
-                if future is None or future.done():
+                if future is None:
                     # No future exists or the future is finished already,
                     # if the backup isn't marked as finished in the backend then it failed
+                    logging.info("Backup {} has no future".format(request.backupName))
                     if not backup.finished:
                         status = BackupMan.STATUS_FAILED
+                elif future.done():
+                    try:
+                        future.result()
+                        logging.info("Backup {} has finished with no exception".format(request.backupName))
+                        if not backup.finished:
+                            status = BackupMan.STATUS_FAILED
+                    except Exception as e:
+                        # If the future failed, then log the exception
+                        logging.error(f"Backup {request.backupName} has failed: {e}")
+                        status = BackupMan.STATUS_FAILED
+                elif future.running():
+                    logging.info("Backup {} is still running".format(request.backupName))
                 if status == BackupMan.STATUS_UNKNOWN:
                     if backup.started:
                         status = BackupMan.STATUS_IN_PROGRESS
@@ -206,6 +219,7 @@ class MedusaService(medusa_pb2_grpc.MedusaServicer):
                 if status == BackupMan.STATUS_FAILED and future is not None:
                     try:
                         future.result()
+                        logging.info("Backup {} has failed with no exception".format(request.backupName))
                     except Exception as e:
                         # If the future failed, then log the exception
                         logging.error(f"Backup {request.backupName} has failed: {e}")

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -208,7 +208,7 @@ class MedusaService(medusa_pb2_grpc.MedusaServicer):
                         # If the future failed, then log the exception
                         logging.error(f"Backup {request.backupName} has failed: {e}")
                         status = BackupMan.STATUS_FAILED
-                elif future.running():
+                else:
                     logging.info("Backup {} is still running".format(request.backupName))
                 if status == BackupMan.STATUS_UNKNOWN:
                     if backup.started:

--- a/tests/service/grpc/server_test.py
+++ b/tests/service/grpc/server_test.py
@@ -24,7 +24,7 @@ from medusa.service.grpc import medusa_pb2
 from medusa.service.grpc.server import MedusaService
 from medusa.storage import Storage
 
-from tests.storage_test import make_node_backup, make_cluster_backup
+from tests.storage_test import make_node_backup, make_cluster_backup, make_unfinished_node_backup
 
 
 class ServerTest(unittest.TestCase):
@@ -146,14 +146,17 @@ class ServerTest(unittest.TestCase):
                         self.assertEqual(medusa_pb2.StatusType.SUCCESS, get_backup_response.backup.status)
                         self.assertEqual('differential', get_backup_response.backup.backupType)
 
-    def test_get_backup_status_unknown_backup(self):
+    def test_get_backup_status_unknown_backup_with_future(self):
+        # Backup isn't started yet and we have a future for it. We consider it in UNKNOWN state.
         # start the Medusa service
         medusa_config = self._make_config()
         service = MedusaService(medusa_config)
+        BackupMan.register_backup('unknown_backup1', True)
+        BackupMan.set_backup_future('unknown_backup1', 'fake_future')
 
         # make a status request for an unknown backup.
         # no need to fake a backup here because we're not actually interested in it
-        request = medusa_pb2.BackupStatusRequest(backupName='unknown_backup')
+        request = medusa_pb2.BackupStatusRequest(backupName='unknown_backup1')
         context = Mock(spec=ServicerContext)
         backup_status = service.BackupStatus(request, context)
 
@@ -167,7 +170,31 @@ class ServerTest(unittest.TestCase):
         self.assertEqual('', backup_status.startTime)
         self.assertEqual('', backup_status.finishTime)
 
-    def test_get_backup_status_known_backup(self):
+    def test_get_backup_status_unknown_backup_no_future(self):
+        # Backup isn't started yet and we don't have a future for it. We consider it in UNKNOWN state.
+        # start the Medusa service
+        medusa_config = self._make_config()
+        service = MedusaService(medusa_config)
+        BackupMan.register_backup('unknown_backup2', True)
+
+        # make a status request for an unknown backup.
+        # no need to fake a backup here because we're not actually interested in it
+        request = medusa_pb2.BackupStatusRequest(backupName='unknown_backup2')
+        context = Mock(spec=ServicerContext)
+        backup_status = service.BackupStatus(request, context)
+
+        # verify the response structure without an emphasis on the actual contents
+        status_fields = {field.name for field in backup_status.DESCRIPTOR.fields}
+        self.assertEqual(
+            status_fields,
+            {'startTime', 'finishTime', 'status'}
+        )
+        self.assertEqual(medusa_pb2.StatusType.UNKNOWN, backup_status.status)
+        self.assertEqual('', backup_status.startTime)
+        self.assertEqual('', backup_status.finishTime)
+
+    def test_get_backup_status_finished_backup_no_future(self):
+        # Backup that has already finished and has no future. We consider it successful.
         # start the Medusa service
         medusa_config = self._make_config()
         service = MedusaService(medusa_config)
@@ -176,7 +203,6 @@ class ServerTest(unittest.TestCase):
         storage = Storage(config=medusa_config.storage)
         node_backup = make_node_backup(storage, 'backup1', datetime.fromtimestamp(123456), differential=True)
         BackupMan.register_backup('backup1', True)
-        BackupMan.update_backup_status('backup1', BackupMan.STATUS_SUCCESS)
 
         # this patch prevents the actual get_node_backup call, and instead returns the fake backup from above
         with patch('medusa.storage.Storage.get_node_backup', return_value=node_backup):
@@ -195,30 +221,84 @@ class ServerTest(unittest.TestCase):
             finish_time = int(datetime.strptime(backup_status.finishTime, '%Y-%m-%d %H:%M:%S').timestamp())
             self.assertEqual(123456, finish_time)
 
-    def test_get_backup_status_incomplete_backup(self):
+    def test_get_backup_status_finished_backup_with_future(self):
+        # Backup is finished and has a future. We consider it successful.
         # start the Medusa service
         medusa_config = self._make_config()
         service = MedusaService(medusa_config)
 
         # build a fake backup object
         storage = Storage(config=medusa_config.storage)
-        node_backup = make_node_backup(storage, 'backup2', datetime.fromtimestamp(123456), differential=True)
+        node_backup = make_node_backup(storage, 'backup3', datetime.fromtimestamp(123456), differential=True)
+        BackupMan.register_backup('backup1', True)
+        BackupMan.set_backup_future('backup1', 'fake_future')
+
+        # this patch prevents the actual get_node_backup call, and instead returns the fake backup from above
+        with patch('medusa.storage.Storage.get_node_backup', return_value=node_backup):
+            request = medusa_pb2.BackupStatusRequest(backupName='backup3')
+            context = Mock(spec=ServicerContext)
+            backup_status = service.BackupStatus(request, context)
+
+            self.assertEqual(medusa_pb2.StatusType.SUCCESS, backup_status.status)
+
+            # the start timestamp of 123456 rendered as a human-readable date
+            # we're parsing this back and forth because hard-coding a human-readable date is
+            # inconsistent across environments
+            start_time = int(datetime.strptime(backup_status.startTime, '%Y-%m-%d %H:%M:%S').timestamp())
+            self.assertEqual(123456, start_time)
+            # the fake backup is instant - starts and finishes at the same time
+            finish_time = int(datetime.strptime(backup_status.finishTime, '%Y-%m-%d %H:%M:%S').timestamp())
+            self.assertEqual(123456, finish_time)
+
+    def test_get_backup_status_started_backup_with_future(self):
+        # Backup is started and has a future. We consider it in progress.
+        # start the Medusa service
+        medusa_config = self._make_config()
+        service = MedusaService(medusa_config)
+
+        # build a fake backup object
+        storage = Storage(config=medusa_config.storage)
+        node_backup = make_unfinished_node_backup(storage, 'backup4', datetime.fromtimestamp(123456), differential=True)
         # we only register the backup, do not move it to SUCCESS
-        BackupMan.register_backup('backup2', True)
+        BackupMan.register_backup('backup4', True)
+        BackupMan.set_backup_future('backup4', 'fake_future')
 
         with patch('medusa.storage.Storage.get_node_backup', return_value=node_backup):
-            request = medusa_pb2.BackupStatusRequest(backupName='backup2')
+            request = medusa_pb2.BackupStatusRequest(backupName='backup4')
             context = Mock(spec=ServicerContext)
             backup_status = service.BackupStatus(request, context)
 
             # we get the response as SUCCESS because the finish time is set (~not None)
-            self.assertEqual(medusa_pb2.StatusType.SUCCESS, backup_status.status)
+            self.assertEqual(medusa_pb2.StatusType.IN_PROGRESS, backup_status.status)
             # the finish time is already set
             # I'm not sure this is because of faking the backup
             start_time = int(datetime.strptime(backup_status.startTime, '%Y-%m-%d %H:%M:%S').timestamp())
             self.assertEqual(123456, start_time)
-            finish_time = int(datetime.strptime(backup_status.finishTime, '%Y-%m-%d %H:%M:%S').timestamp())
-            self.assertEqual(123456, finish_time)
+
+    def test_get_backup_status_started_backup_no_future(self):
+        # Backup is started and has no future. We consider it failed.
+        # start the Medusa service
+        medusa_config = self._make_config()
+        service = MedusaService(medusa_config)
+
+        # build a fake backup object
+        storage = Storage(config=medusa_config.storage)
+        node_backup = make_unfinished_node_backup(storage, 'backup5', datetime.fromtimestamp(123456), differential=True)
+        # we only register the backup, do not move it to SUCCESS
+        BackupMan.register_backup('backup5', True)
+        self.assertIsNone(BackupMan.get_backup_future('backup5'))
+
+        with patch('medusa.storage.Storage.get_node_backup', return_value=node_backup):
+            request = medusa_pb2.BackupStatusRequest(backupName='backup5')
+            context = Mock(spec=ServicerContext)
+            backup_status = service.BackupStatus(request, context)
+
+            # we get the response as SUCCESS because the finish time is set (~not None)
+            self.assertEqual(medusa_pb2.StatusType.FAILED, backup_status.status)
+            # the finish time is already set
+            # I'm not sure this is because of faking the backup
+            start_time = int(datetime.strptime(backup_status.startTime, '%Y-%m-%d %H:%M:%S').timestamp())
+            self.assertEqual(123456, start_time)
 
 
 if __name__ == '__main__':

--- a/tests/storage_test.py
+++ b/tests/storage_test.py
@@ -469,6 +469,20 @@ def make_node_backup(storage, name, backup_date, differential=False, fqdn="local
                       started_timestamp=backup_date.timestamp(), finished_timestamp=backup_date.timestamp())
 
 
+def make_unfinished_node_backup(storage, name, backup_date, differential=False, fqdn="localhost"):
+    if differential is True:
+        differential_blob = make_blob("localhost/{}/meta/differential".format(name), backup_date.timestamp())
+    else:
+        differential_blob = None
+    tokenmap_blob = make_blob("localhost/{}/meta/tokenmap.json".format(name), backup_date.timestamp())
+    schema_blob = make_blob("localhost/{}/meta/schema.cql".format(name), backup_date.timestamp())
+    manifest_blob = None
+    return NodeBackup(storage=storage, fqdn=fqdn, name=str(name),
+                      differential_blob=differential_blob, manifest_blob=manifest_blob,
+                      tokenmap_blob=tokenmap_blob, schema_blob=schema_blob,
+                      started_timestamp=backup_date.timestamp(), finished_timestamp=None)
+
+
 def make_cluster_backup(storage, name, backup_date, nodes, differential=False):
     node_backups = list()
     for node in nodes:


### PR DESCRIPTION
Fixes #797 

Two bugs are fixed in this PR:

- The `BackupMan.register_backup()` function was always registering the backup, even if it existed and overwrite was set to false due to bad code structure.
- The state was computed without taking into account the presence of a future. In case of a restart of the grpc server with an unfinished backup job, the backup would forever be seen as in progress even though it failed.