### PR TITLE
851 Backup Without Snapshot Creation & Deletion

### DIFF
--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -75,7 +75,7 @@ def stagger(fqdn, storage, tokenmap):
 # Called by async thread for backup, called in main thread as synchronous backup.
 # Kicks off the node backup unit of work and registers for backup queries.
 # No return value for async mode, throws back exception for failed kickoff.
-def handle_backup(config, backup_name_arg, stagger_time, enable_md5_checks_flag, mode):
+def handle_backup(config, backup_name_arg, stagger_time, enable_md5_checks_flag, mode, keep_snapshot=False):
     start = datetime.datetime.now()
     backup_name = backup_name_arg or start.strftime('%Y%m%d%H%M')
     monitoring = Monitoring(config=config.monitoring)
@@ -112,7 +112,7 @@ def handle_backup(config, backup_name_arg, stagger_time, enable_md5_checks_flag,
             logging.info("Starting backup using Stagger: {} Mode: {} Name: {}".format(stagger_time, mode, backup_name))
             BackupMan.update_backup_status(backup_name, BackupMan.STATUS_IN_PROGRESS)
             info = start_backup(storage, node_backup, cassandra, differential_mode, stagger_time, start, mode,
-                                enable_md5_checks_flag, backup_name, config, monitoring)
+                                enable_md5_checks_flag, backup_name, config, monitoring, keep_snapshot)
             BackupMan.update_backup_status(backup_name, BackupMan.STATUS_SUCCESS)
 
             logging.debug("Done with backup, returning backup result information")
@@ -136,7 +136,7 @@ def handle_backup(config, backup_name_arg, stagger_time, enable_md5_checks_flag,
 
 
 def start_backup(storage, node_backup, cassandra, differential_mode, stagger_time, start, mode,
-                 enable_md5_checks_flag, backup_name, config, monitoring):
+                 enable_md5_checks_flag, backup_name, config, monitoring, keep_snapshot=False):
     try:
         # Make sure that priority remains to Cassandra/limiting backups resource usage
         throttle_backup()
@@ -172,7 +172,7 @@ def start_backup(storage, node_backup, cassandra, differential_mode, stagger_tim
     actual_start = datetime.datetime.now()
     enable_md5 = enable_md5_checks_flag or medusa.utils.evaluate_boolean(config.checks.enable_md5_checks)
     num_files, num_replaced, num_kept = do_backup(
-        cassandra, node_backup, storage, enable_md5, backup_name
+        cassandra, node_backup, storage, enable_md5, backup_name, keep_snapshot
     )
     end = datetime.datetime.now()
     actual_backup_duration = end - actual_start
@@ -209,13 +209,13 @@ def get_server_type_and_version(cassandra):
     return server_type, release_version
 
 
-def do_backup(cassandra, node_backup, storage, enable_md5_checks, backup_name):
+def do_backup(cassandra, node_backup, storage, enable_md5_checks, backup_name, keep_snapshot=False):
 
     # the cassandra snapshot we use defines __exit__ that cleans up the snapshot
     # so even if exception is thrown, a new snapshot will be created on the next run
     # this is not too good and we will use just one snapshot in the future
     logging.info('Creating snapshot')
-    with cassandra.create_snapshot(backup_name) as snapshot:
+    with cassandra.create_snapshot(backup_name, keep_snapshot) as snapshot:
         manifest = []
         num_files, num_replaced, num_kept = backup_snapshots(
             storage, manifest, node_backup, snapshot, enable_md5_checks

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -124,16 +124,21 @@ def cli(ctx, verbosity, without_log_timestamp, config_file, **kwargs):
               is_flag=True, default=False)
 @click.option('--mode', default="differential", type=click.Choice(['full', 'differential']))
 @click.option('--keep-snapshot', help="Dont delete snapshot after successful backup.", is_flag=True, default=False)
+@click.option('--use-existing-snapshot',
+              help="Dont create snapshot, only backup it. The snapshot needs to be manually created beforehand.",
+              is_flag=True, default=False)
 @pass_MedusaConfig
-def backup(medusaconfig, backup_name, stagger, enable_md5_checks, mode, keep_snapshot):
+def backup(medusaconfig, backup_name, stagger, enable_md5_checks, mode, keep_snapshot, use_existing_snapshot):
     """
     Backup single Cassandra node
     """
     stagger_time = datetime.timedelta(seconds=stagger) if stagger else None
+    if (use_existing_snapshot and not backup_name):
+        raise RuntimeError("Cannot use existing snapshot without providing a backup name")
     actual_backup_name = backup_name or datetime.datetime.now().strftime('%Y%m%d%H%M')
     BackupMan.register_backup(actual_backup_name, is_async=False)
     return backup_node.handle_backup(medusaconfig, actual_backup_name, stagger_time, enable_md5_checks, mode,
-                                     keep_snapshot)
+                                     keep_snapshot, use_existing_snapshot)
 
 
 @cli.command(name='backup-cluster')

--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -123,15 +123,17 @@ def cli(ctx, verbosity, without_log_timestamp, config_file, **kwargs):
                    '(in addition to size, which is used by default)',
               is_flag=True, default=False)
 @click.option('--mode', default="differential", type=click.Choice(['full', 'differential']))
+@click.option('--keep-snapshot', help="Dont delete snapshot after successful backup.", is_flag=True, default=False)
 @pass_MedusaConfig
-def backup(medusaconfig, backup_name, stagger, enable_md5_checks, mode):
+def backup(medusaconfig, backup_name, stagger, enable_md5_checks, mode, keep_snapshot):
     """
     Backup single Cassandra node
     """
     stagger_time = datetime.timedelta(seconds=stagger) if stagger else None
     actual_backup_name = backup_name or datetime.datetime.now().strftime('%Y%m%d%H%M')
     BackupMan.register_backup(actual_backup_name, is_async=False)
-    return backup_node.handle_backup(medusaconfig, actual_backup_name, stagger_time, enable_md5_checks, mode)
+    return backup_node.handle_backup(medusaconfig, actual_backup_name, stagger_time, enable_md5_checks, mode,
+                                     keep_snapshot)
 
 
 @cli.command(name='backup-cluster')


### PR DESCRIPTION
Fixes #851 

Hi,

Added two flags to the "backup" command. The default behaviour of backup is unchanged : it creates a snapshot and deletes it on successful backup.

New flags:

--keep-snapshot: dont delete snapshot on successful backup.
--use-existing-snapshot: dont create a snapshot, use a previously existing one.

- Raises an error when --use-existing-snapshot is set and --backup-name is not defined.
- Raises an error when --use-existing-snapshot and snapshot cant be found.

If the feature is accepted in principle, I’m happy to explore ways to add tests. Currently the integration_steps does not manage nodetool operations needed for theses features (such as `snapshot` and `listsnapshots`).

Also I can work on adding feature to the backup-cluster. Also is more code needed for DSE environment ?

Looking forward to your thoughts—thanks for your time!