### PR TITLE
Don't crash the backup when a DSE node has no metadata folder & Read from cassandra.yaml

### DIFF
--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -266,6 +266,13 @@ class CassandraConfigReader(object):
         return pathlib.Path(saved_caches_directory)
 
     @property
+    def dse_metadata_directory(self):
+        # DSE adds this key to cassandra.yaml itself (not dse.yaml). Older DSE versions (eg 5.1, #826)
+        # don't have it at all, so callers must fall back to a guessed location when this is None.
+        metadata_directory = self._config.get('metadata_directory')
+        return pathlib.Path(metadata_directory) if metadata_directory else None
+
+    @property
     def listen_address(self):
         if 'listen_address' in self._config and self._config['listen_address']:
             return self._config['listen_address']
@@ -355,8 +362,15 @@ class Cassandra(object):
         config_reader = CassandraConfigReader(cassandra_config.config_file, release_version)
         self._cassandra_config_file = cassandra_config.config_file
         self._root = config_reader.root
-        self._dse_root = self._root.parent
-        self._dse_metadata_folder = 'metadata'
+        dse_metadata_directory = config_reader.dse_metadata_directory
+        if dse_metadata_directory is not None:
+            self._dse_root = dse_metadata_directory.parent
+            self._dse_metadata_folder = dse_metadata_directory.name
+        else:
+            # metadata_directory isn't set in cassandra.yaml (older DSE, eg 5.1, #826) - guess its
+            # location next to the data directory, which holds for the common/default DSE layout.
+            self._dse_root = self._root.parent
+            self._dse_metadata_folder = 'metadata'
         self._commitlog_path = config_reader.commitlog_directory
         self._saved_caches_path = config_reader.saved_caches_directory
         self._hostname = contact_point if contact_point is not None else config_reader.listen_address
@@ -581,8 +595,8 @@ class Cassandra(object):
         return False
 
     def dse_snapshot_exists(self, tag):
-        # dse files live one directory up from the data folder
-        # the root field should point to the data directory as defined in the cassandra.yaml
+        # _dse_root is metadata_directory's parent (from cassandra.yaml) when set, otherwise a guess
+        # based on the data directory - see Cassandra.__init__.
         for snapshot in self._dse_root.glob(self.DSE_SNAPSHOT_PATTERN.format('*')):
             if snapshot.is_dir() and snapshot.name == tag:
                 return True

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -463,9 +463,13 @@ class Cassandra(object):
 
         tag = "{}{}".format(self.SNAPSHOT_PREFIX, backup_name)
         if not self.dse_snapshot_exists(tag):
-            src_path = self._dse_root / self._dse_metadata_folder
-            dst_path = self._dse_root / self._dse_metadata_folder / 'snapshots' / tag
-            shutil.copytree(src_path, dst_path, ignore=Cassandra._ignore_snapshots)
+            src_path = self.dse_metadata_path
+            if src_path.is_dir():
+                dst_path = src_path / 'snapshots' / tag
+                shutil.copytree(src_path, dst_path, ignore=Cassandra._ignore_snapshots)
+            else:
+                # Not every DSE node has a metadata folder - warn instead of failing the backup.
+                logging.warning(f'No DSE metadata folder found at {src_path}, nothing to snapshot')
 
         return Cassandra.DseSnapshot(self, tag)
 
@@ -493,7 +497,8 @@ class Cassandra(object):
         def delete(self):
             dse_folder = self._parent._dse_metadata_folder
             dse_folder_path = self._parent._dse_root / dse_folder / 'snapshots' / self._tag
-            shutil.rmtree(dse_folder_path)
+            if dse_folder_path.is_dir():
+                shutil.rmtree(dse_folder_path)
 
         def __repr__(self):
             return '{}<{}>'.format(self.__class__.__qualname__, self._tag)

--- a/medusa/cassandra_utils.py
+++ b/medusa/cassandra_utils.py
@@ -17,6 +17,7 @@
 
 
 import fileinput
+import functools
 import itertools
 import logging
 import os
@@ -452,9 +453,9 @@ class Cassandra(object):
                 session.execute(f"REBUILD SEARCH INDEX ON {fqtn}")
 
     @staticmethod
-    def _ignore_snapshots(folder, contents):
+    def _ignore_snapshots(metadata_folder, folder, contents):
         ignored = set()
-        if folder.endswith('metadata/snapshots'):
+        if folder.endswith(f'{metadata_folder}/snapshots'):
             logging.info(f'Ignoring {contents} in folder {folder}')
             for c in contents:
                 ignored.add(c)
@@ -480,7 +481,8 @@ class Cassandra(object):
             src_path = self.dse_metadata_path
             if src_path.is_dir():
                 dst_path = src_path / 'snapshots' / tag
-                shutil.copytree(src_path, dst_path, ignore=Cassandra._ignore_snapshots)
+                ignore = functools.partial(Cassandra._ignore_snapshots, self._dse_metadata_folder)
+                shutil.copytree(src_path, dst_path, ignore=ignore)
             else:
                 # Not every DSE node has a metadata folder - warn instead of failing the backup.
                 logging.warning(f'No DSE metadata folder found at {src_path}, nothing to snapshot')

