### PR TITLE
Added configuration parameter grpc.port to make the gRPC server port configurable

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -158,6 +158,7 @@ backup_grace_period_in_days = 10
 ; Set to true when running in grpc server mode.
 ; Allows to propagate the exceptions instead of exiting the program.
 ;enabled = False
+;port = <grpc port the server listens to. Defaults to port 50051.>
 
 [kubernetes]
 ; The following settings are only intended to be configured if Medusa is running in containers, preferably in Kubernetes.

--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -170,6 +170,9 @@ use_sudo_for_restore = True
 ; Allows to propagate the exceptions instead of exiting the program.
 ;enabled = False
 
+; if needed, change the port the grpc server listens to
+;port = 50051
+
 [kubernetes]
 ; The following settings are only intended to be configured if Medusa is running in containers, preferably in Kubernetes.
 ;enabled = False

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -73,7 +73,7 @@ LoggingConfig = collections.namedtuple(
 
 GrpcConfig = collections.namedtuple(
     'GrpcConfig',
-    ['enabled', 'max_send_message_length', 'max_receive_message_length']
+    ['enabled', 'max_send_message_length', 'max_receive_message_length', 'port']
 )
 
 KubernetesConfig = collections.namedtuple(
@@ -93,6 +93,7 @@ CONFIG_SECTIONS = {
 }
 
 DEFAULT_CONFIGURATION_PATH = pathlib.Path('/etc/medusa/medusa.ini')
+DEFAULT_GRPC_PORT = 50051
 
 
 def _build_default_config():
@@ -167,6 +168,7 @@ def _build_default_config():
         'enabled': 'False',
         'max_send_message_length': '536870912',
         'max_receive_message_length': '134217728',
+        'port': f'{DEFAULT_GRPC_PORT}'
     }
 
     config['kubernetes'] = {

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -70,8 +70,9 @@ class Server:
         medusa_pb2_grpc.add_MedusaServicer_to_server(MedusaService(config), self.grpc_server)
         health_pb2_grpc.add_HealthServicer_to_server(grpc_health.v1.health.HealthServicer(), self.grpc_server)
 
-        logging.info('Starting server. Listening on port 50051.')
-        self.grpc_server.add_insecure_port('[::]:50051')
+        grpc_port = int(self.medusa_config.grpc.port)
+        logging.info(f"Starting server. Listening on port {grpc_port}.")
+        self.grpc_server.add_insecure_port(f"[::]:{grpc_port}")
         await self.grpc_server.start()
 
         if not self.testing:

--- a/tests/integration/features/steps/integration_steps.py
+++ b/tests/integration/features/steps/integration_steps.py
@@ -447,7 +447,7 @@ def i_am_using_storage_provider_with_grpc_server(context, storage_provider, clie
     context.client_encryption = client_encryption
     context.grpc_server = GRPCServer(config)
     context.grpc_client = medusa.service.grpc.client.Client(
-        "127.0.0.1:50051",
+        f"127.0.0.1:{config['grpc']['port']}",
         channel_options=[('grpc.enable_retries', 0)]
     )
 
@@ -496,7 +496,7 @@ def i_am_using_storage_provider_with_grpc_server_and_mgmt_api(context, storage_p
     context.client_encryption = client_encryption
     context.grpc_server = GRPCServer(config)
     context.grpc_client = medusa.service.grpc.client.Client(
-        "127.0.0.1:50051",
+        f"127.0.0.1:{config['grpc']['port']}",
         channel_options=[('grpc.enable_retries', 0)]
     )
 


### PR DESCRIPTION
## Summary

This change adds one parameter to the `[grpc]` section in `medusa.ini`:

- `port` : grpc port the server listens to. Defaults to 50051

This change resolves [#512](https://github.com/thelastpickle/cassandra-medusa/issues/512)  (_grpc service - port number configurability_) on the Medusa side. 
Other projects such as k8ssandra-operator will need changes to support the new parameter.