### PR TITLE
Bump idna to >= 3.7

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -787,7 +787,7 @@ dev = ["black (>=23.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "mypy (>=1.8)", "
 dnssec = ["cryptography (>=41)"]
 doh = ["h2 (>=4.1.0)", "httpcore (>=1.0.0)", "httpx (>=0.26.0)"]
 doq = ["aioquic (>=0.9.25)"]
-idna = ["idna (>=3.6)"]
+idna = ["idna (>=3.7)"]
 trio = ["trio (>=0.23)"]
 wmi = ["wmi (>=1.5.1)"]
 


### PR DESCRIPTION
Remove risk of installing 3.6 which is vulnerable to:
  https://github.com/advisories/GHSA-jjg7-2v4v-x