--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -971,5 +971,37 @@ class CassandraUtilsTest(unittest.TestCase):
         actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots(folder, contents)
         self.assertEqual(expected_ignored, actual_ignored)
 
+    def test_create_dse_snapshot_without_metadata_folder(self):
+        # Some DSE 6 nodes never write anything under <dse_root>/metadata (eg no Management
+        # Services/Insights activity) - this must not crash the backup, there's just nothing
+        # DSE-specific to snapshot.
+        c = Cassandra(self.get_simple_medusa_config('resources/yaml/original/default-c4.yaml'))
+        with tempfile.TemporaryDirectory() as dse_root:
+            c._dse_root = Path(dse_root)
+            # deliberately not creating <dse_root>/metadata
+
+            snapshot = c.create_dse_snapshot('test-backup')
+
+            self.assertEqual([], list(snapshot.find_dirs()[0].list_files()))
+            # cleanup must also tolerate the snapshot folder never having been created
+            snapshot.delete()
+
+    def test_create_dse_snapshot_with_metadata_folder(self):
+        c = Cassandra(self.get_simple_medusa_config('resources/yaml/original/default-c4.yaml'))
+        with tempfile.TemporaryDirectory() as dse_root:
+            c._dse_root = Path(dse_root)
+            metadata_dir = c._dse_root / c._dse_metadata_folder
+            metadata_dir.mkdir()
+            (metadata_dir / 'nodes').mkdir()
+            (metadata_dir / 'nodes' / 'local').write_text('some dse metadata')
+
+            snapshot = c.create_dse_snapshot('test-backup')
+
+            snapshotted_files = {p.name for p in snapshot.find_dirs()[0].list_files()}
+            self.assertEqual({'local'}, snapshotted_files)
+
+            snapshot.delete()
+            self.assertFalse((metadata_dir / 'snapshots' / snapshot._tag).exists())
+
     if __name__ == '__main__':
         unittest.main()

--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -971,6 +971,34 @@ class CassandraUtilsTest(unittest.TestCase):
         actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots(folder, contents)
         self.assertEqual(expected_ignored, actual_ignored)
 
+    def test_dse_metadata_directory_read_from_cassandra_yaml(self):
+        # DSE puts metadata_directory straight into cassandra.yaml (not dse.yaml) - see
+        # https://docs.datastax.com/en/dse/6.9/managing/configure/configure-cassandra-yaml.html
+        # Build the fixture from the real default-c4.yaml plus that one key, using a value that
+        # differs from the guessed fallback so the test actually proves the explicit config wins.
+        base_yaml_path = os.path.join(os.path.dirname(__file__), 'resources/yaml/original/default-c4.yaml')
+        with open(base_yaml_path) as f:
+            base_yaml = f.read()
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write(base_yaml)
+            f.write('\nmetadata_directory: /opt/dse/metadata\n')
+            yaml_path = f.name
+        try:
+            c = Cassandra(self.get_simple_medusa_config(yaml_path))
+
+            self.assertEqual(Path('/opt/dse/metadata'), c.dse_metadata_path)
+            self.assertEqual(Path('/opt/dse'), c._dse_root)
+            self.assertEqual('metadata', c._dse_metadata_folder)
+        finally:
+            os.unlink(yaml_path)
+
+    def test_dse_metadata_directory_falls_back_without_cassandra_yaml_key(self):
+        # Older DSE (eg 5.1, #826) never sets metadata_directory in cassandra.yaml at all - keep the
+        # previous guess (next to the data directory) so those nodes behave as before.
+        c = Cassandra(self.get_simple_medusa_config('resources/yaml/original/default-c4.yaml'))
+
+        self.assertEqual(Path('/var/lib/cassandra/metadata'), c.dse_metadata_path)
+
     def test_create_dse_snapshot_without_metadata_folder(self):
         # Some DSE 6 nodes never write anything under <dse_root>/metadata (eg no Management
         # Services/Insights activity) - this must not crash the backup, there's just nothing

--- a/tests/cassandra_utils_test.py
+++ b/tests/cassandra_utils_test.py
@@ -947,28 +947,44 @@ class CassandraUtilsTest(unittest.TestCase):
         folder = 'keyspace/table'
         contents = ['file1', 'file2']
         expected_ignored = set()
-        actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots(folder, contents)
+        actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots('metadata', folder, contents)
         self.assertEqual(expected_ignored, actual_ignored)
 
         # none of these combinations is ignored
         folder = 'keyspace/table/snapshots'
         contents = ['snapshot1', 'snapshot2']
         expected_ignored = set()
-        actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots(folder, contents)
+        actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots('metadata', folder, contents)
         self.assertEqual(expected_ignored, actual_ignored)
 
         # we ignore stuff in this specific folder
         folder = 'metadata/snapshots'
         contents = ['snapshot1', 'snapshot2']
         expected_ignored = {'snapshot1', 'snapshot2'}
