### PR TITLE
Fix verify and purge: zero-byte SSTable components and multipart ETag crash

### DIFF
--- a/medusa/medusacli.py
+++ b/medusa/medusacli.py
@@ -320,7 +320,11 @@ def verify(medusaconfig, backup_name, enable_md5_checks):
     """
     Verify the integrity of a backup
     """
-    medusa.verify.verify(medusaconfig, backup_name, enable_md5_checks)
+    try:
+        medusa.verify.verify(medusaconfig, backup_name, enable_md5_checks)
+    except RuntimeError as e:
+        logging.error(str(e))
+        sys.exit(1)
 
 
 @cli.command(name='report-last-backup')

--- a/medusa/storage/abstract_storage.py
+++ b/medusa/storage/abstract_storage.py
@@ -71,11 +71,11 @@ class AbstractStorage(abc.ABC):
         # List objects in the bucket/container that have the corresponding prefix (emtpy means all objects)
         logging.debug("[Storage] Listing objects in {}".format(path if path is not None else 'everywhere'))
 
-        objects = self.list_blobs(prefix=path)
-
-        objects = list(filter(lambda blob: blob.size > 0, objects))
-
-        return objects
+        # Not filtering by size: some SSTable components are legitimately 0 bytes by design
+        # (e.g. BTI's Rows.db when partitions don't need a row index, see BtiFormat.md), and
+        # manifest validation needs to see them. Azure's hierarchical-namespace directory
+        # placeholders are excluded in AzureStorage._list_blobs instead.
+        return self.list_blobs(prefix=path)
 
     @retry(stop=stop_after_attempt(7), wait=wait_exponential(multiplier=10, max=120))
     def list_blobs(self, prefix=None):

--- a/medusa/storage/azure_storage.py
+++ b/medusa/storage/azure_storage.py
@@ -101,8 +101,14 @@ class AzureStorage(AbstractStorage):
         blobs = []
         async for b_props in self.azure_container_client.list_blobs(
                 name_starts_with=str(prefix),
+                include=['metadata'],
                 timeout=self.read_timeout
         ):
