### PR TITLE
Fix for k8s environments without PTR records

### DIFF
--- a/medusa/config.py
+++ b/medusa/config.py
@@ -246,8 +246,19 @@ def _handle_k8s_and_grpc_settings(config, args):
             logging.warning('Forcing use_sudo to False because Kubernetes mode is enabled')
         config['cassandra']['use_sudo'] = 'False'
         config['storage']['use_sudo_for_restore'] = 'False'
-        if "POD_IP" in os.environ:
+        # For StatefulSets, prefer stable HOSTNAME over POD_IP
+        # HOSTNAME provides a stable identifier (e.g., "cassandra-sts-0")
+        # whereas POD_IP can change when pods are rescheduled
+        if "HOSTNAME" in os.environ:
+            config['storage']['fqdn'] = os.environ["HOSTNAME"]
+            logging.debug(f'Using HOSTNAME from environment: {os.environ["HOSTNAME"]}')
+        elif "POD_IP" in os.environ:
+            # Fallback to POD_IP for backwards compatibility or non-StatefulSet deployments
             config['storage']['fqdn'] = os.environ["POD_IP"]
+            logging.warning(
+                f'Using POD_IP ({os.environ["POD_IP"]}) as FQDN. For StatefulSets, '
+                'consider using HOSTNAME for stable backup paths across pod restarts.'
+            )
 
 
 def _handle_env_vars(config):

--- a/medusa/network/hostname_resolver.py
+++ b/medusa/network/hostname_resolver.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dns.exception
 import dns.resolver
 import dns.reversename
 import ipaddress
@@ -52,12 +53,16 @@ class HostnameResolver:
 
     def compute_k8s_hostname(self, ip_address):
         if (self.is_ipv4(ip_address) or self.is_ipv6(ip_address)):
-            reverse_name = dns.reversename.from_address(ip_address).to_text()
-            fqdns = dns.resolver.resolve(reverse_name, 'PTR')
-            for fqdn in fqdns:
-                if not self.is_ipv4(fqdn.to_text().split('.')[0].replace('-', '.')) \
-                   and not self.is_ipv6(fqdn.to_text().split('.')[0].replace('-', ':')):
-                    return fqdn.to_text().split('.')[0]
+            try:
+                reverse_name = dns.reversename.from_address(ip_address).to_text()
+                fqdns = dns.resolver.resolve(reverse_name, 'PTR')
+                for fqdn in fqdns:
+                    if not self.is_ipv4(fqdn.to_text().split('.')[0].replace('-', '.')) \
+                       and not self.is_ipv6(fqdn.to_text().split('.')[0].replace('-', ':')):
+                        return fqdn.to_text().split('.')[0]
+            except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer,
+                    dns.resolver.Timeout, dns.exception.DNSException) as e:
+                logging.debug(f"Failed to resolve PTR record for {ip_address}: {e}. Falling back to IP address.")
 
         return ip_address
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -229,6 +229,29 @@ class ConfigTest(unittest.TestCase):
         config = medusa.config.parse_config(args, self.medusa_config_file)
         assert config['storage']['fqdn'] == socket.gethostbyname(socket.getfqdn())
 
