### PR TITLE
Azure Storage and max_block_size with 4MB

### DIFF
--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -83,7 +83,7 @@ class AzureStorage(AbstractStorage):
         self.azure_blob_service = BlobServiceClient(
             account_url=self.azure_blob_service_url,
             credential=self.credentials,
-            max_block_size=20 * 1024 * 1024,        # 50k 20 MB chunks gives ~1 TB max file size
+            max_block_size=4 * 1024 * 1024,        # 50k 20 MB chunks gives ~1 TB max file size
         )
         self.azure_container_client = self.azure_blob_service.get_container_client(self.bucket_name)
 


### PR DESCRIPTION
Reduced the max_block_size from 20MB to 4MB to avoid being throttled by Azure when uploading the blog.

With 20MB it doesn't work, Azure drops the connections and don't upload anything.