### PR TITLE
Add configuration option for gRPC interface

### DIFF
--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -186,6 +186,9 @@ use_sudo_for_restore = True
 ; Allows to propagate the exceptions instead of exiting the program.
 ;enabled = False
 
+; Interface that service will listen.
+;interface = "[::]"
+
 ; if needed, change the port the grpc server listens to
 ;port = 50051
 

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -74,7 +74,8 @@ LoggingConfig = collections.namedtuple(
 
 GrpcConfig = collections.namedtuple(
     'GrpcConfig',
-    ['enabled', 'max_send_message_length', 'max_receive_message_length', 'port', 'ca_cert', 'tls_cert', 'tls_key']
+    ['enabled', 'max_send_message_length', 'max_receive_message_length', 'port', 'ca_cert', 'tls_cert', 'tls_key',
+     'interface']
 )
 
 KubernetesConfig = collections.namedtuple(
@@ -172,6 +173,7 @@ def _build_default_config():
         'enabled': 'False',
         'max_send_message_length': '536870912',
         'max_receive_message_length': '134217728',
+        'interface': '[::]',
         'port': f'{DEFAULT_GRPC_PORT}'
     }
 

--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -70,6 +70,7 @@ class Server:
         medusa_pb2_grpc.add_MedusaServicer_to_server(MedusaService(config), self.grpc_server)
         health_pb2_grpc.add_HealthServicer_to_server(grpc_health.v1.health.HealthServicer(), self.grpc_server)
 
+        grpc_interface = self.medusa_config.grpc.interface
         grpc_port = int(self.medusa_config.grpc.port)
         logging.info(f"Starting server. Listening on port {grpc_port}.")
 
@@ -84,9 +85,9 @@ class Server:
                 require_client_auth=True
             )
 
-            self.grpc_server.add_secure_port(f"[::]:{grpc_port}", server_credentials)
+            self.grpc_server.add_secure_port(f"{grpc_interface}:{grpc_port}", server_credentials)
         else:
-            self.grpc_server.add_insecure_port(f"[::]:{grpc_port}")
+            self.grpc_server.add_insecure_port(f"{grpc_interface}:{grpc_port}")
 
         await self.grpc_server.start()
 


### PR DESCRIPTION
I am using Medusa gRPC service in a non-conventional setup without kubernetes. It works fine, but there is one minor issue - by default it binds itself to `[::]` interface which is wide open to the whole network. In my case it would be better to limit it to a loopback interface (127.0.0.1), but that is not possible as the interface is hardcoded. This patch adds an option to specify interface in a configuration file.

All tests pass, but I did not add a unit test to tests non-default interface. I could potentially add a case with `interface` set to something like `127.0.0.2` if this is desired.