### PR TITLE
Fix Azure upload seek error by passing AsyncIterable to upload_blob

### DIFF
--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -22,6 +22,7 @@ import logging
 import os
 import pathlib
 import typing as t
+
 import aiofiles
 
 from azure.core.credentials import AzureNamedKeyCredential
@@ -191,6 +192,12 @@ class AzureStorage(AbstractStorage):
             blob_properties.blob_tier
         )
 
+    @staticmethod
+    async def _file_chunks(path: str, chunk_size: int = 4 * 1024 * 1024) -> t.AsyncIterator[bytes]:
+        async with aiofiles.open(path, "rb") as f:
+            while chunk := await f.read(chunk_size):
+                yield chunk
+
     @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5))
     async def _upload_blob(self, src: str, dest: str) -> ManifestObject:
         src_path = Path(src)
@@ -205,14 +212,14 @@ class AzureStorage(AbstractStorage):
             )
         )
         storage_class = self.get_storage_class()
-        async with aiofiles.open(src, "rb") as data:
-            blob_client = await self.azure_container_client.upload_blob(
-                name=object_key,
-                data=data,
-                overwrite=True,
-                max_concurrency=16,
-                standard_blob_tier=StandardBlobTier(storage_class.capitalize()) if storage_class else None,
-            )
+        blob_client = await self.azure_container_client.upload_blob(
+            name=object_key,
+            data=self._file_chunks(src),
+            length=file_size,
+            overwrite=True,
+            max_concurrency=16,
+            standard_blob_tier=StandardBlobTier(storage_class.capitalize()) if storage_class else None,
+        )
         blob_properties = await blob_client.get_blob_properties()
         mo = ManifestObject(
             blob_properties.name,

--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -195,7 +195,10 @@ class AzureStorage(AbstractStorage):
     @staticmethod
     async def _file_chunks(path: str, chunk_size: int = 4 * 1024 * 1024) -> t.AsyncIterator[bytes]:
         async with aiofiles.open(path, "rb") as f:
-            while chunk := await f.read(chunk_size):
+            while True:
+                chunk = await f.read(chunk_size)
+                if not chunk:
+                    break
                 yield chunk
 
     @retry(stop=stop_after_attempt(MAX_UP_DOWN_LOAD_RETRIES), wait=wait_fixed(5))


### PR DESCRIPTION
## Summary

Fixes #891

The Azure Storage Blob SDK calls `.seek()` synchronously on the `data` object passed to `upload_blob()`. When an `aiofiles` file handle is passed directly, `.seek()` returns an unawaited coroutine instead of actually seeking — causing silent failures, PutBlock errors, and upload instability under high concurrency (especially with large block sizes).

This was introduced in #875 (SonarCloud improvement) which replaced a working `with open(src, "rb")` with `async with aiofiles.open(src, "rb")` to satisfy a blocking-I/O lint warning, without realising the Azure SDK requires synchronous seek semantics on the data object.

## Fix

Introduces a `_file_chunks` async generator that yields 4 MB chunks (matching `max_block_size`):

```python
@staticmethod
async def _file_chunks(path: str, chunk_size: int = 4 * 1024 * 1024) -> t.AsyncIterator[bytes]:
    async with aiofiles.open(path, "rb") as f:
        while chunk := await f.read(chunk_size):
            yield chunk
```

The SDK wraps `AsyncIterable` inputs in `AsyncIterStreamer`, which explicitly sets `seekable() = False`. This routes the upload through `upload_data_chunks` — a code path that calls only `stream.read()` (which it correctly `await`s via `inspect.isawaitable`) and **never calls `.seek()`**.

The `length` parameter is also passed so the SDK knows the total file size upfront without needing to seek.

## Why this works (SDK internals traced)

In `_upload_blob_options` (`_blob_client.py`):
- `hasattr(data, '__aiter__')` → wraps in `AsyncIterStreamer`

In `upload_block_blob` (`aio/_upload_helpers.py`, line 106):
```python
use_original_upload_path = ... or \
    hasattr(stream, 'seekable') and not stream.seekable() or ...
```
`AsyncIterStreamer.seekable()` returns `False` → `use_original_upload_path = True` → routes to `upload_data_chunks`, not `upload_substream_blocks`. `SubStream` (the class that calls `.seek()` in the original issue) is only instantiated in `upload_substream_blocks` and is never reached.

In `get_chunk_streams()` (`_shared/uploads_async.py`, line 191):
```python
temp = self.stream.read(read_size)
if inspect.isawaitable(temp):
    temp = await temp  # correctly awaits AsyncIterStreamer.read()
```