### PR TITLE
Fix tenacity wait_fixed values still in milliseconds for S3 and Azure

### DIFF
--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -233,7 +233,7 @@ class AzureStorage(AbstractStorage):
         )
         return await downloader.readall()
 
-    @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5000))
+    @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5))
     async def _delete_object(self, obj: AbstractBlob):
         await self.azure_container_client.delete_blob(obj.name, delete_snapshots='include')
 

--- a/medusa/storage/s3_base_storage.py
+++ b/medusa/storage/s3_base_storage.py
@@ -267,7 +267,7 @@ class S3BaseStorage(AbstractStorage):
 
         return blobs
 
-    @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5000))
+    @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5))
     async def _upload_object(self, data: io.BytesIO, object_key: str, headers: t.Dict[str, str]) -> AbstractBlob:
 
         extra_args = {}
@@ -304,7 +304,7 @@ class S3BaseStorage(AbstractStorage):
         blob = await self._stat_blob(object_key)
         return blob
 
-    @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5000))
+    @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5))
     async def _download_blob(self, src: str, dest: str):
         # boto has a connection pool, but it does not support the asyncio API
         # so we make things ugly and submit the whole download as a task to an executor
@@ -376,7 +376,7 @@ class S3BaseStorage(AbstractStorage):
         item_hash = resp['ETag'].replace('"', '')
         return AbstractBlob(key, int(resp['ContentLength']), item_hash, resp['LastModified'], None)
 
-    @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5000))
+    @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5))
     async def _upload_blob(self, src: str, dest: str) -> ManifestObject:
         src_path = Path(src)
 
@@ -444,7 +444,7 @@ class S3BaseStorage(AbstractStorage):
 
         return self.s3_client.get_object(Bucket=self.bucket_name, Key=blob.name, **extra_args)['Body'].read()
 
-    @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5000))
+    @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5))
     async def _delete_object(self, obj: AbstractBlob):
         self.s3_client.delete_object(
             Bucket=self.bucket_name,


### PR DESCRIPTION
## Summary

#896 switched from `retrying` (ms units) to `tenacity` (seconds units) but missed converting `wait_fixed(5000)` in `s3_base_storage.py` (4 decorators) and `azure_storage._delete_object` (1 decorator). These retries would wait ~83 minutes between attempts instead of 5 seconds.

## Changes

- `medusa/storage/s3_base_storage.py`: fix `wait_fixed(5000)` → `wait_fixed(5)` on `_upload_object`, `_download_blob`, `_upload_blob`, `_delete_object`
- `medusa/storage/azure_storage.py`: fix `wait_fixed(5000)` → `wait_fixed(5)` on `_delete_object`