+            # Directory placeholder blobs (hierarchical namespace accounts, tools like rclone)
+            # are 0-byte blobs tagged with this metadata key. They aren't real SSTable content
+            # and would otherwise show up as spurious entries in listings. See #595.
+            if (b_props.metadata or {}).get('hdi_isfolder', '').lower() == 'true':
+                continue
             blobs.append(AbstractBlob(
                 b_props.name,
                 b_props.size,

--- a/medusa/storage/s3_base_storage.py
+++ b/medusa/storage/s3_base_storage.py
@@ -538,7 +538,9 @@ class S3BaseStorage(AbstractStorage):
         else:
             threshold = int(threshold)
 
-        if actual_size >= threshold > 0 or "-" in hash_in_manifest:
+        # a dash in an S3 ETag is only ever produced by a multipart upload, so it's a reliable
+        # signal regardless of what the manifest recorded or what threshold is configured now
+        if actual_size >= threshold > 0 or "-" in hash_in_manifest or "-" in actual_hash:
             multipart = True
         else:
             multipart = False

--- a/tests/storage/azure_storage_test.py
+++ b/tests/storage/azure_storage_test.py
@@ -5,6 +5,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import os
 import tempfile
 import unittest
@@ -107,3 +108,50 @@ class AzureStorageTest(unittest.TestCase):
             'https://testAccount.blob.core.windows.net/',
             azure_storage.azure_blob_service_url
         )
+
+    def test_list_blobs_skips_directory_placeholders(self):
+        with tempfile.NamedTemporaryFile() as credentials_file:
+            credentials_file.write(self.credentials_file_content.encode())
+            credentials_file.flush()
+            config = AttributeDict({
+                'region': 'region-from-config',
+                'storage_provider': 'azure_blobs',
+                'key_file': credentials_file.name,
+                'bucket_name': 'bucket-from-config',
+                'concurrent_transfers': '1',
+                'host': None,
+                'port': None,
+                'read_timeout': 60,
+            })
+            azure_storage = AzureStorage(config)
+            azure_storage.connect()
+
+            async def fake_list_blobs(name_starts_with=None, include=None, timeout=None):
+                for props in (
+                    # ADLS Gen2 / hierarchical-namespace directory marker: must be skipped
+                    AttributeDict({
+                        'name': 'some/dir/',
+                        'size': 0,
+                        'etag': 'etag1',
+                        'last_modified': None,
+                        'blob_tier': None,
+                        'metadata': {'hdi_isfolder': 'true'},
+                    }),
+                    # legitimately empty SSTable component (e.g. BTI Rows.db): must be kept
+                    AttributeDict({
+                        'name': 'some/dir/da-1-bti-Rows.db',
+                        'size': 0,
+                        'etag': 'etag2',
+                        'last_modified': None,
+                        'blob_tier': None,
+                        'metadata': {},
+                    }),
+                ):
+                    yield props
+
+            azure_storage.azure_container_client.list_blobs = fake_list_blobs
+
+            blobs = asyncio.run(azure_storage._list_blobs())
+
+            self.assertEqual(1, len(blobs))
+            self.assertEqual('some/dir/da-1-bti-Rows.db', blobs[0].name)

--- a/tests/storage/azure_storage_test.py
+++ b/tests/storage/azure_storage_test.py
@@ -126,7 +126,7 @@ class AzureStorageTest(unittest.TestCase):
             azure_storage = AzureStorage(config)
             azure_storage.connect()
 
-            async def fake_list_blobs(name_starts_with=None, include=None, timeout=None):
+            async def fake_list_blobs(name_starts_with=None, include=None, **kwargs):
                 for props in (
                     # ADLS Gen2 / hierarchical-namespace directory marker: must be skipped
                     AttributeDict({

--- a/tests/storage/s3_storage_test.py
+++ b/tests/storage/s3_storage_test.py
@@ -511,7 +511,7 @@ class S3StorageTest(unittest.TestCase):
                     self.assertEqual('when_required', boto_config.response_checksum_validation)
 
     def test_compare_with_manifest_matches_single_part(self):
-        digest = hashlib.md5(b"some file content").digest()
+        digest = hashlib.md5(b"some file content", usedforsecurity=False).digest()
         actual_hash = digest.hex()
         hash_in_manifest = base64.encodebytes(digest).decode('UTF-8').strip()
 

--- a/tests/storage/s3_storage_test.py
+++ b/tests/storage/s3_storage_test.py
@@ -12,7 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import base64
 import datetime
+import hashlib
 import json
 import os
 import unittest
@@ -507,6 +509,35 @@ class S3StorageTest(unittest.TestCase):
                     boto_config = mock_client.call_args.kwargs['config']
                     self.assertEqual('when_required', boto_config.request_checksum_calculation)
                     self.assertEqual('when_required', boto_config.response_checksum_validation)
+
+    def test_compare_with_manifest_matches_single_part(self):
+        digest = hashlib.md5(b"some file content").digest()
+        actual_hash = digest.hex()
+        hash_in_manifest = base64.encodebytes(digest).decode('UTF-8').strip()
+
+        self.assertTrue(S3BaseStorage.compare_with_manifest(
+            actual_size=17,
+            size_in_manifest=17,
+            actual_hash=actual_hash,
+            hash_in_manifest=hash_in_manifest,
+        ))
+
+    def test_compare_with_manifest_real_multipart_etag_not_reflected_in_manifest(self):
+        # actual_hash is what verify sees live on S3: a real multipart ETag (dash present).
+        # hash_in_manifest has no dash, e.g. because it was recorded under mismatched
+        # threshold/chunksize settings at backup time. Detecting multipart-ness from
+        # hash_in_manifest alone used to crash trying to base64-decode actual_hash.
+        actual_hash = "d41d8cd98f00b204e9800998ecf8427e-4"
+        hash_in_manifest = "1B2M2Y8AsgTpgAmY7PhCfg=="
+
+        matches = S3BaseStorage.compare_with_manifest(
+            actual_size=100,
+            size_in_manifest=100,
+            actual_hash=actual_hash,
+            hash_in_manifest=hash_in_manifest,
+        )
+
+        self.assertFalse(matches)
 
 
 def _make_instance_metadata_mock():

--- a/tests/storage_test.py
+++ b/tests/storage_test.py
@@ -111,7 +111,7 @@ class StorageTest(unittest.TestCase):
         self.storage.storage_driver.upload_blob_from_string("test_download_blobs2/file2.txt", file2_content)
         self.storage.storage_driver.upload_blob_from_string("test_download_blobs3/file3.txt", file3_content)
         objects = self.storage.storage_driver.list_objects()
-        self.assertEqual(len(objects), 2)
+        self.assertEqual(len(objects), 3)
         one_object = self.storage.storage_driver.list_objects("test_download_blobs2")
         self.assertEqual(len(one_object), 1)
 

--- a/tests/storage_test_with_prefix.py
+++ b/tests/storage_test_with_prefix.py
@@ -98,7 +98,7 @@ class RestoreNodeTest(unittest.TestCase):
         self.storage.storage_driver.upload_blob_from_string("test_download_blobs2/file2.txt", file2_content)
         self.storage.storage_driver.upload_blob_from_string("test_download_blobs3/file3.txt", file3_content)
         objects = self.storage.storage_driver.list_objects()
-        self.assertEqual(len(objects), 2)
+        self.assertEqual(len(objects), 3)
         one_object = self.storage.storage_driver.list_objects("test_download_blobs2")
         self.assertEqual(len(one_object), 1)
 


### PR DESCRIPTION
1. verify false-fails on legitimately empty BTI SSTable components

```
- Manifest validation: Failed!
- [my_cluster/node1.example.internal/data/my_keyspace/my_table-<uuid>/da-27-bti-Rows.db] Doesn't exists
RuntimeError: Manifest validation failed
```

Cassandra 5's BTI format writes a 0-byte Rows.db when a table's partitions don't need a row index (narrow/partition-key-only tables: see [BtiFormat.md](https://github.com/apache/cassandra/blob/cassandra-5.0/src/java/org/apache/cassandra/io/sstable/format/bti/BtiFormat.md). The file is really in the bucket, but AbstractStorage.list_objects() silently drops every 0-byte object (a fix added in #597 to hide Azure directory markers), so verify can't see it and reports it missing. Same list_objects() call is used by purge, so 0-byte objects were also never
getting cleaned up there.

Fix (8929a8b): removes the size filter from list_objects(); moves the Azure directory exclusion into AzureStorage._list_blobs(), using the hdi_isfolder=true metadata Azure actually tags those with. 

In short applying an azure-only fix (that I can't test other than through pytest) as the general fix skipping 0-Bytes files has undesired side effects.

Fixes #861, Fixes #877. 
Reworked #597 fix.

2. verify --enable-md5-checks crashes on multipart S3 ETags

```
binascii.Error: Invalid base64-encoded string: number of data characters (33) cannot be 1 more than a multiple of 4
```

compare_with_manifest() only checks the manifest's recorded hash for a `-` to decide if an object is multipart, never the `actual_hash`, the real/current S3 ETag. If the manifest's hash doesn't have a dash but the live object actually is multipart, verify wrongly tries to base64-decode a raw hex ETag and crashes.

Fix (803f9cf): also check the live ETag for a dash regardless of what the manifest says. No existing upstream issue for this one, I am happy to submit an issue if useful.


Tests

* New/updated coverage in:
* tests/storage/azure_storage_test.py,
* tests/storage/s3_storage_test.py,
* tests/storage_test.py, 
* tests/storage_test_with_prefix.py

Including a test that reproduces the exact crash above on the pre-fix code and passes cleanly after (regression test).
