### PR TITLE
medusa-example.ini: add reference to nodetool_executable

### DIFF
--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -28,6 +28,7 @@
 ;nodetool_k8s_secrets_path = <path to nodetool kubernetes secrets folder>
 ;nodetool_host = <host name or IP to use for nodetool>
 ;nodetool_port = <port number to use for nodetool>
+;nodetool_executable = <path to the nodetool binary if not in PATH>
 ;certfile= <Client SSL: path to rootCa certificate>
 ;usercert= <Client SSL: path to user certificate>
 ;userkey= <Client SSL: path to user key>


### PR DESCRIPTION
The configuration option `nodetool_executable` (under section `[cassandra]`), defined [here](https://github.com/thelastpickle/cassandra-medusa/blob/c5517e6c5d34f2aeac7b25eab19bd15034d2879d/medusa/config.py#L144) in the config code and used [here](https://github.com/thelastpickle/cassandra-medusa/blob/c5517e6c5d34f2aeac7b25eab19bd15034d2879d/medusa/nodetool.py#L20) to select the binary to use for nodetool, is not appearing anywhere that I found in the documentation or the sample configuration file.

This PR simply adds a commented-out line in the sample configuration file to document this option.