### PR TITLE
MC-1534 Allow using role-based identity for Azure storage

### DIFF
--- a/docs/azure_blobs_setup.md
+++ b/docs/azure_blobs_setup.md
@@ -11,12 +11,35 @@ Create a new storage account or use an existing one which will be used to store 
     "key": "YOUR_KEY"
 }
 ```
-Place this file on all Apache Cassandra™ nodes running medusa under `/etc/medusa/`and set the rights appropriately so that only users running Medusa can read/modify it.
+Place this file on all Apache Cassandra™ nodes running Medusa under `/etc/medusa/`and set the rights appropriately so that only users running Medusa can read/modify it.
 
 
 ### Identity through roles
 
-TBC
+If Medusa runs in an environment with a managed identity set up, then there is no need to create the key file, nor to put the `key_file` field in the `medusa.ini` file.
+
+You can check if the managed identity works by running:
+
+```
+az login --identity
+az storage blob list  --account-name <account_name> --container-name <container_name> --auth-mode login --output table
+```
+
+  * The `--account-name` is the name of the Azure account where the storage is located.
+  * The `--container-name` is the name of the container where the blobs are store. This is equivalent to the _bucket name_ in other storage providers.
+
+To have Medusa use the managed identity, you need to set the `AZURE_STORAGE_ACCOUNT` environment variable before you run `medusa`:
+
+```
+export AZURE_STORAGE_ACCOUNT=<account_name>
+```
+
+In the `medusa.ini` file, set only the `bucket_name` to your container name. You should see log lines like these if everything is working as expected:
+
+```
+[2025-03-24 15:47:22,191] INFO: ManagedIdentityCredential will use IMDS
+[2025-03-24 15:47:22,215] INFO: DefaultAzureCredential acquired a token from ManagedIdentityCredential
+```
 
 ### Create a container
 

--- a/docs/azure_blobs_setup.md
+++ b/docs/azure_blobs_setup.md
@@ -13,6 +13,11 @@ Create a new storage account or use an existing one which will be used to store 
 ```
 Place this file on all Apache Cassandra™ nodes running medusa under `/etc/medusa/`and set the rights appropriately so that only users running Medusa can read/modify it.
 
+
+### Identity through roles
+
+TBC
+
 ### Create a container
 
 Create a new container in your storage account that will be used to store the backups and do not enable public access.

--- a/docs/gcs_setup.md
+++ b/docs/gcs_setup.md
@@ -35,7 +35,7 @@ gsutil mb -p ${GCP_PROJECT} -c regional -l ${LOCATION} ${BUCKET_URL}
 
 ### Create a service account and download its keys
 
