### PR TITLE
Parallelize MD5 checksum comparison and add debug progress logging

### DIFF
--- a/medusa-example.ini
+++ b/medusa-example.ini
@@ -178,6 +178,14 @@ use_sudo_for_restore = True
 ;expected_result = <Coma separated string representation of values returned by the query. Checks only 1st row returned, and only if specified>
 ;enable_md5_checks = <During backups and verify, use md5 calculations to determine file integrity (in addition to size, which is used by default)>
 
+; When enable_md5_checks is on, number of files hashed in parallel while comparing local files
+; against the manifest in differential backups. This is local CPU-bound work (not network) - on
+; SSD/NVMe the disk is not the bottleneck, each concurrent thread will roughly max out a CPU
+; core. Medusa often runs on the same node as Cassandra, so this defaults to 1 (no parallelism)
+; to avoid stealing cores from the database; raise it deliberately if you have cores to spare and
+; want faster differential backups.
+;md5_check_concurrency = 1
+
 
 [logging]
 ; Controls file logging, disabled by default.

--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import concurrent.futures
 import datetime
 import json
 import logging
@@ -180,8 +181,11 @@ def start_backup(storage, node_backup, cassandra, differential_mode, stagger_tim
     # Perform the actual backup
     actual_start = datetime.datetime.now()
     enable_md5 = enable_md5_checks_flag or medusa.utils.evaluate_boolean(config.checks.enable_md5_checks)
+    configured_md5_check_concurrency = int(config.checks.md5_check_concurrency or 0)
+    md5_check_concurrency = max(configured_md5_check_concurrency, 1)
     num_files, num_replaced, num_kept = do_backup(
-        cassandra, node_backup, storage, enable_md5, backup_name, keep_snapshot, use_existing_snapshot
+        cassandra, node_backup, storage, enable_md5, md5_check_concurrency, backup_name, keep_snapshot,
+        use_existing_snapshot
     )
     end = datetime.datetime.now()
     actual_backup_duration = end - actual_start
@@ -218,8 +222,8 @@ def get_server_type_and_version(cassandra):
     return server_type, release_version
 
 
-def do_backup(cassandra, node_backup, storage, enable_md5_checks, backup_name, keep_snapshot=False,
-              use_existing_snapshot=False):
+def do_backup(cassandra, node_backup, storage, enable_md5_checks, md5_check_concurrency, backup_name,
+              keep_snapshot=False, use_existing_snapshot=False):
 
     if use_existing_snapshot:
         logging.debug('Skipping snapshot creation')
@@ -235,14 +239,14 @@ def do_backup(cassandra, node_backup, storage, enable_md5_checks, backup_name, k
     with snapshot:
         manifest = []
         num_files, num_replaced, num_kept = backup_snapshots(
-            storage, manifest, node_backup, snapshot, enable_md5_checks
+            storage, manifest, node_backup, snapshot, enable_md5_checks, md5_check_concurrency
         )
 
     if node_backup.is_dse_6:
         logging.info('Creating DSE snapshot')
         with cassandra.create_dse_snapshot(backup_name) as snapshot:
             dse_num_files, dse_replaced, dse_kept = backup_snapshots(
-                storage, manifest, node_backup, snapshot, enable_md5_checks
+                storage, manifest, node_backup, snapshot, enable_md5_checks, md5_check_concurrency
             )
             num_files += dse_num_files
             num_replaced += dse_replaced
@@ -298,7 +302,7 @@ def update_monitoring(actual_backup_duration, backup_name, monitoring, node_back
     logging.debug('Done emitting metrics')
 
 
-def backup_snapshots(storage, manifest, node_backup, snapshot, enable_md5_checks):
+def backup_snapshots(storage, manifest, node_backup, snapshot, enable_md5_checks, md5_check_concurrency):
     try:
         num_files = 0
         replaced = 0
@@ -323,6 +327,7 @@ def backup_snapshots(storage, manifest, node_backup, snapshot, enable_md5_checks
                 multipart_threshold=multipart_threshold,
                 multipart_chunksize=multipart_chunksize,
                 enable_md5_checks=enable_md5_checks,
+                md5_check_concurrency=md5_check_concurrency,
                 keyspace=snapshot_path.keyspace,
                 srcs=list(snapshot_path.list_files()),
                 fqtn=fqtn)
@@ -371,6 +376,7 @@ def check_already_uploaded(
         multipart_threshold: int,
         multipart_chunksize: t.Optional[str],
         enable_md5_checks: bool,
+        md5_check_concurrency: int,
         files_in_storage: t.Dict[str, t.Dict[str, t.Dict[str, ManifestObject]]],
         keyspace: str,
         srcs: t.List[pathlib.Path],
@@ -389,31 +395,54 @@ def check_already_uploaded(
     keyspace_files_in_storage = files_in_storage.get(keyspace, {})
     storage_driver = storage.storage_driver
 
-    total = len(srcs)
-    logging.debug(f"Comparing {total} files against the manifest for {fqtn} (md5_checks={enable_md5_checks})")
-    start = time.monotonic()
-    progress_step = max(1, total // 20)
-
-    for i, src in enumerate(srcs, start=1):
+    # Files already present in storage need their local copy compared (size, or size+md5 when
+    # enable_md5_checks is on) against the manifest. That's local disk/CPU work with no network
+    # involved, so it's fanned out across threads rather than done one file at a time - with
+    # differential backups that serial loop was a barrier blocking every upload for the table.
+    to_compare = []
+    for src in srcs:
         if src.name in NEVER_BACKED_UP:
             continue
-
         # safe_table_name is either a table, or a "table.2i_name"
         _, safe_table_name = Storage.sanitize_keyspace_and_table_name(src)
         item_in_storage = keyspace_files_in_storage.get(safe_table_name, {}).get(src.name, None)
         # object is not in storage
         if item_in_storage is None:
             needs_backup.append(src)
-        # object is in storage but with different size or digest
-        elif not storage_driver.file_matches_storage(src, item_in_storage, multipart_threshold, enable_md5_checks,
-                                                       multipart_chunksize):
-            needs_reupload.append(src)
-        # object is in storage with correct size and digest
         else:
-            already_backed_up.append(item_in_storage)
+            to_compare.append((src, item_in_storage))
 
-        if i % progress_step == 0 or i == total:
-            logging.debug(f"Compared {i}/{total} files for {fqtn} ({time.monotonic() - start:.1f}s elapsed)")
+    if to_compare:
+        total = len(to_compare)
+        logging.debug(
+            f"Comparing {total} files against the manifest for {fqtn} "
+            f"(md5_checks={enable_md5_checks}, workers={md5_check_concurrency})"
+        )
+        start = time.monotonic()
+        completed = 0
+        progress_step = max(1, total // 20)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=md5_check_concurrency) as executor:
+            futures = {
+                executor.submit(
+                    storage_driver.file_matches_storage,
+                    src, item_in_storage, multipart_threshold, enable_md5_checks, multipart_chunksize
+                ): (src, item_in_storage)
+                for src, item_in_storage in to_compare
+            }
+            for future in concurrent.futures.as_completed(futures):
+                src, item_in_storage = futures[future]
+                if future.result():
+                    # object is in storage with correct size and digest
+                    already_backed_up.append(item_in_storage)
+                else:
+                    # object is in storage but with different size or digest
+                    needs_reupload.append(src)
+                completed += 1
+                if completed % progress_step == 0 or completed == total:
+                    logging.debug(
+                        f"Compared {completed}/{total} files for {fqtn} "
+                        f"({time.monotonic() - start:.1f}s elapsed)"
+                    )
 
     return needs_backup, needs_reupload, already_backed_up
 

--- a/medusa/backup_node.py
+++ b/medusa/backup_node.py
@@ -324,7 +324,8 @@ def backup_snapshots(storage, manifest, node_backup, snapshot, enable_md5_checks
                 multipart_chunksize=multipart_chunksize,
                 enable_md5_checks=enable_md5_checks,
                 keyspace=snapshot_path.keyspace,
-                srcs=list(snapshot_path.list_files()))
+                srcs=list(snapshot_path.list_files()),
+                fqtn=fqtn)
 
             replaced += len(needs_reupload)
             kept += len(already_backed_up)
@@ -372,7 +373,8 @@ def check_already_uploaded(
         enable_md5_checks: bool,
         files_in_storage: t.Dict[str, t.Dict[str, t.Dict[str, ManifestObject]]],
         keyspace: str,
-        srcs: t.List[pathlib.Path]
+        srcs: t.List[pathlib.Path],
+        fqtn: str
 ) -> tuple[t.List[pathlib.Path], t.List[pathlib.Path], t.List[ManifestObject]]:
 
     NEVER_BACKED_UP = ['manifest.json', 'schema.cql']
@@ -385,26 +387,33 @@ def check_already_uploaded(
         return [src for src in srcs if src.name not in NEVER_BACKED_UP], needs_reupload, already_backed_up
 
     keyspace_files_in_storage = files_in_storage.get(keyspace, {})
+    storage_driver = storage.storage_driver
 
-    for src in srcs:
+    total = len(srcs)
+    logging.debug(f"Comparing {total} files against the manifest for {fqtn} (md5_checks={enable_md5_checks})")
+    start = time.monotonic()
+    progress_step = max(1, total // 20)
+
+    for i, src in enumerate(srcs, start=1):
         if src.name in NEVER_BACKED_UP:
             continue
-        else:
-            # safe_table_name is either a table, or a "table.2i_name"
-            _, safe_table_name = Storage.sanitize_keyspace_and_table_name(src)
-            item_in_storage = keyspace_files_in_storage.get(safe_table_name, {}).get(src.name, None)
-            # object is not in storage
-            if item_in_storage is None:
-                needs_backup.append(src)
-                continue
-            # object is in storage but with different size or digest
-            storage_driver = storage.storage_driver
-            if not storage_driver.file_matches_storage(src, item_in_storage, multipart_threshold, enable_md5_checks,
+
+        # safe_table_name is either a table, or a "table.2i_name"
+        _, safe_table_name = Storage.sanitize_keyspace_and_table_name(src)
+        item_in_storage = keyspace_files_in_storage.get(safe_table_name, {}).get(src.name, None)
+        # object is not in storage
+        if item_in_storage is None:
+            needs_backup.append(src)
+        # object is in storage but with different size or digest
+        elif not storage_driver.file_matches_storage(src, item_in_storage, multipart_threshold, enable_md5_checks,
                                                        multipart_chunksize):
-                needs_reupload.append(src)
-                continue
-            # object is in storage with correct size and digest
+            needs_reupload.append(src)
+        # object is in storage with correct size and digest
+        else:
             already_backed_up.append(item_in_storage)
+
+        if i % progress_step == 0 or i == total:
+            logging.debug(f"Compared {i}/{total} files for {fqtn} ({time.monotonic() - start:.1f}s elapsed)")
 
     return needs_backup, needs_reupload, already_backed_up
 

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -52,7 +52,7 @@ SSHConfig = collections.namedtuple(
 
 ChecksConfig = collections.namedtuple(
     'ChecksConfig',
-    ['health_check', 'query', 'expected_rows', 'expected_result', 'enable_md5_checks']
+    ['health_check', 'query', 'expected_rows', 'expected_result', 'enable_md5_checks', 'md5_check_concurrency']
 )
 
 MonitoringConfig = collections.namedtuple(
@@ -162,7 +162,8 @@ def _build_default_config():
         'query': '',
         'expected_rows': '0',
         'expected_result': '',
-        'enable_md5_checks': 'false'
+        'enable_md5_checks': 'false',
+        'md5_check_concurrency': '1'
     }
 
     config['monitoring'] = {

--- a/tests/backup_node_test.py
+++ b/tests/backup_node_test.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 import os
 import pathlib
+import threading
+import time
 import unittest
 from concurrent.futures.thread import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
@@ -124,6 +126,7 @@ class BackupNodeTest(unittest.TestCase):
             multipart_threshold=100,
             multipart_chunksize=None,
             enable_md5_checks=False,
+            md5_check_concurrency=2,
             files_in_storage=files_in_storage,
             keyspace='keyspace1',
             srcs=table1_srcs,
@@ -148,6 +151,7 @@ class BackupNodeTest(unittest.TestCase):
             multipart_threshold=100,
             multipart_chunksize=None,
             enable_md5_checks=False,
+            md5_check_concurrency=2,
             files_in_storage=files_in_storage,
             keyspace='keyspace1',
             srcs=table1_index_srcs,
@@ -170,6 +174,7 @@ class BackupNodeTest(unittest.TestCase):
             multipart_threshold=100,
             multipart_chunksize=None,
             enable_md5_checks=False,
+            md5_check_concurrency=2,
             files_in_storage=files_in_storage,
             keyspace='keyspace2',
             srcs=table2_srcs,
@@ -179,6 +184,62 @@ class BackupNodeTest(unittest.TestCase):
         # the file shows up in the reupload list because it's in the storage, but not at a different shape
         self.assertEqual([table2_srcs[0]], t2_reupload)
         self.assertEqual([], t2_already_up)
+
+    @patch("medusa.storage")
+    @patch("medusa.storage.node_backup.NodeBackup")
+    def test_check_already_uploaded_respects_md5_check_concurrency(self, mock_storage, mock_node_backup):
+        mock_node_backup.is_differential = True
+
+        file_count = 4
+        files_in_storage = {
+            'keyspace1': {
+                'table1-cfid': {
+                    f'nb-1-file{i}-Data.db': ManifestObject(f'nb-1-file{i}-Data.db', 100, 'whatever')
+                    for i in range(file_count)
+                }
+            }
+        }
+        srcs = [
+            pathlib.Path(f'/foo/bar/data/keyspace1/table1-cfid/snapshots/snapshot-name/nb-1-file{i}-Data.db')
+            for i in range(file_count)
+        ]
+
+        active = 0
+        max_active = 0
+        lock = threading.Lock()
+
+        def fake_file_matches_storage(src, cached_item, threshold, enable_md5_checks, chunk_size):
+            nonlocal active, max_active
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+            time.sleep(0.1)
+            with lock:
+                active -= 1
+            return True
+
+        mock_storage.storage_driver.file_matches_storage = fake_file_matches_storage
+
+        start = time.monotonic()
+        _, _, already_up = check_already_uploaded(
+            mock_storage,
+            mock_node_backup,
+            multipart_threshold=100,
+            multipart_chunksize=None,
+            enable_md5_checks=True,
+            md5_check_concurrency=2,
+            files_in_storage=files_in_storage,
+            keyspace='keyspace1',
+            srcs=srcs,
+            fqtn='keyspace1.table1'
+        )
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(file_count, len(already_up))
+        # 2 workers on 4 files taking 0.1s each: parallelized takes ~0.2s (2 batches of 2),
+        # a fully sequential loop would take ~0.4s.
+        self.assertLess(elapsed, 0.35)
+        self.assertEqual(2, max_active)
 
 
 if __name__ == '__main__':

--- a/tests/backup_node_test.py
+++ b/tests/backup_node_test.py
@@ -126,7 +126,8 @@ class BackupNodeTest(unittest.TestCase):
             enable_md5_checks=False,
             files_in_storage=files_in_storage,
             keyspace='keyspace1',
-            srcs=table1_srcs
+            srcs=table1_srcs,
+            fqtn='keyspace1.table1'
         )
 
         self.assertEqual(list(), table1_backup)
@@ -149,7 +150,8 @@ class BackupNodeTest(unittest.TestCase):
             enable_md5_checks=False,
             files_in_storage=files_in_storage,
             keyspace='keyspace1',
-            srcs=table1_index_srcs
+            srcs=table1_index_srcs,
+            fqtn='keyspace1.table1'
         )
         # the first file was not in storage, so we need to reuplaod it
         self.assertEqual([table1_index_srcs[0]], t1_idx_backup)
@@ -171,6 +173,7 @@ class BackupNodeTest(unittest.TestCase):
             files_in_storage=files_in_storage,
             keyspace='keyspace2',
             srcs=table2_srcs,
+            fqtn='keyspace2.table2'
         )
         self.assertEqual([], t2_backup)
         # the file shows up in the reupload list because it's in the storage, but not at a different shape


### PR DESCRIPTION
## Summary

- With differential backups and `enable_md5_checks` on, comparing local files against the manifest was a fully sequential, silent loop (`check_already_uploaded`) - on large tables this could dominate total backup
time with zero visibility.
- Adds debug-level progress logging for this comparison pass (start + periodic progress).
- Parallelizes the comparison across a new dedicated `md5_check_concurrency` setting (`[checks]`, default `1`). Deliberately not reusing `concurrent_transfers`: that setting governs network upload concurrency,
while this is local CPU-bound hashing work - Medusa runs on the same node as Cassandra, so the default stays sequential and must be raised explicitly. Default behavior is sequential and not changed.

**Depends on #969** (not yet merged): this branch is stacked on `fix-s3-connection-pool-size` because `check_already_uploaded`/`file_matches_storage` already take `multipart_chunksize` there. The diff below
includes #969's commits until it merges; once it does, this diff will shrink to just the two commits above it. Hopefully.

Related to #155  - but not a full fix. This PR should ensure there is always something logged at the debug level, but is not tracking progress (% / Bytes etc).

## Tests
- Added `tests/backup_node_test.py::test_check_already_uploaded_respects_md5_check_concurrency` - verifies actual concurrency is capped at the configured value