-        actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots(folder, contents)
+        actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots('metadata', folder, contents)
         self.assertEqual(expected_ignored, actual_ignored)
 
         # we ingore DSE transaction files
         folder = '/metadata/nodes'
         contents = ['local', 'peeers', 'local.txn', 'local.old']
         expected_ignored = {'local.txn', 'local.old'}
-        actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots(folder, contents)
+        actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots('metadata', folder, contents)
+        self.assertEqual(expected_ignored, actual_ignored)
+
+        # the metadata folder name comes from cassandra.yaml's metadata_directory and can be anything
+        folder = 'custom_metadata_dir/snapshots'
+        contents = ['snapshot1', 'snapshot2']
+        expected_ignored = {'snapshot1', 'snapshot2'}
+        actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots(
+            'custom_metadata_dir', folder, contents)
+        self.assertEqual(expected_ignored, actual_ignored)
+
+        # ...and a mismatching folder name is correctly not ignored
+        folder = 'metadata/snapshots'
+        contents = ['snapshot1', 'snapshot2']
+        expected_ignored = set()
+        actual_ignored = medusa.cassandra_utils.Cassandra._ignore_snapshots(
+            'custom_metadata_dir', folder, contents)
         self.assertEqual(expected_ignored, actual_ignored)
 
     def test_dse_metadata_directory_read_from_cassandra_yaml(self):
@@ -1030,6 +1046,26 @@ class CassandraUtilsTest(unittest.TestCase):
 
             snapshot.delete()
             self.assertFalse((metadata_dir / 'snapshots' / snapshot._tag).exists())
+
+    def test_create_dse_snapshot_with_custom_metadata_folder_name(self):
+        # metadata_directory can be configured to anything in cassandra.yaml - the copytree
+        # ignore filter must key off the actual folder name, not assume it's called "metadata",
+        # or it fails to exclude the snapshots dir it's creating and recurses into itself.
+        c = Cassandra(self.get_simple_medusa_config('resources/yaml/original/default-c4.yaml'))
+        with tempfile.TemporaryDirectory() as dse_root:
+            c._dse_root = Path(dse_root)
+            c._dse_metadata_folder = 'custom_metadata_dir'
+            metadata_dir = c._dse_root / c._dse_metadata_folder
+            metadata_dir.mkdir()
+            (metadata_dir / 'nodes').mkdir()
+            (metadata_dir / 'nodes' / 'local').write_text('some dse metadata')
+
+            snapshot = c.create_dse_snapshot('test-backup')
+
+            snapshotted_files = {p.name for p in snapshot.find_dirs()[0].list_files()}
+            self.assertEqual({'local'}, snapshotted_files)
+            # the snapshot must not have copied its own (still growing) snapshots dir into itself
+            self.assertFalse((metadata_dir / 'snapshots' / snapshot._tag / 'snapshots').exists())
 
     if __name__ == '__main__':
         unittest.main()


### PR DESCRIPTION
## Summary

While testing on a real DSE 6.8 cluster, `backup-cluster` failed on every single node with:

```
[Errno 2] No such file or directory: '/myPathToData/dse/metadata'
```

`create_dse_snapshot()` assumes every DSE node has a `<dse_root>/metadata` folder to copy, but I *think* that's not always true (eg no DSE Management Services/Insights activity on that node). The `shutil.copytree` crash aborts `handle_backup` entirely - discarding all the SSTable upload work already done for that node and marking it failed.

Fix philosophy: treat a missing `metadata` folder as "nothing DSE-specific to snapshot" rather than a failure - same treatment on cleanup (`DseSnapshot.delete()`), which would otherwise crash on the same missing directory during `__exit__`. I hope that this is a honest response, not just the "easy" one. I have a (very) limited knowledge of DSE specifics.

On top of that, `_dse_root` was always *guessed* as "one directory up from the data folder", which breaks as soon as `metadata_directory` isn't at its default location (eg the data directory is moved to a dedicated disk). DSE actually writes this path itself into `cassandra.yaml` (key `metadata_directory`, see [DataStax docs](https://docs.datastax.com/en/dse/6.9/managing/configure/configure-cassandra-yaml.html)) - Medusa now reads it from there when present, and only falls back to the old guess for older DSE versions that never set the key (eg 5.1).

Fixes #826 - same crash, different trigger: #826 is DSE 5.1 never having a `metadata` folder at all, this case is a DSE 6.8 node that simply never populated one. Same crash site, same fix works for both regardless of the exact reason the folder is missing.

Fixes #819 - the metadata path is no longer guessed, it's read from `cassandra.yaml` the same way DSE itself defines it, so non-standard locations are now supported automatically instead of requiring a hardcoded guess.

## Tests
- `test_create_dse_snapshot_without_metadata_folder` - reproduces the exact crash without the fix, passes with it
- `test_create_dse_snapshot_with_metadata_folder` - existing behavior (folder present) unchanged
- `test_dse_metadata_directory_read_from_cassandra_yaml` - explicit `metadata_directory` in `cassandra.yaml` is used instead of the guess
- `test_dse_metadata_directory_falls_back_without_cassandra_yaml_key` - older DSE without the key keeps the previous guessed behavior