### PR TITLE
added ssh keepalive and pseudo terminal support to orchestrator

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -127,8 +127,10 @@ backup_grace_period_in_days = 10
 [ssh]
 ;username = <SSH username to use for restoring clusters>
 ;key_file = <SSH key for use for restoring clusters. Expected in PEM unencrypted format.>
-;port = <SSH port for use for restoring clusters. Default to port 22.
+;port = <SSH port for use for restoring clusters. Default to port 22.>
 ;cert_file = <Path of public key signed certificate file to use for authentication. The corresponding private key must also be provided via key_file parameter>
+;keepalive_seconds = <seconds between ssh keepalive messages to the ssh server. Default to 60 seconds. Due to a limitation in parallel-ssh, if 'cert_file' is defined, then 'keepalive_seconds' will be ignored and no keep alive messages will be sent>
+;use_pty = <Boolean: Allocates pseudo-terminal. Default to False. Useful if sudo settings require a tty>
 
 [checks]
 ;health_check = <Which ports to check when verifying a node restored properly. Options are 'cql' (default), 'thrift', 'all'.>

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -45,7 +45,7 @@ CassandraConfig = collections.namedtuple(
 
 SSHConfig = collections.namedtuple(
     'SSHConfig',
-    ['username', 'key_file', 'port', 'cert_file']
+    ['username', 'key_file', 'port', 'cert_file', 'use_pty', 'keepalive_seconds']
 )
 
 ChecksConfig = collections.namedtuple(
@@ -146,7 +146,9 @@ def _build_default_config():
         'username': os.environ.get('USER') or '',
         'key_file': '',
         'port': '22',
-        'cert_file': ''
+        'cert_file': '',
+        'use_pty': 'False',
+        'keepalive_seconds': '60'
     }
 
     config['checks'] = {

--- a/medusa/orchestration.py
+++ b/medusa/orchestration.py
@@ -15,7 +15,8 @@
 
 import logging
 
-from pssh.clients.ssh import ParallelSSHClient
+from pssh.clients.native.parallel import ParallelSSHClient as PsshNativeClient
+from pssh.clients.ssh.parallel import ParallelSSHClient as PsshSSHClient
 
 import medusa.utils
 from medusa.storage import divide_chunks
@@ -39,33 +40,50 @@ class Orchestration(object):
         Runs a command on hosts list using pssh under the hood
         Return: True (success) or False (error)
         """
-        if ssh_client is None:
-            ssh_client = ParallelSSHClient
-        pssh_run_success = False
-        success = []
-        error = []
-        i = 1
-
         username = self.config.ssh.username if self.config.ssh.username != '' else None
         port = int(self.config.ssh.port)
         pkey = self.config.ssh.key_file if self.config.ssh.key_file != '' else None
         cert_file = self.config.ssh.cert_file if self.config.ssh.cert_file != '' else None
+        keepalive_seconds = int(self.config.ssh.keepalive_seconds)
+        use_pty = medusa.utils.evaluate_boolean(self.config.ssh.use_pty)
+
+        if ssh_client is None:
+            if cert_file is None:
+                ssh_client = PsshNativeClient
+            else:
+                ssh_client = PsshSSHClient
+        pssh_run_success = False
+        success = []
+        error = []
+        i = 1
 
         logging.info('Executing "{command}" on following nodes {hosts} with a parallelism/pool size of {pool_size}'
                      .format(command=command, hosts=hosts, pool_size=self.pool_size))
 
         for parallel_hosts in divide_chunks(hosts, self.pool_size):
 
-            client = ssh_client(parallel_hosts,
-                                forward_ssh_agent=True,
-                                pool_size=len(parallel_hosts),
-                                user=username,
-                                port=port,
-                                pkey=pkey,
-                                cert_file=cert_file)
+            if cert_file is None:
+                client = ssh_client(parallel_hosts,
+                                    forward_ssh_agent=True,
+                                    pool_size=len(parallel_hosts),
+                                    user=username,
+                                    port=port,
+                                    pkey=pkey,
+                                    keepalive_seconds=keepalive_seconds)
+            else:
+                logging.debug('The ssh parameter "cert_file" is defined. Due to limitations in parallel-ssh '
+                              '"keep_alive" will be ignored and no ServerAlive messages will be generated')
+                client = ssh_client(parallel_hosts,
+                                    forward_ssh_agent=True,
+                                    pool_size=len(parallel_hosts),
+                                    user=username,
+                                    port=port,
+                                    pkey=pkey,
+                                    cert_file=cert_file)
+
             logging.debug('Batch #{i}: Running "{command}" on nodes {hosts} parallelism of {pool_size}'
                           .format(i=i, command=command, hosts=parallel_hosts, pool_size=len(parallel_hosts)))
-            output = client.run_command(command, host_args=hosts_variables,
+            output = client.run_command(command, host_args=hosts_variables, use_pty=use_pty,
                                         sudo=medusa.utils.evaluate_boolean(self.config.cassandra.use_sudo))
             client.join(output)
 

--- a/tests/orchestration_test.py
+++ b/tests/orchestration_test.py
@@ -67,7 +67,9 @@ class OrchestrationTest(unittest.TestCase):
             'username': '',
             'key_file': '',
             'port': '22',
-            'cert_file': ''
+            'cert_file': '',
+            'keepalive_seconds': '60',
+            'use_pty': 'False'
         }
         return config
 
@@ -91,7 +93,7 @@ class OrchestrationTest(unittest.TestCase):
         self.mock_pssh.run_command.return_value = output
         assert self.orchestration.pssh_run(list(self.hosts.keys()), 'fake command',
                                            ssh_client=self.fake_ssh_client_factory)
-        self.mock_pssh.run_command.assert_called_with('fake command', host_args=None, sudo=True)
+        self.mock_pssh.run_command.assert_called_with('fake command', host_args=None, use_pty=False, sudo=True)
 
     def test_pssh_without_sudo(self):
         """Ensure that Parallel SSH honors configuration when we don't want to use sudo in commands"""
@@ -105,7 +107,7 @@ class OrchestrationTest(unittest.TestCase):
         assert orchestration_no_sudo.pssh_run(list(self.hosts.keys()), 'fake command',
                                               ssh_client=self.fake_ssh_client_factory)
 
-        self.mock_pssh.run_command.assert_called_with('fake command', host_args=None, sudo=False)
+        self.mock_pssh.run_command.assert_called_with('fake command', host_args=None, use_pty=False, sudo=False)
 
     def test_pssh_run_failure(self):
         """Ensure that Parallel SSH detects a failed command on a host"""
@@ -118,7 +120,7 @@ class OrchestrationTest(unittest.TestCase):
         self.mock_pssh.run_command.return_value = output
         assert not self.orchestration.pssh_run(list(self.hosts.keys()), 'fake command',
                                                ssh_client=self.fake_ssh_client_factory)
-        self.mock_pssh.run_command.assert_called_with('fake command', host_args=None, sudo=True)
+        self.mock_pssh.run_command.assert_called_with('fake command', host_args=None, use_pty=False, sudo=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

This change adds two parameters to the `[ssh]` section in `medusa.ini`:

- `keepalive_seconds` : seconds between ssh keepalive messages to the ssh server. Default to 60 seconds. Due to a limitation in parallel-ssh, if `cert_file` is defined, then `keepalive_seconds` will be ignored and no keep alive messages will be sent
- `use_pty` : Boolean: Allocates a pseudo-terminal. Default to False. It's useful if sudo settings require a tty

## details about the change for keepalive_seconds

`parallel-ssh` includes two implementations of a parallel ssh client:

1.  [Native Parallel Client](https://parallel-ssh.readthedocs.io/en/latest/native_parallel.html) - Based on `ssh2-python` (`libssh2`) .
2.  [ssh-python Parallel Client](https://parallel-ssh.readthedocs.io/en/latest/ssh_parallel.html) - Based on `ssh-python` (`libssh`)

Medusa uses implementation (2) which has an important limitation when it comes to ssh keepalive messages as `libssh` client does not implement it. `libssh` can understand these messages on its server implementation, but its client side (what parallel-ssh uses), does not physically has the code to generate the keepalive messages. The library is also documented as using `~/.ssh/config` (an openssh config file) but that only applies to a small subset of parameters, and crucially excludes `ServerAlive*` parameters that control the way a client sends those messages. The keepalive implementation in parallel-ssh when using libssh is explicitly [dummy](https://github.com/ParallelSSH/parallel-ssh/blob/master/pssh/clients/ssh/single.py#L135).

* * *

in implementation (1), `libssh2` client code has the machinery to send client generated keep alive messages and that can be controlled programmatically only ( `libssh2` does not care about `~/.ssh/config`). `parallel-ssh` [uses it](https://github.com/ParallelSSH/parallel-ssh/blob/master/pssh/clients/native/single.py#L241), and the `ParallelSSHClient` constructor has a `keepalive_seconds=60` parameter.

When enabling debug (`LogLevel DEBUG3`) on `/etc/ssh/sshd_config` the messages are recorded as

```
Sep  4 12:40:01 b07 sshd[1961781]: debug3: receive packet: type 80
Sep  4 12:40:01 b07 sshd[1961781]: debug1: server_input_global_request: rtype keepalive@libssh2.org want_reply 0
```

To see the difference, the keepalive messages coming from an openssh ssh client are recorded as:

```
Sep  1 20:18:13 b07 sshd[468119]: debug3: receive packet: type 80
Sep  1 20:18:13 b07 sshd[468119]: debug1: server_input_global_request: rtype keepalive@openssh.com want_reply 1
Sep  1 20:18:13 b07 sshd[468119]: debug3: send packet: type 82
```

The downside of using `libssh2` is that it does not implement certificate-based ssh authentication, which Medusa uses (parameter `ssh.cert_file`).

Therefore, the changes switches using (1) unless `ssh.cert_file` has a value in which case it uses (2) instead and keep-alive won't be generated.

### testing keepalive

All the `sshd` servers need to be configured (`/etc/ssh/sshd_config`) with values like to

```
ClientAliveInterval 60
ClientAliveCountMax 0
```

which would close an ssh connection after 60s if it detects no "activity" on it, where activity looks to be either a keystroke or a keepalive message coming from the ssh client. If you run a cluster backup that takes several minutes to complete, the command will fail after ~ `ClientAliveInterval` seconds with

```
ssh.exceptions.SSHError: (-1, b'Socket error: disconnected')
```

If you then re-do the backup with a Medusa that includes this patch, and set a keep_alive of 20s, the backup will go through and you should also see the libssh2 keepalive messages in the sshd logs (`/var/log/secure` often) spaced 20s from one another.

This change should take care of [medusa issue 689](https://github.com/thelastpickle/cassandra-medusa/issues/689) **SSH Timeout** ( Error on first backup-cluster or restore ).

## details about the change for use-pty
In restrictive environments, sudoers can be required to have a terminal associated to what they run. This is the parameter `Defaults requiretty` in `/etc/sudoers*` . If this setting cannot be changed for the user running Medusa command, then when executing a cluster backup with sudo (or anything distributed requiring sudo) the operation will fail with 
```
sudo: sorry, you must have a tty to run sudo
```
setting `use_pty=true` will avoid this problem.
Both implementations (1) and (2) accept the parameter. 