-Medusa will require a `credentials.json` file with the information and keys for a service account with the appropriate role in order to interact with the bucket.
+Medusa will require a `credentials.json` file with the information and keys for a service account with the appropriate role in order to interact with the bucket.
 
 Create the service account (if it doesn't exist yet):
 
@@ -43,7 +43,7 @@ Create the service account (if it doesn't exist yet):
 gcloud --project ${GCP_PROJECT} iam service-accounts create ${SERVICE_ACCOUNT_NAME} --display-name ${SERVICE_ACCOUNT_NAME}
 ```
 
-### Configure the service account with the role
+### Configure the service account with the role
 
 Once the service account has been created, and considering [jq](https://stedolan.github.io/jq/) is installed, run the following command to add the `MedusaStorageRole` to it, for our backup bucket:
 

--- a/medusa/storage/google_storage.py
+++ b/medusa/storage/google_storage.py
@@ -41,10 +41,10 @@ class GoogleStorage(AbstractStorage):
     def __init__(self, config):
         if config.key_file is not None:
             self.service_file = str(Path(config.key_file).expanduser())
-            logging.info("Using service file: {}".format(self.service_file))
+            logging.debug("Using service file: {}".format(self.service_file))
         else:
             self.service_file = None
-            logging.info("Using attached service account")
+            logging.debug("Using attached service account")
 
         self.bucket_name = config.bucket_name
 

--- a/tests/storage/azure_storage_test.py
+++ b/tests/storage/azure_storage_test.py
@@ -5,8 +5,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import tempfile
 import unittest
+
+from azure.core.credentials import AzureNamedKeyCredential
+from azure.identity import DefaultAzureCredential
 
 from medusa.storage.azure_storage import AzureStorage
 from tests.storage.abstract_storage_test import AttributeDict
@@ -36,6 +40,7 @@ class AzureStorageTest(unittest.TestCase):
                 'read_timeout': 60,
             })
             azure_storage = AzureStorage(config)
+            self.assertTrue(isinstance(azure_storage.credentials, AzureNamedKeyCredential))
             self.assertEqual(
                 'https://medusa-unit-test.blob.core.windows.net/',
                 azure_storage.azure_blob_service_url
@@ -56,6 +61,7 @@ class AzureStorageTest(unittest.TestCase):
                 'read_timeout': 60,
             })
             azure_storage = AzureStorage(config)
+            self.assertTrue(isinstance(azure_storage.credentials, AzureNamedKeyCredential))
             self.assertEqual(
                 'https://medusa-unit-test.blob.core.custom.host.net/',
                 azure_storage.azure_blob_service_url
@@ -76,7 +82,28 @@ class AzureStorageTest(unittest.TestCase):
                 'read_timeout': 60,
             })
             azure_storage = AzureStorage(config)
+            self.assertTrue(isinstance(azure_storage.credentials, AzureNamedKeyCredential))
             self.assertEqual(
                 'https://medusa-unit-test.blob.core.custom.host.net:123/',
                 azure_storage.azure_blob_service_url
             )
+
+    def test_use_default_azure_credentials(self):
+        config = AttributeDict({
+            'region': 'region-from-config',
+            'storage_provider': 'azure_blobs',
+            'bucket_name': 'bucket-from-config',
+            'concurrent_transfers': '1',
+            'host': None,
+            'port': None,
+            'read_timeout': 60,
+            'key_file': None,
+        })
+        os.environ['AZURE_STORAGE_ACCOUNT'] = 'testAccount'
+        azure_storage = AzureStorage(config)
+        self.assertTrue(isinstance(azure_storage.credentials, DefaultAzureCredential))
+        # we need the account name for making the connection url
+        self.assertEqual(
+            'https://testAccount.blob.core.windows.net/',
+            azure_storage.azure_blob_service_url
+        )


### PR DESCRIPTION
Fixes #856.

According to preliminary testing, this kinda works:
```
export AZURE_STORAGE_ACCOUNT=medusaintegrationtests
medusa -v --config-file medusa.ini list-backups
[2025-02-17 11:40:20,383] DEBUG: Loading configuration from medusa.ini
[2025-02-17 11:40:20,391] INFO: Resolving ip address
[2025-02-17 11:40:20,397] INFO: ip address to resolve 10.3.0.4
[2025-02-17 11:40:20,398] DEBUG: Resolved 10.3.0.4 to azure-backup.internal.cloudapp.net
[2025-02-17 11:40:20,399] DEBUG: Loading storage_provider: azure_blobs
[2025-02-17 11:40:20,399] DEBUG: No credentials file specified, using DefaultAzureCredential
[2025-02-17 11:40:20,400] INFO: No environment configuration found.
[2025-02-17 11:40:20,401] INFO: ManagedIdentityCredential will use IMDS
[2025-02-17 11:40:20,404] DEBUG: [Storage] Listing objects in index/backup_index
[2025-02-17 11:40:20,404] DEBUG: Using selector: GeventSelector
[2025-02-17 11:40:20,417] DEBUG: EnvironmentCredential.get_token failed: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.
Visit https://aka.ms/azsdk/python/identity/environmentcredential/troubleshoot to troubleshoot this issue.
Traceback (most recent call last):
  File "/home/azureuser/.cache/pypoetry/virtualenvs/cassandra-medusa-gy6GO9U1-py3.12/lib/python3.12/site-packages/azure/identity/_internal/decorators.py", line 33, in wrapper
    token = fn(*args, **kwargs)
            ^^^^^^^^^^^^^^^^^^^
  File "/home/azureuser/.cache/pypoetry/virtualenvs/cassandra-medusa-gy6GO9U1-py3.12/lib/python3.12/site-packages/azure/identity/_credentials/environment.py", line 150, in get_token
    raise CredentialUnavailableError(message=message)
azure.identity._exceptions.CredentialUnavailableError: EnvironmentCredential authentication unavailable. Environment variables are not fully configured.
Visit https://aka.ms/azsdk/python/identity/environmentcredential/troubleshoot to troubleshoot this issue.
[2025-02-17 11:40:20,444] DEBUG: event={
    "data": {},
    "response": {
        "access_token": "********",
        "client_id": "1d97d72b-aa4d-47c3-8971-5c2618358c92",
        "expires_in": "85867",
        "expires_on": 1739878287,
        "ext_expires_in": "86399",
        "not_before": "1739791587",
        "resource": "https://storage.azure.com",
        "token_type": "Bearer"
    },
    "scope": [
        "https://storage.azure.com"
    ]
}
[2025-02-17 11:40:20,444] DEBUG: ImdsCredential.get_token succeeded
[2025-02-17 11:40:20,444] DEBUG: ManagedIdentityCredential.get_token succeeded
[2025-02-17 11:40:20,445] DEBUG: [Authenticated account] Client ID: 1d97d72b-aa4d-47c3-8971-5c2618358c92. Tenant ID: 2f49592e-1a6a-48f0-a3fe-d7c6e268b749. User Principal Name: unavailableUpn. Object ID (user): b982be5b-2f85-4750-ae3c-3ca2bae6111a
[2025-02-17 11:40:20,445] INFO: DefaultAzureCredential acquired a token from ManagedIdentityCredential
^CKeyboardInterrupt
2025-02-17T11:40:26Z
^CKeyboardInterrupt
2025-02-17T11:40:27Z
[2025-02-17 11:40:27,579] DEBUG: Disconnecting from Azure Storage

Aborted!
```
* we need the AZURE_STORAGE_ACCOUNT to be set
* there are errors and exceptions about some other variables missing, [see this](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/identity/azure-identity/TROUBLESHOOTING.md#troubleshoot-environmentcredential-authentication-issues)
* despite the warnings, the proper credentials type is chosen and an attempt to the storage systems seems to be made
* it gets stuck however, in a silent retry/backoff loop, because the instance does not have proper roles assigned to it.

I'm currently stuck on the role assignments.