### PR TITLE
Fix backup summary node accounting for unexpected node backups

### DIFF
--- a/medusa/storage/cluster_backup.py
+++ b/medusa/storage/cluster_backup.py
@@ -43,8 +43,8 @@ class ClusterBackup(object):
         if any(self.missing_nodes()):
             return None
 
-        finished_timestamps = list(map(operator.attrgetter('finished'), self.node_backups.values()))
-        if all(finished_timestamps):
+        finished_timestamps = list(map(operator.attrgetter('finished'), self.expected_node_backups()))
+        if finished_timestamps and all(finished_timestamps):
             return max(finished_timestamps)
         else:
             return None
@@ -66,19 +66,26 @@ class ClusterBackup(object):
         return "differential" if self._first_nodebackup.is_differential else "full"
 
     def is_complete(self):
-        return not self.missing_nodes() and all(map(operator.attrgetter('finished'), self.node_backups.values()))
+        expected_node_backups = self.expected_node_backups()
+        return not self.missing_nodes() and bool(expected_node_backups) \
+            and all(map(operator.attrgetter('finished'), expected_node_backups))
 
     def missing_nodes(self):
         return set(self.tokenmap.keys()) - set(self.node_backups.keys())
 
+    def expected_node_backups(self):
+        return [self.node_backups[fqdn]
+                for fqdn in self.tokenmap
+                if fqdn in self.node_backups]
+
     def complete_nodes(self):
         return [node_backup
-                for node_backup in self.node_backups.values()
+                for node_backup in self.expected_node_backups()
                 if node_backup.finished]
 
     def incomplete_nodes(self):
         return [node_backup
-                for node_backup in self.node_backups.values()
+                for node_backup in self.expected_node_backups()
                 if node_backup.finished is None]
 
     def size(self):

--- a/tests/service/grpc/backup_summary_test.py
+++ b/tests/service/grpc/backup_summary_test.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+from unittest.mock import Mock
+
+from medusa.service.grpc import medusa_pb2
+from medusa.service.grpc.server import get_backup_summary
+from medusa.storage import ClusterBackup
+
+
+def make_node_backup(fqdn, finished, tokenmap):
+    node_backup = Mock()
+    node_backup.fqdn = fqdn
+    node_backup.started = 1
+    node_backup.finished = finished
+    node_backup.tokenmap = json.dumps(tokenmap)
+    node_backup.schema = ''
+    node_backup.is_differential = True
+    node_backup.size.return_value = 1
+    node_backup.num_objects.return_value = 1
+    return node_backup
+
+
+def test_summary_ignores_unexpected_incomplete_node_backup():
+    tokenmap = {
+        'node1': {'tokens': [1], 'rack': 'rack1', 'dc': 'dc1'},
+        'node2': {'tokens': [2], 'rack': 'rack1', 'dc': 'dc1'},
+    }
+    backup = ClusterBackup('backup1', [
+        make_node_backup('node1', 10, tokenmap),
+        make_node_backup('node2', 11, tokenmap),
+        make_node_backup('old-node', None, tokenmap),
+    ])
+
+    summary = get_backup_summary(backup)
+
+    assert summary.status == medusa_pb2.StatusType.SUCCESS
+    assert summary.finishTime == 11
+    assert summary.totalNodes == 2
+    assert summary.finishedNodes == 2
+
+
+def test_summary_does_not_count_unexpected_node_as_missing_node():
+    tokenmap = {
+        'node1': {'tokens': [1], 'rack': 'rack1', 'dc': 'dc1'},
+        'node2': {'tokens': [2], 'rack': 'rack1', 'dc': 'dc1'},
+        'node3': {'tokens': [3], 'rack': 'rack1', 'dc': 'dc1'},
+    }
+    backup = ClusterBackup('backup1', [
+        make_node_backup('node1', 10, tokenmap),
+        make_node_backup('node2', 11, tokenmap),
+        make_node_backup('replacement-node', 12, tokenmap),
+    ])
+
+    summary = get_backup_summary(backup)
+
+    assert summary.status == medusa_pb2.StatusType.IN_PROGRESS
+    assert summary.finishTime == 0
+    assert summary.totalNodes == 3
+    assert summary.finishedNodes == 2


### PR DESCRIPTION
## What changed

Use the backup token map as the source of expected cluster nodes.

`ClusterBackup.finished`, `is_complete()`, `complete_nodes()`, and `incomplete_nodes()` now ignore node backup records that are not present in the token map.

This prevents two inconsistent cases:

- an old incomplete node backup keeps the status `IN_PROGRESS` even though all expected nodes finished;
- an unrelated finished node backup increases `finishedNodes` while an expected node is missing.

Regression tests cover both scenarios.

## Why

`BackupSummary.totalNodes` was calculated from the token map, while `finishedNodes` and `backup.finished` considered all stored node backup records. This could produce summaries such as:

    totalNodes: 3
    finishedNodes: 3
    status: IN_PROGRESS

After this change, completion status and node counters are calculated from the same expected node set.

Fixes #965

## Testing

- New backup summary tests: 2 passed
- Related gRPC, listing, and status tests: 19 passed
- Flake8 passed
- `git diff --check` passed