+    @patch.dict('os.environ', {'HOSTNAME': 'cassandra-1-dc1-default-sts-0', 'POD_IP': '127.0.0.1'})
+    def test_k8s_prefers_hostname_over_pod_ip(self):
+        """Ensure that HOSTNAME is preferred over POD_IP for StatefulSet stability"""
+        args = {
+            'k8s_enabled': 'True'
+        }
+        config = medusa.config.parse_config(args, self.medusa_config_file)
+        # Should use stable HOSTNAME, not POD_IP
+        assert config['storage']['fqdn'] == 'cassandra-1-dc1-default-sts-0'
+
+    @patch.dict('os.environ', {'POD_IP': '127.0.0.1'}, clear=False)
+    def test_k8s_uses_pod_ip_when_hostname_unavailable(self):
+        """Ensure that POD_IP is used as fallback when HOSTNAME is not set"""
+        # Remove HOSTNAME if it exists
+        import os
+        os.environ.pop('HOSTNAME', None)
+        args = {
+            'k8s_enabled': 'True'
+        }
+        config = medusa.config.parse_config(args, self.medusa_config_file)
+        # Should fallback to POD_IP
+        assert config['storage']['fqdn'] == '127.0.0.1'
+
     @patch('medusa.config.logging.error')
     def test_slash_in_bucket_name(self, mock_log_error):
         args = {

--- a/tests/network/hostname_resolver_test.py
+++ b/tests/network/hostname_resolver_test.py
@@ -15,6 +15,7 @@
 
 import unittest
 from unittest.mock import patch, MagicMock, Mock
+import dns.resolver
 
 from medusa.network.hostname_resolver import HostnameResolver
 
@@ -99,3 +100,71 @@ class HostnameResolverTest(unittest.TestCase):
             self.assertEqual(
                 mock_fqdn,
                 hostname_resolver.resolve_fqdn("127.0.0.1"))
+
+    def test_kubernetes_nxdomain_fallback(self):
+        """Test that NXDOMAIN exception is handled gracefully and falls back to IP address"""
+        with patch('medusa.network.hostname_resolver.socket') as mock_socket:
+            with patch('medusa.network.hostname_resolver.dns.resolver') as mock_resolver:
+                with patch('medusa.network.hostname_resolver.dns.reversename') as mock_reverser:
+                    mock_socket.getfqdn.return_value = mock_fqdn
+                    mock_resolver.NXDOMAIN = dns.resolver.NXDOMAIN
+                    mock_resolver.NoAnswer = dns.resolver.NoAnswer
+                    mock_resolver.Timeout = dns.resolver.Timeout
+                    mock_resolver.resolve.side_effect = dns.resolver.NXDOMAIN()
+                    mock_reverser.from_address.return_value = mock_reverse
+                    hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
+                    # When PTR record doesn't exist, should fall back to IP address
+                    self.assertEqual(
+                        "127.0.0.1",
+                        hostname_resolver.resolve_fqdn("127.0.0.1"))
+
+    def test_kubernetes_no_answer_fallback(self):
+        """Test that NoAnswer exception is handled gracefully and falls back to IP address"""
+        with patch('medusa.network.hostname_resolver.socket') as mock_socket:
+            with patch('medusa.network.hostname_resolver.dns.resolver') as mock_resolver:
+                with patch('medusa.network.hostname_resolver.dns.reversename') as mock_reverser:
+                    mock_socket.getfqdn.return_value = mock_fqdn
+                    mock_resolver.NXDOMAIN = dns.resolver.NXDOMAIN
+                    mock_resolver.NoAnswer = dns.resolver.NoAnswer
+                    mock_resolver.Timeout = dns.resolver.Timeout
+                    mock_resolver.resolve.side_effect = dns.resolver.NoAnswer()
+                    mock_reverser.from_address.return_value = mock_reverse
+                    hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
+                    # When DNS query has no answer, should fall back to IP address
+                    self.assertEqual(
+                        "127.0.0.1",
+                        hostname_resolver.resolve_fqdn("127.0.0.1"))
+
+    def test_kubernetes_timeout_fallback(self):
+        """Test that Timeout exception is handled gracefully and falls back to IP address"""
+        with patch('medusa.network.hostname_resolver.socket') as mock_socket:
+            with patch('medusa.network.hostname_resolver.dns.resolver') as mock_resolver:
+                with patch('medusa.network.hostname_resolver.dns.reversename') as mock_reverser:
+                    mock_socket.getfqdn.return_value = mock_fqdn
+                    mock_resolver.NXDOMAIN = dns.resolver.NXDOMAIN
+                    mock_resolver.NoAnswer = dns.resolver.NoAnswer
+                    mock_resolver.Timeout = dns.resolver.Timeout
+                    mock_resolver.resolve.side_effect = dns.resolver.Timeout()
+                    mock_reverser.from_address.return_value = mock_reverse
+                    hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
+                    # When DNS query times out, should fall back to IP address
+                    self.assertEqual(
+                        "127.0.0.1",
+                        hostname_resolver.resolve_fqdn("127.0.0.1"))
+
+    def test_kubernetes_hostname_skips_ptr_lookup(self):
+        """Test that non-IP hostnames skip PTR lookups in k8s mode"""
+        with patch('medusa.network.hostname_resolver.socket') as mock_socket:
+            with patch('medusa.network.hostname_resolver.dns.resolver') as mock_resolver:
+                # Set up hostname (not an IP)
+                test_hostname = "cassandra-1-dc1-default-sts-0"
+                mock_socket.getfqdn.return_value = test_hostname
+                hostname_resolver = HostnameResolver(resolve_addresses=True, k8s_mode=True)
+
+                # Should return hostname without attempting PTR lookup
+                result = hostname_resolver.resolve_fqdn(test_hostname)
+
+                # dns.resolver.resolve should never be called for non-IP hostnames
+                mock_resolver.resolve.assert_not_called()
+                # Result should be the original hostname
+                self.assertEqual(test_hostname, result)


### PR DESCRIPTION
Problem:
  When Medusa runs in Kubernetes mode, it performs reverse DNS (PTR) lookups
  on IP addresses to resolve pod hostnames. In environments where PTR records
  don't exist, this causes dns.resolver.NXDOMAIN exceptions that crash the
  application on startup. Additionally, using POD_IP for StatefulSet pods
  creates unstable backup paths that break when pods are rescheduled with
  new IP addresses.

  Solution:
  1. Prefer HOSTNAME over POD_IP in Kubernetes mode (config.py)
     - HOSTNAME provides stable pod names (e.g., "cassandra-sts-0") for
       StatefulSets, ensuring backup paths remain consistent across pod
       restarts
     - Falls back to POD_IP for backwards compatibility with non-StatefulSet
       deployments
     - Adds warning when POD_IP is used to guide users toward HOSTNAME

  2. Add graceful exception handling for PTR lookup failures
     (hostname_resolver.py)
     - Catches dns.resolver.NXDOMAIN, NoAnswer, Timeout, and DNSException
     - Falls back to using IP address when PTR records are unavailable
     - Logs debug message explaining the fallback behavior

  3. Add comprehensive test coverage (tests/)
     - test_k8s_prefers_hostname_over_pod_ip: Verifies HOSTNAME priority
     - test_k8s_uses_pod_ip_when_hostname_unavailable: Verifies fallback
     - test_kubernetes_nxdomain_fallback: Verifies NXDOMAIN handling
     - test_kubernetes_no_answer_fallback: Verifies NoAnswer handling
     - test_kubernetes_timeout_fallback: Verifies Timeout handling
     - test_kubernetes_hostname_skips_ptr_lookup: Verifies non-IP hostnames
       skip PTR lookups entirely

  Impact:
  - Eliminates crash-loops in Kubernetes environments without PTR records
  - Provides stable backup paths for StatefulSet pods (survives pod restarts)
  - Maintains backwards compatibility with existing deployments
  - Non-IP hostnames (from HOSTNAME) skip PTR lookups entirely, improving
    startup performance and reliability

  Fixes issue where Medusa would fail with:
    dns.resolver.NXDOMAIN: The DNS query name does not exist: X.X.X.X.in-addr.arpa.