### PR TITLE
Change how the Boto S3 client is created with default parameters

### DIFF
--- a/medusa/storage/s3_base_storage.py
+++ b/medusa/storage/s3_base_storage.py
@@ -142,11 +142,9 @@ class S3BaseStorage(AbstractStorage):
 
         boto_config = Config(
             region_name=self.credentials.region,
-            signature_version='v4',
             tcp_keepalive=True,
             max_pool_connections=max_pool_size,
-            read_timeout=self.read_timeout,
-            s3={'addressing_style': self.config.s3_addressing_style},
+            read_timeout=self.read_timeout
         )
         if self.credentials.access_key_id is not None:
             self.s3_client = boto3.client(

--- a/medusa/storage/s3_base_storage.py
+++ b/medusa/storage/s3_base_storage.py
@@ -144,7 +144,8 @@ class S3BaseStorage(AbstractStorage):
             region_name=self.credentials.region,
             tcp_keepalive=True,
             max_pool_connections=max_pool_size,
-            read_timeout=self.read_timeout
+            read_timeout=self.read_timeout,
+            s3={'addressing_style': self.config.s3_addressing_style},
         )
         if self.credentials.access_key_id is not None:
             self.s3_client = boto3.client(


### PR DESCRIPTION
I removed two lines to let the boto client use its default configuration values:

- `addressing_style = auto`
- `signature_version = s3v4`

This allows users to configure the client in the standard way, using environment variables or a configuration file.  
For more information how to configure with env or config, see the documentation: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-a-configuration-file

In my case, I need to use an older signature version because my company uses an outdated S3 server.

I'm sorry, I don't have a Python toolchain available to test this.
