### PR TITLE
Fix GetBackups error response status field

### DIFF
--- a/medusa/service/grpc/server.py
+++ b/medusa/service/grpc/server.py
@@ -273,7 +273,7 @@ class MedusaService(medusa_pb2_grpc.MedusaServicer):
         except Exception as e:
             context.set_details("Failed to get backups due to error: {}".format(e))
             context.set_code(grpc.StatusCode.INTERNAL)
-            response.status = medusa_pb2.StatusType.UNKNOWN
+            response.overallStatus = medusa_pb2.StatusType.UNKNOWN
         return response
 
     def DeleteBackup(self, request, context):

--- a/tests/service/grpc/server_test.py
+++ b/tests/service/grpc/server_test.py
@@ -88,6 +88,21 @@ class ServerTest(unittest.TestCase):
         # but at least the status of the response and the status of the backup match
         self.assertEqual(get_backup_response.status, get_backup_response.backup.status)
 
+    def test_get_backups_failure_sets_overall_status(self):
+        medusa_config = self._make_config()
+        service = MedusaService(medusa_config)
+
+        request = medusa_pb2.GetBackupsRequest()
+        context = Mock(spec=ServicerContext)
+
+        with patch('medusa.service.grpc.server.get_backups', side_effect=Exception('storage failure')):
+            get_backups_response = service.GetBackups(request, context)
+
+        response_fields = {field.name for field in get_backups_response.DESCRIPTOR.fields}
+        self.assertEqual({'backups', 'overallStatus'}, response_fields)
+        self.assertEqual([], get_backups_response.backups)
+        self.assertEqual(medusa_pb2.StatusType.UNKNOWN, get_backups_response.overallStatus)
+
     def test_get_known_incomplete_backup(self):
         # start the Medusa service
         medusa_config = self._make_config()


### PR DESCRIPTION
## Summary

Fixes #818.

This updates the `GetBackups` error path to set `overallStatus` instead of `status` on `GetBackupsResponse`. The protobuf response message does not define a `status` field, so the previous error handling could raise an `AttributeError` while trying to handle the original failure.

## Changes

- Set `response.overallStatus` to `UNKNOWN` when `GetBackups` fails.
- Add a regression test for the `GetBackups` failure path.

## Testing

- `compile()` syntax check for `medusa/service/grpc/server.py` and `tests/service/grpc/server_test.py`
- `git diff --check`
