### PR TITLE
Add support for using an attached GCE service account

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -71,6 +71,7 @@ bucket_name = cassandra_backups
 kms_id = <ARN of KMS key used for server-side bucket encryption>
 
 ; JSON key file for service account with access to GCS bucket or AWS credentials file (home-dir/.aws/credentials)
+; optional if using GCS (see ./Docs/gcs_setup.md)
 key_file = /etc/medusa/credentials
 
 ; Path of the local storage bucket (used only with 'local' storage provider)

--- a/docs/gcs_setup.md
+++ b/docs/gcs_setup.md
@@ -54,7 +54,9 @@ gsutil iam set ${iamGetFile} ${BUCKET_URL} && \
 rm -rf ${iamGetFile}
 ```
 
-### Configure Medusa
+### Configure Medusa using a service account key
+
+note: Skip this step if you intend to use a service account attached to a VM or workload identity)
 
 Generate a json key file called `credentials.json`, for the service account:
 
@@ -73,3 +75,17 @@ key_file = /etc/medusa/credentials.json
 ```
 
 Medusa should now be able to access the bucket and perform all required operations.
+
+### Configure Medusa using an attached service account.
+
+If you are running medusa on a GCE Virtual Machine, you can use an attached service account without providing a credentials file. This can be useful to avoid having to rotate service account keys frequently
+
+To do this, configure `/etc/medusa/medusa.ini` without specifying a `key_file`, as below:
+
+```
+[storage]
+storage_provider = google_storage
+bucket_name = my_gcs_bucket
+```
+
+For this to work, ensure that the `storage-rw` access scope set on the GCE instance.

--- a/medusa/storage/google_storage.py
+++ b/medusa/storage/google_storage.py
@@ -39,9 +39,12 @@ MAX_UP_DOWN_LOAD_RETRIES = 5
 class GoogleStorage(AbstractStorage):
 
     def __init__(self, config):
-
-        self.service_file = str(Path(config.key_file).expanduser())
-        logging.info("Using service file: {}".format(self.service_file))
+        if config.key_file is not None:
+            self.service_file = str(Path(config.key_file).expanduser())
+            logging.info("Using service file: {}".format(self.service_file))
+        else:
+            self.service_file = None
+            logging.info("Using attached service account")
 
         self.bucket_name = config.bucket_name
 


### PR DESCRIPTION
Support using service accounts that are attached to a GCE instance, rather than requiring a service account key to be present.

The `gcloud-aio` library supports using a service account that is assigned to a VM by default just by omitting the `service_file` parameter (or by setting it to `None`).

Removing this requirement means that the service account key does not need to be manually rotated, as the assigned service account credentials provided by the GCE metadata API are automatically rotated frequently. 

Closes: #833